### PR TITLE
Fix Link usage in dev pages

### DIFF
--- a/pages/dev/projects/[id].js
+++ b/pages/dev/projects/[id].js
@@ -59,8 +59,8 @@ export default function ProjectDetail() {
             <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">
               {project.name}
             </h1>
-            <Link href="/dev/projects">
-              <a className="text-[var(--color-primary)] hover:underline">&larr; Back to Projects</a>
+            <Link href="/dev/projects" className="text-[var(--color-primary)] hover:underline">
+              &larr; Back to Projects
             </Link>
           </div>
 
@@ -70,8 +70,8 @@ export default function ProjectDetail() {
 
           <div className="flex justify-between items-center">
             <h2 className="text-2xl font-semibold text-[var(--color-text-primary)]">Tasks</h2>
-            <Link href={`/dev/projects/${id}/tasks/new`}>
-              <a className="button">+ Add Task</a>
+            <Link href={`/dev/projects/${id}/tasks/new`} className="button">
+              + Add Task
             </Link>
           </div>
 
@@ -81,15 +81,13 @@ export default function ProjectDetail() {
             <div className="grid gap-4">
               {tasks.map(t => (
                 <Card key={t.id} className="group relative">
-                  <Link href={`/dev/tasks/${t.id}`}>
-                    <a className="block">
-                      <h3 className="text-xl font-semibold text-[var(--color-text-primary)]">
-                        {t.title}
-                      </h3>
-                      <p className="mt-1 text-[var(--color-text-secondary)]">
-                        Status: {t.status}
-                      </p>
-                    </a>
+                  <Link href={`/dev/tasks/${t.id}`} className="block">
+                    <h3 className="text-xl font-semibold text-[var(--color-text-primary)]">
+                      {t.title}
+                    </h3>
+                    <p className="mt-1 text-[var(--color-text-secondary)]">
+                      Status: {t.status}
+                    </p>
                   </Link>
                   <button
                     onClick={async () => {

--- a/pages/dev/projects/[id]/tasks/new.js
+++ b/pages/dev/projects/[id]/tasks/new.js
@@ -153,8 +153,8 @@ export default function NewTask() {
                 >
                   {loading ? 'Creating…' : 'Create Task'}
                 </button>
-                <Link href={`/dev/projects/${id}`}>
-                  <a className="button-secondary">Cancel</a>
+                <Link href={`/dev/projects/${id}`} className="button-secondary">
+                  Cancel
                 </Link>
               </div>
             </form>

--- a/pages/dev/projects/index.js
+++ b/pages/dev/projects/index.js
@@ -17,14 +17,14 @@ export default function Projects() {
         <Header/>
         <main className="p-8">
           <h1 className="text-3xl mb-4">Projects</h1>
-          <Link href="/dev/projects/new"><a className="button">+ New Project</a></Link>
+          <Link href="/dev/projects/new" className="button">+ New Project</Link>
           <div className="mt-4 space-y-4">
             {projects.map(p=>(
               <Card key={p.id}>
-                <Link href={`/dev/projects/${p.id}`}><a>
+                <Link href={`/dev/projects/${p.id}`} className="block">
                   <h2 className="font-semibold">{p.name}</h2>
                   <p className="text-sm">{p.description}</p>
-                </a></Link>
+                </Link>
               </Card>
             ))}
           </div>

--- a/pages/dev/projects/new.js
+++ b/pages/dev/projects/new.js
@@ -72,8 +72,8 @@ export default function NewProject() {
                 <button type="submit" className="button" disabled={loading}>
                   {loading ? 'Creating…' : 'Create Project'}
                 </button>
-                <Link href="/dev/projects">
-                  <a className="button-secondary">Cancel</a>
+                <Link href="/dev/projects" className="button-secondary">
+                  Cancel
                 </Link>
               </div>
             </form>

--- a/pages/dev/tasks/[id].js
+++ b/pages/dev/tasks/[id].js
@@ -43,8 +43,8 @@ export default function TaskDetail() {
             <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">
               {task.title}
             </h1>
-            <Link href={`/dev/projects/${task.dev_project_id}`}> 
-              <a className="text-[var(--color-primary)] hover:underline">&larr; Back to Project</a>
+            <Link href={`/dev/projects/${task.dev_project_id}`} className="text-[var(--color-primary)] hover:underline">
+              &larr; Back to Project
             </Link>
           </div>
 


### PR DESCRIPTION
## Summary
- use modern Link component syntax across dev pages

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685aecad2464832a8bd397347bb52e47