### PR TITLE
Handle @dashboard mentions as important

### DIFF
--- a/__tests__/highlightMentions.test.js
+++ b/__tests__/highlightMentions.test.js
@@ -15,3 +15,14 @@ test('highlightMentions wraps mentions with highlight class', () => {
   expect(spans[1].className).toBe('text-[var(--color-mention)]');
   expect(container.textContent).toBe('hi @user-name!');
 });
+
+test('highlightMentions uses red class for @dashboard', () => {
+  const { container } = render(
+    React.createElement('div', null, highlightMentions('attention @dashboard!')),
+  );
+  const spans = container.querySelectorAll('span');
+  expect(spans).toHaveLength(3);
+  expect(spans[1].textContent).toBe('@dashboard');
+  expect(spans[1].className).toBe('text-red-500');
+  expect(container.textContent).toBe('attention @dashboard!');
+});

--- a/lib/highlightMentions.js
+++ b/lib/highlightMentions.js
@@ -1,9 +1,13 @@
 import React from "react";
 
 export function highlightMentions(text) {
-  return text.split(/(@[\w.-]+)/g).map((part, i) =>
-    part.startsWith('@')
-      ? React.createElement('span', { key: i, className: 'text-[var(--color-mention)]' }, part)
-      : React.createElement('span', { key: i }, part)
-  );
+  return text.split(/(@[\w.-]+)/g).map((part, i) => {
+    if (part.toLowerCase() === '@dashboard') {
+      return React.createElement('span', { key: i, className: 'text-red-500' }, part);
+    }
+    if (part.startsWith('@')) {
+      return React.createElement('span', { key: i, className: 'text-[var(--color-mention)]' }, part);
+    }
+    return React.createElement('span', { key: i }, part);
+  });
 }

--- a/migrations/20250601_add_messages_is_important.sql
+++ b/migrations/20250601_add_messages_is_important.sql
@@ -1,0 +1,5 @@
+ALTER TABLE messages
+  ADD COLUMN is_important BOOLEAN DEFAULT FALSE;
+
+UPDATE messages
+  SET is_important = (body LIKE '%@dashboard%');

--- a/pages/api/dev/dashboard.js
+++ b/pages/api/dev/dashboard.js
@@ -41,11 +41,11 @@ export default async function handler(req, res) {
   const params = isDeveloper ? [] : [userId, userId];
   const [projects] = await pool.query(projectQuery, params);
 
-  // Important announcements tagged with @dashboard
+  // Important announcements flagged as important
   const [announcements] = await pool.query(
     `SELECT id, user, body, s3_key, content_type, created_at
        FROM messages
-      WHERE deleted_at IS NULL AND body LIKE '%@dashboard%'
+      WHERE deleted_at IS NULL AND is_important=1
       ORDER BY created_at DESC
       LIMIT 20`
   );


### PR DESCRIPTION
## Summary
- highlight `@dashboard` with a red class
- store a new `is_important` flag for chat messages
- show important messages in the dashboard
- add migration for `is_important`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cb2eaac7c832aa25d0266ea762400