### PR TITLE
Add env example and clarify setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env.local and fill in your secrets
+# Database connection string
+DATABASE_URL="mysql://user:pass@localhost:3306/garage"
+# Secret key for JWT tokens
+JWT_SECRET="change-me"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-1. Copy `.env.example` to `.env.local` and fill in secrets.
+1. Copy `.env.example` to `.env.local` and fill in secrets. The required variables are `DATABASE_URL` and `JWT_SECRET`.
 2. Install dependencies: `npm install`
 3. Make the bootstrap script executable and run it to scaffold the portal:
    `chmod +x bootstrap_dev_portal.sh && ./bootstrap_dev_portal.sh`


### PR DESCRIPTION
## Summary
- add a `.env.example` describing environment variables
- mention required variables in setup instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae32d9418832abd6edb78d0332dd3