### PR TITLE
Add developer dashboard

### DIFF
--- a/pages/api/dev/dashboard.js
+++ b/pages/api/dev/dashboard.js
@@ -1,0 +1,54 @@
+import pool from '../../../lib/db';
+import { getTokenFromReq } from '../../../lib/auth';
+
+export default async function handler(req, res) {
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const userId = t.sub;
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).end();
+  }
+
+  // determine if user is developer (role id 1)
+  const [[role]] = await pool.query(
+    'SELECT role_id FROM user_roles WHERE user_id=?',
+    [userId]
+  );
+  const isDeveloper = role && role.role_id === 1;
+
+  // Aggregate projects with task counts
+  const projectQuery = isDeveloper
+    ? `SELECT p.id, p.name,
+         COALESCE(SUM(t.status='todo'),0) AS todo,
+         COALESCE(SUM(t.status='in-progress'),0) AS in_progress,
+         COALESCE(SUM(t.status='done'),0) AS done
+       FROM dev_projects p
+       LEFT JOIN dev_tasks t ON t.dev_project_id=p.id
+       GROUP BY p.id
+       ORDER BY p.created_at DESC`
+    : `SELECT p.id, p.name,
+         COALESCE(SUM(t.status='todo'),0) AS todo,
+         COALESCE(SUM(t.status='in-progress'),0) AS in_progress,
+         COALESCE(SUM(t.status='done'),0) AS done
+       FROM dev_projects p
+       LEFT JOIN dev_tasks t ON t.dev_project_id=p.id AND t.created_by=?
+       WHERE p.created_by=?
+       GROUP BY p.id
+       ORDER BY p.created_at DESC`;
+
+  const params = isDeveloper ? [] : [userId, userId];
+  const [projects] = await pool.query(projectQuery, params);
+
+  // Important announcements tagged with @dashboard
+  const [announcements] = await pool.query(
+    `SELECT id, user, body, s3_key, content_type, created_at
+       FROM messages
+      WHERE deleted_at IS NULL AND body LIKE '%@dashboard%'
+      ORDER BY created_at DESC
+      LIMIT 20`
+  );
+
+  res.json({ projects, announcements });
+}

--- a/pages/dev/dashboard.js
+++ b/pages/dev/dashboard.js
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { Sidebar } from '../../components/Sidebar';
+import { Header } from '../../components/Header';
+import { Card } from '../../components/Card';
+import { highlightMentions } from '../../lib/highlightMentions.js';
+
+const S3_BASE_URL = `https://${process.env.NEXT_PUBLIC_S3_BUCKET}.s3.${process.env.NEXT_PUBLIC_AWS_REGION}.amazonaws.com`;
+
+const userColor = (name) => {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue} 65% 45%)`;
+};
+
+export default function DevDashboard() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const r = await fetch('/api/dev/dashboard', { credentials: 'include' });
+        if (!r.ok) throw new Error(`Fetch failed (${r.status})`);
+        const d = await r.json();
+        setData(d);
+      } catch (err) {
+        setError(err.message);
+      }
+    }
+    load();
+  }, []);
+
+  if (error) {
+    return <p className="p-8 text-red-500">Error: {error}</p>;
+  }
+  if (!data) {
+    return <p className="p-8">Loading dashboard…</p>;
+  }
+
+  const { projects, announcements } = data;
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex-1 flex flex-col">
+        <Header />
+        <main className="p-8 space-y-8">
+          <Head><title>Dashboard</title></Head>
+          <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">Dashboard</h1>
+
+          <section>
+            <h2 className="text-2xl font-semibold mb-4 text-[var(--color-text-primary)]">Project Summary</h2>
+            <div className="space-y-4">
+              {projects.map(p => (
+                <Card key={p.id} className="flex justify-between items-center">
+                  <span className="font-semibold">{p.name}</span>
+                  <div className="flex space-x-4 text-sm">
+                    <span>Todo: {p.todo}</span>
+                    <span>In Progress: {p.in_progress}</span>
+                    <span>Done: {p.done}</span>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-semibold mb-4 text-[var(--color-text-primary)]">Important Announcements</h2>
+            {!announcements.length ? (
+              <p className="text-[var(--color-text-secondary)]">No announcements.</p>
+            ) : (
+              <div className="space-y-4">
+                {announcements.map(a => (
+                  <Card key={a.id}>
+                    <div>
+                      <span className="font-semibold mr-2" style={{ color: userColor(a.user) }}>
+                        {a.user}:
+                      </span>
+                      <span>{highlightMentions(a.body)}</span>
+                      {a.s3_key && (
+                        a.content_type && a.content_type.startsWith('image/') ? (
+                          <img src={`${S3_BASE_URL}/${a.s3_key}`} alt="attachment" className="mt-2 max-w-xs" />
+                        ) : (
+                          <a href={`${S3_BASE_URL}/${a.s3_key}`} target="_blank" rel="noopener noreferrer" className="block mt-2 text-blue-500 underline">
+                            {a.s3_key.split('/').pop()}
+                          </a>
+                        )
+                      )}
+                    </div>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -31,6 +31,14 @@ function ChatIcon() {
   );
 }
 
+function DashboardIcon() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor" className="mb-2">
+      <path d="M3 13h8V3H3v10zM13 21h8V11h-8v10zM3 21h8v-6H3v6zM13 3v6h8V3h-8z" />
+    </svg>
+  );
+}
+
 // Custom hook to fetch current user
 function useCurrentUser() {
   const [user, setUser] = useState(null);
@@ -109,6 +117,7 @@ export default function Home() {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-xl">
           <DashboardCard href="/admin/users" title="User Setup" Icon={UsersIcon} />
           <DashboardCard href="/dev/projects" title="Projects" Icon={ProjectsIcon} />
+          <DashboardCard href="/dev/dashboard" title="Dashboard" Icon={DashboardIcon} />
           <DashboardCard href="/chat" title="Dev Chat" Icon={ChatIcon} />
         </div>
         <button


### PR DESCRIPTION
## Summary
- add a dashboard page under `pages/dev`
- expose dashboard data via new API route
- link dashboard from the home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cb1a7fb80832aa0d98ff249861438