### PR TITLE
Validate DATABASE_URL with URL API

### DIFF
--- a/__tests__/db.test.js
+++ b/__tests__/db.test.js
@@ -1,0 +1,8 @@
+describe('db module', () => {
+  test('throws error when DATABASE_URL is missing', async () => {
+    delete process.env.DATABASE_URL;
+    await expect(import('../lib/db.js?nocache=' + Date.now())).rejects.toThrow(
+      'DATABASE_URL is not defined',
+    );
+  });
+});

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,3 +1,12 @@
 import mysql from 'mysql2/promise';
-const pool = mysql.createPool(process.env.DATABASE_URL + '?multipleStatements=true');
+
+const urlStr = process.env.DATABASE_URL;
+if (!urlStr) {
+  throw new Error('DATABASE_URL is not defined');
+}
+
+const parsed = new URL(urlStr);
+parsed.searchParams.set('multipleStatements', 'true');
+const pool = mysql.createPool(parsed.toString());
+
 export default pool;


### PR DESCRIPTION
## Summary
- improve DB initialization logic
- add a test for missing `DATABASE_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b4c4411d0832a9fd5f15731d3b501