### PR TITLE
Fix task detail imports

### DIFF
--- a/pages/dev/tasks/[id].js
+++ b/pages/dev/tasks/[id].js
@@ -2,9 +2,9 @@ import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Sidebar } from '../../components/Sidebar';
-import { Header } from '../../components/Header';
-import { Card } from '../../components/Card';
+import { Sidebar } from '../../../components/Sidebar';
+import { Header } from '../../../components/Header';
+import { Card } from '../../../components/Card';
 
 export default function TaskDetail() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- fix relative imports for dev task detail page

## Testing
- `npm run build` *(fails: Your custom PostCSS configuration must export a `plugins` key)*

------
https://chatgpt.com/codex/tasks/task_e_685ae2811a48832ab2f3e488d103b4c6