### PR TITLE
Add admin role check with tests

### DIFF
--- a/__tests__/admin-users.test.js
+++ b/__tests__/admin-users.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('admin users index returns 403 for non-admin', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ name: 'viewer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 1 }),
+    hashPassword: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/admin/users/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+  expect(queryMock).toHaveBeenCalledTimes(1);
+});
+
+test('admin user delete returns 403 for non-admin', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ name: 'user' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 2 }),
+    hashPassword: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/admin/users/[id].js');
+  const req = { method: 'DELETE', query: { id: 3 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+  expect(queryMock).toHaveBeenCalledTimes(1);
+});

--- a/pages/api/admin/users/[id].js
+++ b/pages/api/admin/users/[id].js
@@ -1,8 +1,21 @@
 // File: pages/api/admin/users/[id].js
 import pool from '../../../../lib/db';
+import { getTokenFromReq } from '../../../../lib/auth';
 
 export default async function handler(req, res) {
   const { id } = req.query;
+
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const [[roleRow]] = await pool.query(
+    `SELECT r.name FROM user_roles ur
+       JOIN roles r ON ur.role_id = r.id
+     WHERE ur.user_id = ?`,
+    [t.sub]
+  );
+  if (!roleRow || roleRow.name !== 'admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
 
   if (req.method === 'DELETE') {
     try {


### PR DESCRIPTION
## Summary
- enforce admin role check in admin users endpoints
- add unit tests for admin users API role enforcement

## Testing
- `node --experimental-vm-modules node_modules/.bin/jest --config '{}'`
- `npm test` *(fails: Validation Error for `extensionsToTreatAsEsm`)*

------
https://chatgpt.com/codex/tasks/task_e_685ad469e974832ab7cf565eeab3e022