### PR TITLE
Implement idle logout hook

### DIFF
--- a/components/useIdleLogout.js
+++ b/components/useIdleLogout.js
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
+
+export default function useIdleLogout(timeoutMs = 15 * 60 * 1000) {
+  const router = useRouter();
+  const timer = useRef(null);
+
+  useEffect(() => {
+    function reset() {
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(async () => {
+        try {
+          await fetch('/api/auth/logout', { credentials: 'include' });
+        } finally {
+          router.push('/login');
+        }
+      }, timeoutMs);
+    }
+
+    reset();
+    const events = ['mousemove', 'mousedown', 'keydown', 'scroll', 'touchstart'];
+    events.forEach((e) => window.addEventListener(e, reset));
+    return () => {
+      events.forEach((e) => window.removeEventListener(e, reset));
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [router, timeoutMs]);
+}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,7 +15,7 @@ export async function verifyPassword(p, h) {
   return bcrypt.compare(p, h);
 }
 export function signToken(payload) {
-  return jwt.sign(payload, SECRET, { expiresIn: '8h' });
+  return jwt.sign(payload, SECRET, { expiresIn: '1h' });
 }
 export function verifyToken(token) {
   return jwt.verify(token, SECRET);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,9 @@
 import '../styles/globals.css';
 import { useEffect } from 'react';
+import useIdleLogout from '../components/useIdleLogout';
 
 export default function MyApp({ Component, pageProps }) {
+  useIdleLogout();
   useEffect(() => {
     const stored = localStorage.getItem('theme');
     document.documentElement.classList.toggle('dark', stored === 'dark');

--- a/pages/api/auth/login.js
+++ b/pages/api/auth/login.js
@@ -14,7 +14,7 @@ export default async function handler(req, res) {
   const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
   res.setHeader(
     'Set-Cookie',
-    `auth_token=${token}; HttpOnly; Path=/; Max-Age=28800; SameSite=Strict${secure}`
+    `auth_token=${token}; HttpOnly; Path=/; Max-Age=3600; SameSite=Strict${secure}`
   );
   res.status(200).json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- add `useIdleLogout` hook to redirect to login when the user is idle
- use the hook from `_app.js`
- shorten auth token duration to one hour

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cb404e0fc832aa028a1ed84f342c3