### PR TITLE
Restrict admin user link visibility

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -15,7 +15,7 @@ export function Sidebar() {
       <a href="/" className="block font-bold mb-4 text-center">Garage Vision</a>
       <a href="/dev/projects" className="button block text-center w-full">Dev → Projects</a>
       <a href="/chat" className="button block text-center w-full">Dev → Chat</a>
-      {(userRole === 'admin' || userRole === 'developer') && (
+      {userRole === 'admin' && (
         <a href="/admin/users" className="button block text-center w-full">Admin → Users</a>
       )}
     </nav>


### PR DESCRIPTION
## Summary
- only show the **Admin → Users** link in the sidebar when the current user is an admin

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand` *(fails: Cannot find module 'jest-config')*

------
https://chatgpt.com/codex/tasks/task_e_685ca5987eec832aac01d38c5b18da2c