### PR TITLE
Remove admin users console logs

### DIFF
--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -31,7 +31,6 @@ export default function Users() {
 
   const handleAdd = async (e) => {
     e.preventDefault();
-    console.log('🛠️ handleAdd fired', form);
     setLoading(true);
     try {
       const res = await fetch('/api/admin/users', {
@@ -40,9 +39,7 @@ export default function Users() {
         credentials: 'include',
         body: JSON.stringify(form),
       });
-      console.log('🛠️ POST /api/admin/users status:', res.status);
     } catch (err) {
-      console.error('🛠️ handleAdd error', err);
     } finally {
       setForm({ username: '', email: '', password: '', role: 'developer' });
       await loadUsers();
@@ -60,7 +57,6 @@ export default function Users() {
       if (!res.ok) throw new Error('Failed to delete user');
       await loadUsers();
     } catch (err) {
-      console.error(err.message);
     }
   };
 


### PR DESCRIPTION
## Summary
- keep production logs clean by removing console statements from `pages/admin/users.js`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b258bf4c4832abd1ee427cb78376d