### PR TITLE
Update login redirect by user role

### DIFF
--- a/pages/api/auth/me.js
+++ b/pages/api/auth/me.js
@@ -4,9 +4,13 @@ import { getTokenFromReq } from '../../../lib/auth';
 export default async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
-  const [user] = await pool.query(
-    'SELECT id, username, email FROM users WHERE id=?',
+  const [rows] = await pool.query(
+    `SELECT u.id, u.username, u.email, r.name AS role
+       FROM users u
+  LEFT JOIN user_roles ur ON u.id = ur.user_id
+  LEFT JOIN roles r ON ur.role_id = r.id
+      WHERE u.id=?`,
     [t.sub]
   );
-  res.status(200).json(user[0]);
+  res.status(200).json(rows[0]);
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -46,8 +46,16 @@ export default function Login() {
          throw new Error(errMsg);
      }
      
-      // Redirect to admin or dev portal based on role
-      router.push('/admin/users');
+      // Fetch user info to determine role, then route accordingly
+      const meRes = await fetch('/api/auth/me', { credentials: 'include' });
+      if (meRes.ok) {
+        const me = await meRes.json();
+        const dest = me.role === 'admin' ? '/admin/users' : '/dev/projects';
+        router.push(dest);
+      } else {
+        // default to developer portal if role cannot be fetched
+        router.push('/dev/projects');
+      }
     } catch (err) {
       setError(err.message);
     } finally {


### PR DESCRIPTION
## Summary
- determine user role using `/api/auth/me` after login
- include role in `/api/auth/me` response

## Testing
- `npm test` *(fails: Validation Error about extensionsToTreatAsEsm)*

------
https://chatgpt.com/codex/tasks/task_e_685ad58084b8832a9f5d65b5612ca9b5