### PR TITLE
Allow developer role user management access

### DIFF
--- a/__tests__/admin-users.test.js
+++ b/__tests__/admin-users.test.js
@@ -40,3 +40,46 @@ test('admin user delete returns 403 for non-admin', async () => {
   expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
   expect(queryMock).toHaveBeenCalledTimes(1);
 });
+
+test('admin users index allows developer role', async () => {
+  const queryMock = jest
+    .fn()
+    .mockResolvedValueOnce([[{ name: 'developer' }]])
+    .mockResolvedValueOnce([[]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 3 }),
+    hashPassword: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/admin/users/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith([]);
+  expect(queryMock).toHaveBeenCalledTimes(2);
+});
+
+test('admin user delete allows developer role', async () => {
+  const queryMock = jest
+    .fn()
+    .mockResolvedValueOnce([[{ name: 'developer' }]])
+    .mockResolvedValueOnce([{}])
+    .mockResolvedValueOnce([{ affectedRows: 1 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 4 }),
+    hashPassword: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/admin/users/[id].js');
+  const req = { method: 'DELETE', query: { id: 5 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ success: true });
+  expect(queryMock).toHaveBeenCalledTimes(3);
+});

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -15,7 +15,7 @@ export function Sidebar() {
       <a href="/" className="block font-bold mb-4 text-center">Garage Vision</a>
       <a href="/dev/projects" className="button block text-center w-full">Dev → Projects</a>
       <a href="/chat" className="button block text-center w-full">Dev → Chat</a>
-      {userRole === 'admin' && (
+      {['admin', 'developer'].includes(userRole) && (
         <a href="/admin/users" className="button block text-center w-full">Admin → Users</a>
       )}
     </nav>

--- a/pages/api/admin/users/[id].js
+++ b/pages/api/admin/users/[id].js
@@ -13,7 +13,7 @@ export default async function handler(req, res) {
      WHERE ur.user_id = ?`,
     [t.sub]
   );
-  if (!roleRow || roleRow.name !== 'admin') {
+  if (!roleRow || !['admin', 'developer'].includes(roleRow.name)) {
     return res.status(403).json({ error: 'Forbidden' });
   }
 

--- a/pages/api/admin/users/index.js
+++ b/pages/api/admin/users/index.js
@@ -11,7 +11,7 @@ export default async function handler(req, res) {
      WHERE ur.user_id = ?`,
     [t.sub]
   );
-  if (!roleRow || roleRow.name !== 'admin') {
+  if (!roleRow || !['admin', 'developer'].includes(roleRow.name)) {
     return res.status(403).json({ error: 'Forbidden' });
   }
   if (req.method === 'GET') {


### PR DESCRIPTION
## Summary
- allow developer role to see the Users link in sidebar
- authorize developer role for admin APIs
- extend tests to verify developer access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ca90cc318832aaeb7638984cc632a