### PR TITLE
Add admin users link to Sidebar

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -1,9 +1,23 @@
+import { useEffect, useState } from 'react';
+
 export function Sidebar() {
+  const [userRole, setUserRole] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/auth/me', { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((u) => setUserRole(u?.role))
+      .catch(() => null);
+  }, []);
+
   return (
     <nav className="w-64 bg-[var(--color-surface)] h-screen p-4 space-y-2">
       <a href="/" className="block font-bold mb-4">Garage Vision</a>
       <a href="/dev/projects" className="block hover:underline">Dev → Projects</a>
       <a href="/chat" className="block hover:underline">Dev → Chat</a>
+      {userRole === 'admin' && (
+        <a href="/admin/users" className="block hover:underline">Admin → Users</a>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- fetch user role on Sidebar mount
- show `Admin → Users` link when role is `admin`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685afba3ebf0832ab28a48b4be78b7ae