### PR TITLE
Add Jest setup and initial auth tests

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -1,0 +1,16 @@
+let signToken;
+let verifyToken;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  const mod = await import('../lib/auth.js');
+  signToken = mod.signToken;
+  verifyToken = mod.verifyToken;
+});
+
+test('signToken and verifyToken round trip', () => {
+  const payload = { userId: 42 };
+  const token = signToken(payload);
+  const decoded = verifyToken(token);
+  expect(decoded.userId).toBe(payload.userId);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "migrate": "node scripts/migrate.js",
     "lint": "next lint",
-    "test": "echo \"No tests yet\""
+    "test": "jest"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.270.0",
@@ -23,10 +23,13 @@
     "react-dom": "latest"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.0",
     "autoprefixer": "^10.4.14",
     "eslint": "8.36.0",
     "eslint-config-next": "13.4.4",
+    "jest": "^30.0.0",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.2"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
## Summary
- install Jest and @testing-library/react
- replace `test` script with `jest`
- add sample test for token signing and verification

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b391eba7c832ab594ca5b11035cfc