### PR TITLE
Handle mixed-case roles in Sidebar IGNORE

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -6,7 +6,7 @@ export function Sidebar() {
   useEffect(() => {
     fetch('/api/auth/me', { credentials: 'include' })
       .then((r) => (r.ok ? r.json() : null))
-      .then((u) => setUserRole(u?.role))
+      .then((u) => setUserRole(u?.role?.toLowerCase()))
       .catch(() => null);
   }, []);
 
@@ -15,7 +15,7 @@ export function Sidebar() {
       <a href="/" className="block font-bold mb-4">Garage Vision</a>
       <a href="/dev/projects" className="block hover:underline">Dev → Projects</a>
       <a href="/chat" className="block hover:underline">Dev → Chat</a>
-      {userRole === 'admin' && (
+      {userRole?.toLowerCase() === 'admin' && (
         <a href="/admin/users" className="block hover:underline">Admin → Users</a>
       )}
     </nav>

--- a/migrations/20250521_schema.sql
+++ b/migrations/20250521_schema.sql
@@ -45,8 +45,10 @@ CREATE TABLE IF NOT EXISTS messages (
   deleted_at TIMESTAMP NULL
 );
 
+-- Ensure the room foreign key is only added once
 ALTER TABLE messages
-  ADD CONSTRAINT fk_messages_room FOREIGN KEY (room_id) REFERENCES chat_rooms(id);
+  ADD CONSTRAINT IF NOT EXISTS fk_messages_room
+  FOREIGN KEY (room_id) REFERENCES chat_rooms(id);
 
 CREATE TABLE IF NOT EXISTS embeddings (
   id BIGINT PRIMARY KEY AUTO_INCREMENT,

--- a/migrations/garage.sql
+++ b/migrations/garage.sql
@@ -45,8 +45,10 @@ CREATE TABLE IF NOT EXISTS messages (
   deleted_at TIMESTAMP NULL
 );
 
+-- Ensure the room foreign key is only added once
 ALTER TABLE messages
-  ADD CONSTRAINT fk_messages_room FOREIGN KEY (room_id) REFERENCES chat_rooms(id);
+  ADD CONSTRAINT IF NOT EXISTS fk_messages_room
+  FOREIGN KEY (room_id) REFERENCES chat_rooms(id);
 
 CREATE TABLE IF NOT EXISTS embeddings (
   id BIGINT PRIMARY KEY AUTO_INCREMENT,


### PR DESCRIPTION
## Summary
- normalize the user role to lowercase in `Sidebar`
- make the admin check case-insensitive
- make chat-room foreign-key migration idempotent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b15e33ce4832abb928af7534b621c