### PR TITLE
Unify styling across pages

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -16,8 +16,11 @@ export function Header() {
     }
   }
   return (
-    <header className="bg-[var(--color-primary)] text-white p-4 flex justify-between items-center">
-      <div>Dev Portal</div>
+    <header className="bg-gradient-to-r from-blue-600 to-blue-500 text-white p-4 flex justify-between items-center shadow-lg">
+      <div className="flex items-center space-x-3">
+        <img src="/logo.png" alt="Garage Vision Logo" className="w-8 h-8 rounded-full" />
+        <span className="font-bold text-lg">Garage Vision</span>
+      </div>
       {user && (
         <div className="flex items-center space-x-4">
           <span>{user.username}</span>

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -61,7 +61,7 @@ export default function Users() {
   };
 
   return (
-    <div className="flex min-h-screen bg-[var(--color-bg)] dark:bg-[var(--color-bg)]">
+    <div className="flex min-h-screen">
       <Sidebar />
       <div className="flex-1 flex flex-col">
         <Header />

--- a/pages/chat.js
+++ b/pages/chat.js
@@ -98,7 +98,7 @@ export default function Chat() {
   };
 
   return (
-    <div className="flex min-h-screen bg-[var(--color-bg)]">
+    <div className="flex min-h-screen">
       <Sidebar />
       <div className="flex-1 flex flex-col">
         <Header />

--- a/pages/dev/projects/[id].js
+++ b/pages/dev/projects/[id].js
@@ -48,7 +48,7 @@ export default function ProjectDetail() {
   }
 
   return (
-    <div className="flex min-h-screen bg-[var(--color-bg)]">
+    <div className="flex min-h-screen">
       <Sidebar />
       <div className="flex-1 flex flex-col">
         <Header />

--- a/pages/dev/projects/[id]/edit.js
+++ b/pages/dev/projects/[id]/edit.js
@@ -56,7 +56,7 @@ export default function EditProject() {
   };
 
   return (
-    <div className="flex min-h-screen bg-[var(--color-bg)]">
+    <div className="flex min-h-screen">
       <Sidebar />
       <div className="flex-1 flex flex-col">
         <Header />

--- a/pages/dev/projects/[id]/tasks/new.js
+++ b/pages/dev/projects/[id]/tasks/new.js
@@ -70,7 +70,7 @@ export default function NewTask() {
   };
 
   return (
-    <div className="flex min-h-screen bg-[var(--color-bg)]">
+    <div className="flex min-h-screen">
       <Sidebar />
       <div className="flex-1 flex flex-col">
         <Header />

--- a/pages/dev/projects/index.js
+++ b/pages/dev/projects/index.js
@@ -21,7 +21,7 @@ export default function Projects() {
     loadProjects();
   }, []);
   return (
-    <div className="flex">
+    <div className="flex min-h-screen">
       <Sidebar/>
       <div className="flex-1">
         <Header/>

--- a/pages/dev/projects/new.js
+++ b/pages/dev/projects/new.js
@@ -38,7 +38,7 @@ export default function NewProject() {
   };
 
   return (
-    <div className="flex min-h-screen bg-[var(--color-bg)]">
+    <div className="flex min-h-screen">
       <Sidebar />
       <div className="flex-1 flex flex-col">
         <Header />

--- a/pages/dev/tasks/[id].js
+++ b/pages/dev/tasks/[id].js
@@ -32,7 +32,7 @@ export default function TaskDetail() {
   }
 
   return (
-    <div className="flex min-h-screen bg-[var(--color-bg)]">
+    <div className="flex min-h-screen">
       <Sidebar />
       <div className="flex-1 flex flex-col">
         <Header />

--- a/pages/dev/tasks/[id]/edit.js
+++ b/pages/dev/tasks/[id]/edit.js
@@ -86,7 +86,7 @@ export default function EditTask() {
   };
 
   return (
-    <div className="flex min-h-screen bg-[var(--color-bg)]">
+    <div className="flex min-h-screen">
       <Sidebar />
       <div className="flex-1 flex flex-col">
         <Header />

--- a/pages/login.js
+++ b/pages/login.js
@@ -66,7 +66,8 @@ export default function Login() {
       <Head>
         <title>Login - Garage Vision</title>
       </Head>
-      <div className="min-h-screen flex items-center justify-center bg-[var(--color-bg)] dark:bg-[var(--color-bg)]">
+      <div className="min-h-screen flex flex-col items-center justify-center">
+        <img src="/logo.png" alt="Garage Vision Logo" width={120} height={120} className="mb-6 rounded-full shadow-lg" />
         <div className="absolute top-4 right-4">
           <button
             onClick={toggleTheme}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -34,3 +34,7 @@
 .button-secondary {
   @apply bg-gray-300 text-[var(--color-text-primary)] rounded-full py-3 shadow-xl hover:bg-gray-400 transition;
 }
+
+body {
+  @apply bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white;
+}


### PR DESCRIPTION
## Summary
- apply global gradient background
- update `Header` to include logo and gradient style
- show the logo on login page
- drop page-specific background colors to use the global style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c9917939c832a9afe9b7a8070fe51