### PR TITLE
Fix label capitalization regex spacing

### DIFF
--- a/pages/office/clients/[id].js
+++ b/pages/office/clients/[id].js
@@ -67,7 +67,7 @@ const EditClientPage = () => {
           'post_code',
         ].map(field => (
           <div key={field}>
-            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
+            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g, c => c.toUpperCase())}</label>
             <input
               name={field}
               value={form[field] || ''}

--- a/pages/office/clients/new.js
+++ b/pages/office/clients/new.js
@@ -54,7 +54,7 @@ const NewClientPage = () => {
           'post_code',
         ].map(field => (
           <div key={field}>
-            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
+            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g, c => c.toUpperCase())}</label>
             <input
               name={field}
               value={form[field]}


### PR DESCRIPTION
## Summary
- ensure client form labels use properly spaced regex replace

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_685dc8e0b064832a8bd94d0d83ead60e