### PR TITLE
Add runtime check for JWT_SECRET

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -1,16 +1,27 @@
-let signToken;
-let verifyToken;
+describe('auth module', () => {
+  test('throws error when JWT_SECRET is missing', async () => {
+    delete process.env.JWT_SECRET;
+    await expect(import('../lib/auth.js?nocache=' + Date.now())).rejects.toThrow(
+      'JWT_SECRET is not defined',
+    );
+  });
 
-beforeAll(async () => {
-  process.env.JWT_SECRET = 'testsecret';
-  const mod = await import('../lib/auth.js');
-  signToken = mod.signToken;
-  verifyToken = mod.verifyToken;
-});
+  describe('with JWT_SECRET set', () => {
+    let signToken;
+    let verifyToken;
 
-test('signToken and verifyToken round trip', () => {
-  const payload = { userId: 42 };
-  const token = signToken(payload);
-  const decoded = verifyToken(token);
-  expect(decoded.userId).toBe(payload.userId);
+    beforeAll(async () => {
+      process.env.JWT_SECRET = 'testsecret';
+      const mod = await import('../lib/auth.js?nocache=' + Date.now());
+      signToken = mod.signToken;
+      verifyToken = mod.verifyToken;
+    });
+
+    test('signToken and verifyToken round trip', () => {
+      const payload = { userId: 42 };
+      const token = signToken(payload);
+      const decoded = verifyToken(token);
+      expect(decoded.userId).toBe(payload.userId);
+    });
+  });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 export default {
   testEnvironment: 'node',
-  extensionsToTreatAsEsm: ['.js'],
 };

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -4,6 +4,10 @@ import { parse } from 'cookie';
 
 const SECRET = process.env.JWT_SECRET;
 
+if (!SECRET) {
+  throw new Error('JWT_SECRET is not defined');
+}
+
 export async function hashPassword(p) {
   return bcrypt.hash(p, 10);
 }


### PR DESCRIPTION
## Summary
- check for `JWT_SECRET` on auth module load
- update Jest config for ESM
- extend auth tests to cover missing `JWT_SECRET`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685adad24e40832abbd9c384d7aef24e