### PR TITLE
Add black text color to client forms

### DIFF
--- a/pages/office/clients/[id].js
+++ b/pages/office/clients/[id].js
@@ -72,7 +72,7 @@ const EditClientPage = () => {
               name={field}
               value={form[field] || ''}
               onChange={change}
-              className="w-full border px-3 py-2 rounded"
+              className="w-full border px-3 py-2 rounded text-black"
             />
           </div>
         ))}

--- a/pages/office/clients/new.js
+++ b/pages/office/clients/new.js
@@ -59,7 +59,7 @@ const NewClientPage = () => {
               name={field}
               value={form[field]}
               onChange={change}
-              className="w-full border px-3 py-2 rounded"
+              className="w-full border px-3 py-2 rounded text-black"
             />
           </div>
         ))}


### PR DESCRIPTION
## Summary
- keep text consistent in forms by using `text-black` on all client `<input>` elements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ddf82f330832aa127af760e8936dd