### PR TITLE
Fix admin sidebar check

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -15,7 +15,7 @@ export function Sidebar() {
       <a href="/" className="block font-bold mb-4">Garage Vision</a>
       <a href="/dev/projects" className="block hover:underline">Dev → Projects</a>
       <a href="/chat" className="block hover:underline">Dev → Chat</a>
-      {userRole?.toLowerCase() === 'admin' && (
+      {userRole === 'admin' && (
         <a href="/admin/users" className="block hover:underline">Admin → Users</a>
       )}
     </nav>


### PR DESCRIPTION
## Summary
- avoid unnecessary `toLowerCase()` when checking admin role

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b241c8008832abc5531984ddf9e87