### PR TITLE
Show admin for devs and fix chat history load

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -15,7 +15,7 @@ export function Sidebar() {
       <a href="/" className="block font-bold mb-4">Garage Vision</a>
       <a href="/dev/projects" className="block hover:underline">Dev → Projects</a>
       <a href="/chat" className="block hover:underline">Dev → Chat</a>
-      {userRole === 'admin' && (
+      {(userRole === 'admin' || userRole === 'developer') && (
         <a href="/admin/users" className="block hover:underline">Admin → Users</a>
       )}
     </nav>

--- a/pages/chat.js
+++ b/pages/chat.js
@@ -22,6 +22,7 @@ export default function Chat() {
   const [newTopic, setNewTopic] = useState("");
   const [input, setInput] = useState("");
   const [user, setUser] = useState(null);
+  const [socketReady, setSocketReady] = useState(false);
   const socketRef = useRef(null);
 
   useEffect(() => {
@@ -47,6 +48,7 @@ export default function Chat() {
       await fetch("/api/socket-io"); // start socket endpoint
       const socket = window.io({ path: "/api/socket-io" });
       socketRef.current = socket;
+      setSocketReady(true);
 
       socket.on("chat:recv", (msg) => {
         setMessages((m) => [...m, msg]);
@@ -61,7 +63,7 @@ export default function Chat() {
   }, []);
 
   useEffect(() => {
-    if (!socketRef.current || !topicId) return;
+    if (!socketReady || !socketRef.current || !topicId) return;
     socketRef.current.emit("chat:join", topicId);
     const load = async () => {
       try {
@@ -72,7 +74,7 @@ export default function Chat() {
       }
     };
     load();
-  }, [topicId]);
+  }, [topicId, socketReady]);
 
   const sendMessage = () => {
     if (!input || !socketRef.current) return;


### PR DESCRIPTION
## Summary
- show Admin link to developers as well as admins
- ensure chat history loads after refresh by waiting for socket connection

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685b3c9f47c4832abc9e596e2a906dce