### PR TITLE
Ensure S3 links trigger download

### DIFF
--- a/pages/chat.js
+++ b/pages/chat.js
@@ -207,6 +207,7 @@ export default function Chat() {
                         target="_blank"
                         rel="noopener noreferrer"
                         className="block mt-2 text-blue-500 underline"
+                        download
                       >
                         {m.s3_key.split('/').pop()}
                       </a>

--- a/pages/dev/dashboard.js
+++ b/pages/dev/dashboard.js
@@ -85,7 +85,7 @@ export default function DevDashboard() {
                         a.content_type && a.content_type.startsWith('image/') ? (
                           <img src={`${S3_BASE_URL}/${a.s3_key}`} alt="attachment" className="mt-2 max-w-xs" />
                         ) : (
-                          <a href={`${S3_BASE_URL}/${a.s3_key}`} target="_blank" rel="noopener noreferrer" className="block mt-2 text-blue-500 underline">
+                          <a href={`${S3_BASE_URL}/${a.s3_key}`} target="_blank" rel="noopener noreferrer" className="block mt-2 text-blue-500 underline" download>
                             {a.s3_key.split('/').pop()}
                           </a>
                         )

--- a/pages/dev/projects/[id].js
+++ b/pages/dev/projects/[id].js
@@ -184,7 +184,7 @@ export default function ProjectDetail() {
                   {f.content_type && f.content_type.startsWith('image/') ? (
                     <img src={`${S3_BASE_URL}/${f.s3_key}`} alt="attachment" className="max-w-xs" />
                   ) : (
-                    <a href={`${S3_BASE_URL}/${f.s3_key}`} target="_blank" rel="noopener noreferrer" className="text-blue-500 underline">
+                    <a href={`${S3_BASE_URL}/${f.s3_key}`} target="_blank" rel="noopener noreferrer" className="text-blue-500 underline" download>
                       {f.s3_key.split('/').pop()}
                     </a>
                   )}

--- a/pages/dev/tasks/[id].js
+++ b/pages/dev/tasks/[id].js
@@ -117,7 +117,7 @@ export default function TaskDetail() {
                   {f.content_type && f.content_type.startsWith('image/') ? (
                     <img src={`${S3_BASE_URL}/${f.s3_key}`} alt="attachment" className="max-w-xs" />
                   ) : (
-                    <a href={`${S3_BASE_URL}/${f.s3_key}`} target="_blank" rel="noopener noreferrer" className="text-blue-500 underline">
+                    <a href={`${S3_BASE_URL}/${f.s3_key}`} target="_blank" rel="noopener noreferrer" className="text-blue-500 underline" download>
                       {f.s3_key.split('/').pop()}
                     </a>
                   )}


### PR DESCRIPTION
## Summary
- make all links to S3 objects download instead of opening in the browser

## Testing
- `npm test` *(fails: Cannot find module 'node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_685de339488c832a8d00a65a7c2436b7