### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 export function Sidebar() {
   const [userRole, setUserRole] = useState(null);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     fetch('/api/auth/me', { credentials: 'include' })
@@ -10,14 +11,50 @@ export function Sidebar() {
       .catch(() => null);
   }, []);
 
+  const linkProps = {
+    className: 'button block text-center w-full',
+    onClick: () => setOpen(false),
+  };
+
   return (
-    <nav className="w-64 bg-[var(--color-surface)] h-screen p-4 space-y-4 text-[var(--color-text-primary)]">
-      <a href="/" className="block font-bold mb-4 text-center">Garage Vision</a>
-      <a href="/dev/projects" className="button block text-center w-full">Dev → Projects</a>
-      <a href="/chat" className="button block text-center w-full">Dev → Chat</a>
-      {['admin', 'developer'].includes(userRole) && (
-        <a href="/admin/users" className="button block text-center w-full">Admin → Users</a>
-      )}
-    </nav>
+    <div className="sm:w-64">
+      <button
+        className="sm:hidden p-4"
+        aria-label="Toggle navigation"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <svg
+          className="w-6 h-6 text-[var(--color-text-primary)]"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M4 6h16M4 12h16M4 18h16"
+          />
+        </svg>
+      </button>
+      <nav
+        className={`bg-[var(--color-surface)] text-[var(--color-text-primary)] space-y-4 p-4 sm:h-screen sm:block ${open ? 'block' : 'hidden'}`}
+      >
+        <a href="/" className="block font-bold mb-4 text-center" onClick={() => setOpen(false)}>
+          Garage Vision
+        </a>
+        <a href="/dev/projects" {...linkProps}>
+          Dev → Projects
+        </a>
+        <a href="/chat" {...linkProps}>
+          Dev → Chat
+        </a>
+        {['admin', 'developer'].includes(userRole) && (
+          <a href="/admin/users" {...linkProps}>
+            Admin → Users
+          </a>
+        )}
+      </nav>
+    </div>
   );
 }

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -78,9 +78,9 @@ export default function Users() {
   };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
         <main className="p-8 space-y-8">
           <Head>

--- a/pages/chat.js
+++ b/pages/chat.js
@@ -128,9 +128,9 @@ export default function Chat() {
   };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
         <Script
           src="/api/socket-io/socket.io.js"

--- a/pages/dev/dashboard.js
+++ b/pages/dev/dashboard.js
@@ -44,9 +44,9 @@ export default function DevDashboard() {
   const { projects, announcements } = data;
 
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
         <main className="p-8 space-y-8">
           <Head><title>Dashboard</title></Head>

--- a/pages/dev/projects/[id].js
+++ b/pages/dev/projects/[id].js
@@ -93,9 +93,9 @@ export default function ProjectDetail() {
   }
 
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
         <main className="p-8 space-y-6">
           <Head><title>Project – {project.name}</title></Head>

--- a/pages/dev/projects/[id]/edit.js
+++ b/pages/dev/projects/[id]/edit.js
@@ -56,9 +56,9 @@ export default function EditProject() {
   };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
         <main className="p-8">
           <Head><title>Edit Project</title></Head>

--- a/pages/dev/projects/[id]/tasks/new.js
+++ b/pages/dev/projects/[id]/tasks/new.js
@@ -70,9 +70,9 @@ export default function NewTask() {
   };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
         <main className="p-8">
           <Head><title>New Task</title></Head>

--- a/pages/dev/projects/index.js
+++ b/pages/dev/projects/index.js
@@ -21,9 +21,9 @@ export default function Projects() {
     loadProjects();
   }, []);
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar/>
-      <div className="flex-1">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header/>
         <main className="p-8">
           <h1 className="text-3xl mb-4">Projects</h1>

--- a/pages/dev/projects/new.js
+++ b/pages/dev/projects/new.js
@@ -38,9 +38,9 @@ export default function NewProject() {
   };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
         <main className="p-8">
           <Head><title>New Project</title></Head>

--- a/pages/dev/tasks/[id].js
+++ b/pages/dev/tasks/[id].js
@@ -76,9 +76,9 @@ export default function TaskDetail() {
   }
 
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
         <main className="p-8 space-y-6">
           <Head><title>Task – {task.title}</title></Head>

--- a/pages/dev/tasks/[id]/edit.js
+++ b/pages/dev/tasks/[id]/edit.js
@@ -86,9 +86,9 @@ export default function EditTask() {
   };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen flex flex-col sm:flex-row">
       <Sidebar />
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
         <main className="p-8">
           <Head><title>Edit Task</title></Head>


### PR DESCRIPTION
## Summary
- collapse sidebar on small screens
- refactor pages to stack vertically with scrolling on mobile
- keep portal functional on narrow viewports

## Testing
- `npm test`
- `npm run build`
- `npm start` *(fails: Playwright install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685cb4b5f5e0832a9bc6ef9ef343c8a5