### PR TITLE
Fix migration DB URL handling

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -4,14 +4,16 @@ import path from 'path';
 import mysql from 'mysql2/promise';
 
 async function runMigrations() {
-  const url = process.env.DATABASE_URL;
-  if (!url) {
+  const urlStr = process.env.DATABASE_URL;
+  if (!urlStr) {
     console.error('DATABASE_URL not set');
     process.exit(1);
   }
+  const parsed = new URL(urlStr);
+  parsed.searchParams.set('multipleStatements', 'true');
   const sql = fs.readFileSync(path.resolve('./migrations/garage.sql'), 'utf8');
   // Ensure multiple statements are allowed like in lib/db.js
-  const conn = await mysql.createConnection(url + '?multipleStatements=true');
+  const conn = await mysql.createConnection(parsed.toString());
   try {
     console.log('Running migrations...');
     await conn.query(sql);


### PR DESCRIPTION
## Summary
- parse the `DATABASE_URL` with `new URL()` in `scripts/migrate.js`
- set `multipleStatements=true` using `searchParams`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b2ae64354832a98afdb5c3b107430