### PR TITLE
Add clients API tests

### DIFF
--- a/__tests__/clients-api.test.js
+++ b/__tests__/clients-api.test.js
@@ -1,0 +1,163 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// GET /clients success
+
+test('clients index returns list of clients', async () => {
+  const clients = [{ id: 1, name: 'Alice' }];
+  const getAllMock = jest.fn().mockResolvedValue(clients);
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getAllClients: getAllMock,
+    createClient: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/clients/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(clients);
+  expect(getAllMock).toHaveBeenCalledTimes(1);
+});
+
+
+test('clients index creates client', async () => {
+  const newClient = { id: 2, name: 'Bob' };
+  const createMock = jest.fn().mockResolvedValue(newClient);
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getAllClients: jest.fn(),
+    createClient: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/clients/index.js');
+  const req = { method: 'POST', body: { name: 'Bob' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(newClient);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+});
+
+
+test('clients index rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getAllClients: jest.fn(),
+    createClient: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/clients/index.js');
+  const req = { method: 'PUT', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','POST']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method PUT Not Allowed');
+});
+
+
+test('clients index handles errors', async () => {
+  const error = new Error('db fail');
+  const getAllMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getAllClients: getAllMock,
+    createClient: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/clients/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+
+
+test('client detail returns client by id', async () => {
+  const client = { id: 1, name: 'Alice' };
+  const getMock = jest.fn().mockResolvedValue(client);
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getClientById: getMock,
+    updateClient: jest.fn(),
+    deleteClient: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/clients/[id].js');
+  const req = { method: 'GET', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(client);
+  expect(getMock).toHaveBeenCalledWith('1');
+});
+
+
+test('client update returns updated data', async () => {
+  const updated = { ok: true };
+  const updateMock = jest.fn().mockResolvedValue(updated);
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getClientById: jest.fn(),
+    updateClient: updateMock,
+    deleteClient: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/clients/[id].js');
+  const req = { method: 'PUT', query: { id: '2' }, body: { name: 'Bob' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(updated);
+  expect(updateMock).toHaveBeenCalledWith('2', req.body);
+});
+
+
+test('client delete succeeds', async () => {
+  const deleteMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getClientById: jest.fn(),
+    updateClient: jest.fn(),
+    deleteClient: deleteMock,
+  }));
+  const { default: handler } = await import('../pages/api/clients/[id].js');
+  const req = { method: 'DELETE', query: { id: '3' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(204);
+  expect(res.end).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalledWith('3');
+});
+
+
+test('client detail rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getClientById: jest.fn(),
+    updateClient: jest.fn(),
+    deleteClient: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/clients/[id].js');
+  const req = { method: 'POST', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','PUT','DELETE']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+
+test('client detail handles errors', async () => {
+  const error = new Error('fail');
+  const getMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getClientById: getMock,
+    updateClient: jest.fn(),
+    deleteClient: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/clients/[id].js');
+  const req = { method: 'GET', query: { id: '4' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+


### PR DESCRIPTION
## Summary
- add tests for `/api/clients` and `/api/clients/[id]`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dae63facc832a977adc1727ffed81