### PR TITLE
Add Secure cookie flag in prod

### DIFF
--- a/pages/api/auth/login.js
+++ b/pages/api/auth/login.js
@@ -11,9 +11,10 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: 'Invalid credentials' });
   }
   const token = signToken({ sub: rows[0].id });
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
   res.setHeader(
     'Set-Cookie',
-    `auth_token=${token}; HttpOnly; Path=/; Max-Age=28800; SameSite=Strict`
+    `auth_token=${token}; HttpOnly; Path=/; Max-Age=28800; SameSite=Strict${secure}`
   );
   res.status(200).json({ ok: true });
 }

--- a/pages/api/auth/logout.js
+++ b/pages/api/auth/logout.js
@@ -1,4 +1,5 @@
 export default function handler(req, res) {
-  res.setHeader('Set-Cookie', 'auth_token=; HttpOnly; Path=/; Max-Age=0');
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+  res.setHeader('Set-Cookie', `auth_token=; HttpOnly; Path=/; Max-Age=0${secure}`);
   res.status(200).json({ ok:true });
 }


### PR DESCRIPTION
## Summary
- add a `Secure` flag when setting auth cookies in production

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*


------
https://chatgpt.com/codex/tasks/task_e_685ada24cb18832ab4ce9c52794e8744