### PR TITLE
Fix SQL migration for MariaDB

### DIFF
--- a/migrations/garage.sql
+++ b/migrations/garage.sql
@@ -42,13 +42,9 @@ CREATE TABLE IF NOT EXISTS messages (
   s3_key VARCHAR(256),
   content_type VARCHAR(80),
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  deleted_at TIMESTAMP NULL
+  deleted_at TIMESTAMP NULL,
+  FOREIGN KEY (room_id) REFERENCES chat_rooms(id)
 );
-
--- Ensure the room foreign key is only added once
-ALTER TABLE messages
-  ADD CONSTRAINT IF NOT EXISTS fk_messages_room
-  FOREIGN KEY (room_id) REFERENCES chat_rooms(id);
 
 CREATE TABLE IF NOT EXISTS embeddings (
   id BIGINT PRIMARY KEY AUTO_INCREMENT,


### PR DESCRIPTION
## Summary
- remove unsupported `IF NOT EXISTS` clause when creating foreign key
- embed the `messages` table foreign key directly in the CREATE TABLE statement

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b3966d950832a96c4be53c44f886f