### PR TITLE
Add file attachments for dev tasks and projects

### DIFF
--- a/migrations/garage.sql
+++ b/migrations/garage.sql
@@ -53,3 +53,16 @@ CREATE TABLE IF NOT EXISTS embeddings (
   txt TEXT,
   vec BLOB NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS task_files (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  task_id INT DEFAULT NULL,
+  project_id INT DEFAULT NULL,
+  s3_key VARCHAR(256) NOT NULL,
+  content_type VARCHAR(100),
+  uploaded_by INT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (task_id) REFERENCES dev_tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (project_id) REFERENCES dev_projects(id) ON DELETE CASCADE,
+  FOREIGN KEY (uploaded_by) REFERENCES users(id)
+);

--- a/pages/api/dev/files/index.js
+++ b/pages/api/dev/files/index.js
@@ -1,0 +1,44 @@
+import pool from '../../../../lib/db';
+import { getTokenFromReq } from '../../../../lib/auth';
+
+export default async function handler(req, res) {
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const userId = t.sub;
+
+  const task_id = req.query.task_id || req.body.task_id;
+  const project_id = req.query.project_id || req.body.project_id;
+
+  if (req.method === 'GET') {
+    if (!task_id && !project_id) {
+      return res.status(400).json({ error: 'task_id or project_id required' });
+    }
+    const cond = task_id ? 'f.task_id=?' : 'f.project_id=?';
+    const id = task_id || project_id;
+    const [files] = await pool.query(
+      `SELECT f.*, u.username AS uploader
+         FROM task_files f
+         JOIN users u ON f.uploaded_by=u.id
+        WHERE ${cond}
+        ORDER BY f.created_at DESC`,
+      [id]
+    );
+    return res.json(files);
+  }
+
+  if (req.method === 'POST') {
+    const { s3_key, content_type } = req.body;
+    if (!s3_key || (!task_id && !project_id)) {
+      return res.status(400).json({ error: 'Missing required fields' });
+    }
+    const [{ insertId }] = await pool.query(
+      `INSERT INTO task_files (task_id, project_id, s3_key, content_type, uploaded_by)
+       VALUES (?,?,?,?,?)`,
+      [task_id || null, project_id || null, s3_key, content_type || null, userId]
+    );
+    return res.status(201).json({ id: insertId });
+  }
+
+  res.setHeader('Allow', ['GET','POST']);
+  res.status(405).end();
+}


### PR DESCRIPTION
## Summary
- add `task_files` table to base schema
- implement `/api/dev/files` endpoint for uploading/listing files
- show attachments on project and task detail pages
- allow uploading files via existing S3 upload API

## Testing
- `npm run lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cb08611c8832a8afc7a1e25712b0f