### PR TITLE
Fix default text color

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -36,5 +36,6 @@
 }
 
 body {
-  @apply bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white;
+  @apply bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700;
+  color: var(--color-text-primary);
 }


### PR DESCRIPTION
## Summary
- prevent white text on white pages by removing text color from body

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685c9e817778832ab2556d82c21cb655