### PR TITLE
Implement sequential SQL migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
 2. Install dependencies: `npm install`
 3. Make the bootstrap script executable and run it to scaffold the portal:
    `chmod +x bootstrap_dev_portal.sh && ./bootstrap_dev_portal.sh`
-4. Run migrations (this will also create the `clients` table): `npm run migrate`
-5. If upgrading from an earlier version, apply `migrations/20250701_extend_clients.sql`
-   to add new client columns before starting the app.
-6. Start dev server: `npm run dev`
+4. Run migrations: `npm run migrate`
+   - This command executes every `.sql` file in the `migrations/` directory in
+     order and records which have been run.
+   - Running the script again safely skips already-applied migrations.
+5. Start dev server: `npm run dev`
 
 ## Database
 
-The schema used by the migration script lives in `migrations/garage.sql`.
-This file is the single source of truth for the initial database structure.
+All database schema changes are stored as `.sql` files in the `migrations/`
+directory. The migration script executes them sequentially and records the
+results so it can be run repeatedly without errors.

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -11,12 +11,41 @@ async function runMigrations() {
   }
   const parsed = new URL(urlStr);
   parsed.searchParams.set('multipleStatements', 'true');
-  const sql = fs.readFileSync(path.resolve('./migrations/garage.sql'), 'utf8');
-  // Ensure multiple statements are allowed like in lib/db.js
   const conn = await mysql.createConnection(parsed.toString());
   try {
     console.log('Running migrations...');
-    await conn.query(sql);
+
+    // Ensure a table exists to track executed migrations
+    await conn.query(`CREATE TABLE IF NOT EXISTS schema_migrations (
+      id INT PRIMARY KEY AUTO_INCREMENT,
+      filename VARCHAR(255) UNIQUE NOT NULL,
+      run_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )`);
+
+    const files = fs
+      .readdirSync(path.resolve('./migrations'))
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+
+    for (const file of files) {
+      const [[already]] = await conn.query(
+        'SELECT 1 FROM schema_migrations WHERE filename = ? LIMIT 1',
+        [file]
+      );
+      if (already) {
+        console.log(`Skipping ${file} (already applied)`);
+        continue;
+      }
+
+      const sql = fs.readFileSync(
+        path.resolve('./migrations', file),
+        'utf8'
+      );
+      console.log(`Applying ${file}...`);
+      await conn.query(sql);
+      await conn.query('INSERT INTO schema_migrations (filename) VALUES (?)', [file]);
+    }
+
     console.log('Migrations complete.');
     await conn.end();
     process.exit(0);


### PR DESCRIPTION
## Summary
- run each SQL file in `migrations/` sequentially with tracking table
- document automated migration process in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dcef45e1c832a8a75755907474edd