### PR TITLE
Fix job cards folder name

### DIFF
--- a/pages/office/job-cards/index.js
+++ b/pages/office/job-cards/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Layout } from '@/components/Layout';
+
+const JobCardsPage = () => (
+  <Layout>
+    <h1 className="text-xl font-semibold">Job Cards</h1>
+    {/* TODO: Job cards list */}
+  </Layout>
+);
+
+export default JobCardsPage;


### PR DESCRIPTION
## Summary
- rename `pages/office/job-carsd` -> `job-cards`
- implement placeholder JobCardsPage component

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_685dadba21a0832abe3cb71ad864ef14