### PR TITLE
Fix migrations connection

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -10,7 +10,8 @@ async function runMigrations() {
     process.exit(1);
   }
   const sql = fs.readFileSync(path.resolve('./migrations/garage.sql'), 'utf8');
-  const conn = await mysql.createConnection(url);
+  // Ensure multiple statements are allowed like in lib/db.js
+  const conn = await mysql.createConnection(url + '?multipleStatements=true');
   try {
     console.log('Running migrations...');
     await conn.query(sql);


### PR DESCRIPTION
## Summary
- allow multiple statements in migration script's DB connection

## Testing
- `node --experimental-vm-modules node_modules/.bin/jest -c '{}'`

------
https://chatgpt.com/codex/tasks/task_e_685ad9378fc4832aa0a816a8de79e5df