### PR TITLE
Fix dev task creation and user dropdown

### DIFF
--- a/pages/api/dev/tasks/index.js
+++ b/pages/api/dev/tasks/index.js
@@ -5,9 +5,12 @@ export default async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const userId = t.sub;
-  const { project_id } = req.query;
+  const project_id = req.query.project_id || req.body.project_id;
 
   if (req.method === 'GET') {
+    if (!project_id) {
+      return res.status(400).json({ error: 'project_id required' });
+    }
     const [tasks] = await pool.query(
       `SELECT t.*, u.username AS assignee
          FROM dev_tasks t
@@ -20,6 +23,9 @@ export default async function handler(req, res) {
   }
 
   if (req.method === 'POST') {
+    if (!project_id) {
+      return res.status(400).json({ error: 'project_id required' });
+    }
     const { title, description, status, assigned_to, due_date } = req.body;
     const [{ insertId }] = await pool.query(
       `INSERT INTO dev_tasks

--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -1,0 +1,16 @@
+import pool from '../../../lib/db';
+import { getTokenFromReq } from '../../../lib/auth';
+
+export default async function handler(req, res) {
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).end();
+  }
+
+  const [users] = await pool.query('SELECT id, username FROM users ORDER BY username');
+  res.status(200).json(users);
+}
+

--- a/pages/dev/projects/[id]/tasks/new.js
+++ b/pages/dev/projects/[id]/tasks/new.js
@@ -27,7 +27,7 @@ export default function NewTask() {
   useEffect(() => {
     async function loadUsers() {
       try {
-        const r = await fetch('/api/admin/users', { credentials: 'include' });
+        const r = await fetch('/api/users', { credentials: 'include' });
         if (!r.ok) throw new Error(`Users fetch failed (${r.status})`);
         const data = await r.json();
         setUsers(Array.isArray(data) ? data : []);


### PR DESCRIPTION
## Summary
- add `GET /api/users` endpoint for listing users
- update new task page to fetch from the new endpoint
- allow `project_id` via body in tasks API and validate it

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_685af1bf3e68832a9db8eef91eb2212b