### PR TITLE
Initialize theme from localStorage

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,11 @@
 import '../styles/globals.css';
+import { useEffect } from 'react';
+
 export default function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    document.documentElement.classList.toggle('dark', stored === 'dark');
+  }, []);
+
   return <Component {...pageProps} />;
 }


### PR DESCRIPTION
## Summary
- check `localStorage` for saved theme on startup
- apply `dark` class to `<html>` based on stored value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ca1d108f8832aa6d0c2c152f03f9e