### PR TITLE
Handle mixed-case roles in Sidebar

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -6,7 +6,7 @@ export function Sidebar() {
   useEffect(() => {
     fetch('/api/auth/me', { credentials: 'include' })
       .then((r) => (r.ok ? r.json() : null))
-      .then((u) => setUserRole(u?.role))
+      .then((u) => setUserRole(u?.role?.toLowerCase()))
       .catch(() => null);
   }, []);
 
@@ -15,7 +15,7 @@ export function Sidebar() {
       <a href="/" className="block font-bold mb-4">Garage Vision</a>
       <a href="/dev/projects" className="block hover:underline">Dev → Projects</a>
       <a href="/chat" className="block hover:underline">Dev → Chat</a>
-      {userRole === 'admin' && (
+      {userRole?.toLowerCase() === 'admin' && (
         <a href="/admin/users" className="block hover:underline">Admin → Users</a>
       )}
     </nav>


### PR DESCRIPTION
## Summary
- normalize the user role to lowercase in `Sidebar`
- make the admin check case-insensitive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b15e33ce4832abb928af7534b621c