### PR TITLE
Add welcome dashboard after login

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,42 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+
 export default function Home() {
-  return <div className="p-6">Landing Page</div>;
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/auth/me', { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then(setUser)
+      .catch(() => null);
+  }, []);
+
+  async function handleLogout() {
+    try {
+      await fetch('/api/auth/logout', { credentials: 'include' });
+    } finally {
+      window.location = '/login';
+    }
+  }
+
+  if (!user) return null;
+
+  return (
+    <>
+      <Head>
+        <title>Welcome - Garage Vision</title>
+      </Head>
+      <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--color-primary)] text-white space-y-8 p-6">
+        <h1 className="text-6xl font-bold">Garage Vision</h1>
+        <p className="text-xl">Welcome, {user.username}!</p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-xl">
+          <Link href="/admin/users" className="bg-gray-200 text-[var(--color-primary)] font-semibold rounded-2xl py-6 text-center shadow-xl hover:-translate-y-1 transition transform">User Setup</Link>
+          <Link href="/dev/projects" className="bg-gray-200 text-[var(--color-primary)] font-semibold rounded-2xl py-6 text-center shadow-xl hover:-translate-y-1 transition transform">Projects</Link>
+          <Link href="/chat" className="bg-gray-200 text-[var(--color-primary)] font-semibold rounded-2xl py-6 text-center shadow-xl hover:-translate-y-1 transition transform">Dev Chat</Link>
+        </div>
+        <button onClick={handleLogout} className="underline">Logout</button>
+      </div>
+    </>
+  );
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -49,12 +49,10 @@ export default function Login() {
       // Fetch user info to determine role, then route accordingly
       const meRes = await fetch('/api/auth/me', { credentials: 'include' });
       if (meRes.ok) {
-        const me = await meRes.json();
-        const dest = me.role?.toLowerCase() === 'admin' ? '/admin/users' : '/dev/projects';
-        router.push(dest);
+        await meRes.json();
+        router.push('/');
       } else {
-        // default to developer portal if role cannot be fetched
-        router.push('/dev/projects');
+        router.push('/');
       }
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- create a new landing page with personalized welcome and navigation
- redirect login flow to the new homepage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c8e106824832abc5e32eef27511ed