### PR TITLE
Add chat history API and preload messages

### DIFF
--- a/pages/api/chat/history.js
+++ b/pages/api/chat/history.js
@@ -1,0 +1,17 @@
+import pool from '../../../lib/db';
+
+export default async function handler(req, res) {
+  const limit = parseInt(req.query.limit || '50', 10);
+  try {
+    const [rows] = await pool.query(
+      `SELECT user, body, s3_key, content_type, created_at
+         FROM (SELECT * FROM messages ORDER BY created_at DESC LIMIT ?) m
+         ORDER BY created_at ASC`,
+      [limit]
+    );
+    res.status(200).json(rows);
+  } catch (err) {
+    console.error('HISTORY ERROR:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}


### PR DESCRIPTION
## Summary
- expose recent chat messages at `/api/chat/history`
- fetch chat history on page load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685aebd87dfc832abf58bacb8ab578eb