### PR TITLE
Ensure topic is set before sending chat messages

### DIFF
--- a/docs/docs/CHAT_E2E_STEPS.md
+++ b/docs/docs/CHAT_E2E_STEPS.md
@@ -1,0 +1,10 @@
+# Chat Feature Manual Test
+
+Follow these steps to verify chat history persistence:
+
+1. Start the dev server with `npm run dev` and open `http://localhost:3000/chat`.
+2. In the topic dropdown, create a new topic using the **New topic** field and **Create** button.
+3. Type a message in the input box and click **Send**.
+4. Refresh the page. The chat should automatically join the previously selected topic and display the message you sent in the history list.
+
+This verifies that topics are created, messages are stored with their `room_id`, and history loads correctly after reloads.

--- a/pages/chat.js
+++ b/pages/chat.js
@@ -76,6 +76,10 @@ export default function Chat() {
 
   const sendMessage = () => {
     if (!input || !socketRef.current) return;
+    if (!topicId) {
+      console.warn("topicId not set; refusing to send message");
+      return;
+    }
     const msg = {
       user: user?.username || "anon",
       body: input,


### PR DESCRIPTION
## Summary
- avoid sending messages without a topic
- add manual end-to-end verification steps for chat feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b360f9fe4832aad1bf1235235ec46