### PR TITLE
Add clients service layer

### DIFF
--- a/pages/api/clients/[id].js
+++ b/pages/api/clients/[id].js
@@ -1,5 +1,5 @@
 // pages/api/clients/[id].js
-import { getClientById, updateClient, deleteClient } from '@/services/clientsService';
+import { getClientById, updateClient, deleteClient } from '../../../services/clientsService';
 
 export default async function handler(req, res) {
   const { id } = req.query;

--- a/pages/api/clients/index.js
+++ b/pages/api/clients/index.js
@@ -1,5 +1,5 @@
 // pages/api/clients/index.js
-import { getAllClients, createClient } from '@/services/clientsService';
+import { getAllClients, createClient } from '../../../services/clientsService';
 
 export default async function handler(req, res) {
   try {

--- a/services/clientsService.js
+++ b/services/clientsService.js
@@ -1,0 +1,37 @@
+import pool from '../lib/db.js';
+
+export async function getAllClients() {
+  const [rows] = await pool.query(
+    'SELECT id, name, email, phone FROM clients ORDER BY id'
+  );
+  return rows;
+}
+
+export async function getClientById(id) {
+  const [[row]] = await pool.query(
+    'SELECT id, name, email, phone FROM clients WHERE id=?',
+    [id]
+  );
+  return row || null;
+}
+
+export async function createClient({ name, email, phone }) {
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO clients (name, email, phone) VALUES (?,?,?)',
+    [name, email, phone]
+  );
+  return { id: insertId, name, email, phone };
+}
+
+export async function updateClient(id, { name, email, phone }) {
+  await pool.query(
+    'UPDATE clients SET name=?, email=?, phone=? WHERE id=?',
+    [name, email, phone, id]
+  );
+  return { ok: true };
+}
+
+export async function deleteClient(id) {
+  await pool.query('DELETE FROM clients WHERE id=?', [id]);
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- implement `clientsService.js` for database access
- reference service functions from `pages/api/clients`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dab01e7ac832a917f6bc0ad90ff9b