### PR TITLE
fix db import path

### DIFF
--- a/pages/api/socket-io.js
+++ b/pages/api/socket-io.js
@@ -1,5 +1,5 @@
 import { Server } from 'socket.io';
-import pool from '../lib/db';
+import pool from '../../lib/db';
 
 export default function handler(req, res) {
   if (!res.socket.server.io) {


### PR DESCRIPTION
## Summary
- correct pool import path for socket-io API

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_684b391bc894832ab4a3753faeefd1c5