### PR TITLE
Add Layout component and fix office imports

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Sidebar } from './Sidebar';
+import { Header } from './Header';
+
+export function Layout({ children }) {
+  return (
+    <div className="min-h-screen flex flex-col sm:flex-row">
+      <Sidebar />
+      <div className="flex-1 flex flex-col overflow-y-auto">
+        <Header />
+        <main className="p-8">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/pages/office/clients/[id].js
+++ b/pages/office/clients/[id].js
@@ -1,7 +1,7 @@
 // pages/office/clients/[id].js
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const EditClientPage = () => {
   const { id } = useRouter().query;

--- a/pages/office/clients/index.js
+++ b/pages/office/clients/index.js
@@ -1,8 +1,8 @@
 // pages/office/clients/index.js
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Layout } from '@/components/Layout';
-import { fetchClients } from '@/lib/clients';
+import { Layout } from '../../../components/Layout';
+import { fetchClients } from '../../../lib/clients';
 
 const ClientsPage = () => {
   const [clients, setClients] = useState([]);

--- a/pages/office/clients/new.js
+++ b/pages/office/clients/new.js
@@ -1,7 +1,7 @@
 // pages/office/clients/new.js
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const NewClientPage = () => {
   const [form, setForm] = useState({ name: '', email: '', phone: '' });

--- a/pages/office/crm/index.js
+++ b/pages/office/crm/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const CrmPage = () => (
   <Layout>

--- a/pages/office/engineers/index.js
+++ b/pages/office/engineers/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const EngineersPage = () => (
   <Layout>

--- a/pages/office/index.js
+++ b/pages/office/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../components/Layout';
 
 const OfficeDashboard = () => (
   <Layout>

--- a/pages/office/invoices/index.js
+++ b/pages/office/invoices/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const InvoicesPage = () => (
   <Layout>

--- a/pages/office/job-cards/index.js
+++ b/pages/office/job-cards/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const JobCardsPage = () => (
   <Layout>

--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const JobManagementPage = () => (
   <Layout>

--- a/pages/office/parts/index.js
+++ b/pages/office/parts/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const PartsPage = () => (
   <Layout>

--- a/pages/office/quotations/index.js
+++ b/pages/office/quotations/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const QuotationsPage = () => (
   <Layout>

--- a/pages/office/reporting/index.js
+++ b/pages/office/reporting/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const ReportingPage = () => (
   <Layout>

--- a/pages/office/scheduling/index.js
+++ b/pages/office/scheduling/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const SchedulingPage = () => (
   <Layout>

--- a/pages/office/vehicles/index.js
+++ b/pages/office/vehicles/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Layout } from '@/components/Layout';
+import { Layout } from '../../../components/Layout';
 
 const VehiclesPage = () => (
   <Layout>


### PR DESCRIPTION
## Summary
- add a shared `Layout` component
- update all `pages/office` imports to use relative path to `Layout`
- fix clients index page import path

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db14bb39c832a916b3b349834b889