### PR TITLE
Sync bootstrap schema with migrations

### DIFF
--- a/bootstrap_dev_portal.sh
+++ b/bootstrap_dev_portal.sh
@@ -35,6 +35,13 @@ CREATE TABLE IF NOT EXISTS dev_tasks (
   FOREIGN KEY (assigned_to) REFERENCES users(id)
 );
 
+CREATE TABLE IF NOT EXISTS chat_rooms (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(100) NOT NULL UNIQUE
+);
+
+INSERT IGNORE INTO chat_rooms (id, name) VALUES (1, 'General');
+
 CREATE TABLE IF NOT EXISTS messages (
   id BIGINT PRIMARY KEY AUTO_INCREMENT,
   room_id BIGINT DEFAULT 1,
@@ -43,7 +50,8 @@ CREATE TABLE IF NOT EXISTS messages (
   s3_key VARCHAR(256),
   content_type VARCHAR(80),
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  deleted_at TIMESTAMP NULL
+  deleted_at TIMESTAMP NULL,
+  FOREIGN KEY (room_id) REFERENCES chat_rooms(id)
 );
 
 CREATE TABLE IF NOT EXISTS embeddings (


### PR DESCRIPTION
## Summary
- add `chat_rooms` table setup to bootstrap script
- insert the default `General` chat room
- include `FOREIGN KEY (room_id)` constraint in `messages` table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b5247f924832ab2c5ce6ebb95de31