### PR TITLE
Switch portal to Codex integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@
 2. Install dependencies: `npm install`
 3. Run migrations: `npm run migrate`
 4. Start dev server: `npm run dev`
-added chatgpt
+
+### Codex Integration
+
+Set `CODEX_API_KEY` (and optionally `CODEX_API_URL`) in your environment to enable the `/api/codex` endpoint for AI-powered chat assistance.

--- a/docs/docs/DEV_PORTAL_DISCUSSION.md
+++ b/docs/docs/DEV_PORTAL_DISCUSSION.md
@@ -39,8 +39,8 @@ _This file captures the high-level decisions and context from our ChatGPT sessio
 ## Environment & Infrastructure
 - **Heroku** auto-deploy from `main`  
 - **MariaDB** on AWS RDS (`DATABASE_URL`)  
-- **AWS S3** for file storage (`S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`)  
-- **OpenAI** integration (`OPENAI_API_KEY`)  
+- **AWS S3** for file storage (`S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`)
+- **Codex** integration (`CODEX_API_KEY`, `CODEX_API_URL`)
 - Secrets managed in **GitHub Codespaces** & **Actions**
 
 ## GitHub Integration

--- a/pages/api/codex.js
+++ b/pages/api/codex.js
@@ -1,0 +1,31 @@
+import { getTokenFromReq } from '../../lib/auth';
+
+export default async function handler(req, res) {
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end();
+  }
+
+  const { prompt } = req.body;
+  if (!prompt) return res.status(400).json({ error: 'Missing prompt' });
+
+  const resp = await fetch(`${process.env.CODEX_API_URL || 'https://api.codex.com/v1'}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.CODEX_API_KEY}`
+    },
+    body: JSON.stringify({ messages: [{ role: 'user', content: prompt }] })
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    return res.status(500).json({ error: 'Codex API error', details: text });
+  }
+
+  const data = await resp.json();
+  return res.status(200).json(data);
+}


### PR DESCRIPTION
## Summary
- add `/api/codex` endpoint to proxy requests to Codex
- update documentation to reference Codex integration and variables

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684b30e08068832aa751fd73a1526c0e