### PR TITLE
Add vehicles CRUD features

### DIFF
--- a/__tests__/vehicles-api.test.js
+++ b/__tests__/vehicles-api.test.js
@@ -1,0 +1,154 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// GET /vehicles success
+
+test('vehicles index returns list of vehicles', async () => {
+  const vehicles = [{ id: 1, licence_plate: 'ABC' }];
+  const getAllMock = jest.fn().mockResolvedValue(vehicles);
+  jest.unstable_mockModule('../services/vehiclesService.js', () => ({
+    getAllVehicles: getAllMock,
+    createVehicle: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/vehicles/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(vehicles);
+  expect(getAllMock).toHaveBeenCalledTimes(1);
+});
+
+test('vehicles index creates vehicle', async () => {
+  const newVehicle = { id: 2, licence_plate: 'XYZ' };
+  const createMock = jest.fn().mockResolvedValue(newVehicle);
+  jest.unstable_mockModule('../services/vehiclesService.js', () => ({
+    getAllVehicles: jest.fn(),
+    createVehicle: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/vehicles/index.js');
+  const req = { method: 'POST', body: { licence_plate: 'XYZ' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(newVehicle);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+});
+
+test('vehicles index rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/vehiclesService.js', () => ({
+    getAllVehicles: jest.fn(),
+    createVehicle: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/vehicles/index.js');
+  const req = { method: 'PUT', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','POST']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method PUT Not Allowed');
+});
+
+test('vehicles index handles errors', async () => {
+  const error = new Error('db fail');
+  const getAllMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/vehiclesService.js', () => ({
+    getAllVehicles: getAllMock,
+    createVehicle: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/vehicles/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+
+test('vehicle detail returns vehicle by id', async () => {
+  const vehicle = { id: 1, licence_plate: 'AAA' };
+  const getMock = jest.fn().mockResolvedValue(vehicle);
+  jest.unstable_mockModule('../services/vehiclesService.js', () => ({
+    getVehicleById: getMock,
+    updateVehicle: jest.fn(),
+    deleteVehicle: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/vehicles/[id].js');
+  const req = { method: 'GET', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(vehicle);
+  expect(getMock).toHaveBeenCalledWith('1');
+});
+
+test('vehicle update returns updated data', async () => {
+  const updated = { ok: true };
+  const updateMock = jest.fn().mockResolvedValue(updated);
+  jest.unstable_mockModule('../services/vehiclesService.js', () => ({
+    getVehicleById: jest.fn(),
+    updateVehicle: updateMock,
+    deleteVehicle: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/vehicles/[id].js');
+  const req = { method: 'PUT', query: { id: '2' }, body: { make: 'Ford' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(updated);
+  expect(updateMock).toHaveBeenCalledWith('2', req.body);
+});
+
+test('vehicle delete succeeds', async () => {
+  const deleteMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/vehiclesService.js', () => ({
+    getVehicleById: jest.fn(),
+    updateVehicle: jest.fn(),
+    deleteVehicle: deleteMock,
+  }));
+  const { default: handler } = await import('../pages/api/vehicles/[id].js');
+  const req = { method: 'DELETE', query: { id: '3' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(204);
+  expect(res.end).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalledWith('3');
+});
+
+test('vehicle detail rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/vehiclesService.js', () => ({
+    getVehicleById: jest.fn(),
+    updateVehicle: jest.fn(),
+    deleteVehicle: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/vehicles/[id].js');
+  const req = { method: 'POST', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','PUT','DELETE']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('vehicle detail handles errors', async () => {
+  const error = new Error('fail');
+  const getMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/vehiclesService.js', () => ({
+    getVehicleById: getMock,
+    updateVehicle: jest.fn(),
+    deleteVehicle: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/vehicles/[id].js');
+  const req = { method: 'GET', query: { id: '4' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});

--- a/lib/vehicles.js
+++ b/lib/vehicles.js
@@ -1,0 +1,6 @@
+export async function fetchVehicles(customer_id) {
+  const url = customer_id ? `/api/vehicles?customer_id=${customer_id}` : '/api/vehicles';
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch vehicles');
+  return res.json();
+}

--- a/migrations/20250801_create_vehicles.sql
+++ b/migrations/20250801_create_vehicles.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS vehicles (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  licence_plate VARCHAR(20) NOT NULL,
+  make VARCHAR(50),
+  model VARCHAR(50),
+  color VARCHAR(30),
+  customer_id INT,
+  fleet_id INT,
+  CONSTRAINT fk_vehicles_customer_id FOREIGN KEY (customer_id) REFERENCES clients(id)
+);

--- a/pages/api/vehicles/[id].js
+++ b/pages/api/vehicles/[id].js
@@ -1,0 +1,24 @@
+import { getVehicleById, updateVehicle, deleteVehicle } from '../../../services/vehiclesService';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const vehicle = await getVehicleById(id);
+      return res.status(200).json(vehicle);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateVehicle(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await deleteVehicle(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/vehicles/index.js
+++ b/pages/api/vehicles/index.js
@@ -1,0 +1,20 @@
+import { getAllVehicles, createVehicle } from '../../../services/vehiclesService';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const { customer_id } = req.query || {};
+      const vehicles = await getAllVehicles(customer_id);
+      return res.status(200).json(vehicles);
+    }
+    if (req.method === 'POST') {
+      const newVehicle = await createVehicle(req.body);
+      return res.status(201).json(newVehicle);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/office/clients/[id].js
+++ b/pages/office/clients/[id].js
@@ -1,7 +1,9 @@
 // pages/office/clients/[id].js
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import { Layout } from '../../../components/Layout';
+import { fetchVehicles } from '../../../lib/vehicles';
 
 const EditClientPage = () => {
   const { id } = useRouter().query;
@@ -17,6 +19,7 @@ const EditClientPage = () => {
     province: '',
     post_code: '',
   });
+  const [vehicles, setVehicles] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const router = useRouter();
@@ -28,6 +31,10 @@ const EditClientPage = () => {
       .then(data => setForm(data))
       .catch(() => setError('Failed to load'))
       .finally(() => setLoading(false));
+    fetchVehicles(id)
+      .then(setVehicles)
+      .catch(() => {})
+      .finally(() => {});
   }, [id]);
 
   const submit = async e => {
@@ -46,6 +53,12 @@ const EditClientPage = () => {
   };
 
   const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const handleDeleteVehicle = async vid => {
+    if (!confirm('Delete this vehicle?')) return;
+    await fetch(`/api/vehicles/${vid}`, { method: 'DELETE' });
+    fetchVehicles(id).then(setVehicles);
+  };
 
   if (loading) return <Layout><p>Loading…</p></Layout>;
 
@@ -78,6 +91,50 @@ const EditClientPage = () => {
         ))}
         <button type="submit" className="btn">Update</button>
       </form>
+      <div className="mt-8">
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="text-xl font-semibold">Vehicles</h2>
+          <Link href={`/office/vehicles/new?customer_id=${id}`}>
+            <a className="underline">Add Vehicle</a>
+          </Link>
+        </div>
+        {vehicles.length === 0 ? (
+          <p>No vehicles</p>
+        ) : (
+          <table className="min-w-full bg-white border">
+            <thead>
+              <tr>
+                <th className="px-4 py-2 border text-black">Plate</th>
+                <th className="px-4 py-2 border text-black">Make</th>
+                <th className="px-4 py-2 border text-black">Model</th>
+                <th className="px-4 py-2 border text-black">Color</th>
+                <th className="px-4 py-2 border text-black">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {vehicles.map(v => (
+                <tr key={v.id}>
+                  <td className="px-4 py-2 border text-black">{v.licence_plate}</td>
+                  <td className="px-4 py-2 border text-black">{v.make}</td>
+                  <td className="px-4 py-2 border text-black">{v.model}</td>
+                  <td className="px-4 py-2 border text-black">{v.color}</td>
+                  <td className="px-4 py-2 border text-black">
+                    <Link href={`/office/vehicles/${v.id}`}>
+                      <a className="mr-2 underline">Edit</a>
+                    </Link>
+                    <button
+                      onClick={() => handleDeleteVehicle(v.id)}
+                      className="underline text-red-600"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
     </Layout>
   );
 };

--- a/pages/office/clients/new.js
+++ b/pages/office/clients/new.js
@@ -16,6 +16,12 @@ const NewClientPage = () => {
     province: '',
     post_code: '',
   });
+  const [vehicle, setVehicle] = useState({
+    licence_plate: '',
+    make: '',
+    model: '',
+    color: '',
+  });
   const [error, setError] = useState(null);
   const router = useRouter();
 
@@ -28,6 +34,14 @@ const NewClientPage = () => {
         body: JSON.stringify(form),
       });
       if (!res.ok) throw new Error();
+      const created = await res.json();
+      if (vehicle.licence_plate) {
+        await fetch('/api/vehicles', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...vehicle, customer_id: created.id }),
+        });
+      }
       router.push('/office/clients');
     } catch {
       setError('Failed to create client');
@@ -35,15 +49,16 @@ const NewClientPage = () => {
   };
 
   const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+  const changeVehicle = e => setVehicle(v => ({ ...v, [e.target.name]: e.target.value }));
 
   return (
     <Layout>
       <h1 className="text-2xl font-semibold mb-4">New Client</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
-        {[
-          'first_name',
-          'last_name',
+      {[
+        'first_name',
+        'last_name',
           'email',
           'mobile',
           'landline',
@@ -51,14 +66,26 @@ const NewClientPage = () => {
           'street_address',
           'town',
           'province',
-          'post_code',
-        ].map(field => (
+        'post_code',
+      ].map(field => (
+        <div key={field}>
+          <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g, c => c.toUpperCase())}</label>
+          <input
+            name={field}
+            value={form[field]}
+            onChange={change}
+            className="w-full border px-3 py-2 rounded text-black"
+          />
+        </div>
+      ))}
+        <h2 className="text-xl font-semibold mt-6">Vehicle (optional)</h2>
+        {['licence_plate','make','model','color'].map(field => (
           <div key={field}>
-            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g, c => c.toUpperCase())}</label>
+            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
             <input
               name={field}
-              value={form[field]}
-              onChange={change}
+              value={vehicle[field]}
+              onChange={changeVehicle}
               className="w-full border px-3 py-2 rounded text-black"
             />
           </div>

--- a/pages/office/vehicles/[id].js
+++ b/pages/office/vehicles/[id].js
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Layout } from '../../../components/Layout';
+
+const EditVehiclePage = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const [form, setForm] = useState({
+    licence_plate: '',
+    make: '',
+    model: '',
+    color: '',
+    customer_id: '',
+    fleet_id: '',
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/vehicles/${id}`)
+      .then(r => r.json())
+      .then(setForm)
+      .catch(() => setError('Failed to load'))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`/api/vehicles/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error();
+      router.push('/office/vehicles');
+    } catch {
+      setError('Failed to update');
+    }
+  };
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  if (loading) return <Layout><p>Loading…</p></Layout>;
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Edit Vehicle</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        {['licence_plate','make','model','color','customer_id','fleet_id'].map(field => (
+          <div key={field}>
+            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
+            <input
+              name={field}
+              value={form[field] || ''}
+              onChange={change}
+              className="w-full border px-3 py-2 rounded text-black"
+            />
+          </div>
+        ))}
+        <button type="submit" className="btn">Update</button>
+      </form>
+    </Layout>
+  );
+};
+
+export default EditVehiclePage;

--- a/pages/office/vehicles/index.js
+++ b/pages/office/vehicles/index.js
@@ -1,11 +1,94 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Layout } from '../../../components/Layout';
+import { fetchVehicles } from '../../../lib/vehicles';
 
-const VehiclesPage = () => (
-  <Layout>
-    <h1 className="text-xl font-semibold">Vehicles</h1>
-    {/* TODO: Fetch and display vehicles */}
-  </Layout>
-);
+const VehiclesPage = () => {
+  const [vehicles, setVehicles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const load = () => {
+    setLoading(true);
+    fetchVehicles()
+      .then(setVehicles)
+      .catch(() => setError('Failed to load vehicles'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const handleDelete = async id => {
+    if (!confirm('Delete this vehicle?')) return;
+    await fetch(`/api/vehicles/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  const filtered = vehicles.filter(v => {
+    const q = searchQuery.toLowerCase();
+    return (
+      v.licence_plate.toLowerCase().includes(q) ||
+      (v.make || '').toLowerCase().includes(q) ||
+      (v.model || '').toLowerCase().includes(q) ||
+      (v.customer_name || '').toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <Layout>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-semibold">Vehicles</h1>
+        <Link href="/office/vehicles/new">
+          <a className="btn">+ New Vehicle</a>
+        </Link>
+      </div>
+      {loading && <p>Loading…</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      {!loading && !error && (
+        <>
+          <input
+            type="text"
+            placeholder="Search…"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            className="mb-4 border px-3 py-2 rounded text-black w-full"
+          />
+          <table className="min-w-full bg-white border">
+            <thead>
+              <tr>
+                <th className="px-4 py-2 border text-black">Plate</th>
+                <th className="px-4 py-2 border text-black">Make</th>
+                <th className="px-4 py-2 border text-black">Model</th>
+                <th className="px-4 py-2 border text-black">Color</th>
+                <th className="px-4 py-2 border text-black">Client</th>
+                <th className="px-4 py-2 border text-black">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map(v => (
+                <tr key={v.id}>
+                  <td className="px-4 py-2 border text-black">{v.licence_plate}</td>
+                  <td className="px-4 py-2 border text-black">{v.make}</td>
+                  <td className="px-4 py-2 border text-black">{v.model}</td>
+                  <td className="px-4 py-2 border text-black">{v.color}</td>
+                  <td className="px-4 py-2 border text-black">{v.customer_name}</td>
+                  <td className="px-4 py-2 border text-black">
+                    <Link href={`/office/vehicles/${v.id}`}>
+                      <a className="mr-2 underline">Edit</a>
+                    </Link>
+                    <button onClick={() => handleDelete(v.id)} className="underline text-red-600">
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </Layout>
+  );
+};
 
 export default VehiclesPage;

--- a/pages/office/vehicles/new.js
+++ b/pages/office/vehicles/new.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Layout } from '../../../components/Layout';
+
+const NewVehiclePage = () => {
+  const router = useRouter();
+  const [form, setForm] = useState({
+    licence_plate: '',
+    make: '',
+    model: '',
+    color: '',
+    customer_id: router.query.customer_id || '',
+    fleet_id: '',
+  });
+  const [error, setError] = useState(null);
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/vehicles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error();
+      router.push('/office/vehicles');
+    } catch {
+      setError('Failed to create vehicle');
+    }
+  };
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">New Vehicle</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        {['licence_plate','make','model','color','customer_id','fleet_id'].map(field => (
+          <div key={field}>
+            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
+            <input
+              name={field}
+              value={form[field]}
+              onChange={change}
+              className="w-full border px-3 py-2 rounded text-black"
+            />
+          </div>
+        ))}
+        <button type="submit" className="btn">Save</button>
+      </form>
+    </Layout>
+  );
+};
+
+export default NewVehiclePage;

--- a/services/vehiclesService.js
+++ b/services/vehiclesService.js
@@ -1,0 +1,42 @@
+import pool from '../lib/db.js';
+
+export async function getAllVehicles(customer_id) {
+  const base = `SELECT v.id, v.licence_plate, v.make, v.model, v.color, v.customer_id, v.fleet_id,
+                       CONCAT(c.first_name, ' ', c.last_name) AS customer_name
+                  FROM vehicles v
+             LEFT JOIN clients c ON v.customer_id=c.id`;
+  const [rows] = customer_id
+    ? await pool.query(`${base} WHERE v.customer_id=? ORDER BY v.id`, [customer_id])
+    : await pool.query(`${base} ORDER BY v.id`);
+  return rows;
+}
+
+export async function getVehicleById(id) {
+  const [[row]] = await pool.query(
+    `SELECT id, licence_plate, make, model, color, customer_id, fleet_id FROM vehicles WHERE id=?`,
+    [id],
+  );
+  return row || null;
+}
+
+export async function createVehicle({ licence_plate, make, model, color, customer_id, fleet_id }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO vehicles (licence_plate, make, model, color, customer_id, fleet_id)
+     VALUES (?,?,?,?,?,?)`,
+    [licence_plate, make, model, color, customer_id || null, fleet_id || null],
+  );
+  return { id: insertId, licence_plate, make, model, color, customer_id, fleet_id };
+}
+
+export async function updateVehicle(id, { licence_plate, make, model, color, customer_id, fleet_id }) {
+  await pool.query(
+    `UPDATE vehicles SET licence_plate=?, make=?, model=?, color=?, customer_id=?, fleet_id=? WHERE id=?`,
+    [licence_plate, make, model, color, customer_id || null, fleet_id || null, id],
+  );
+  return { ok: true };
+}
+
+export async function deleteVehicle(id) {
+  await pool.query('DELETE FROM vehicles WHERE id=?', [id]);
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- create vehicles table migration
- add vehicles service and REST API
- implement vehicles CRUD pages with search
- allow adding vehicle when creating client
- show vehicles on client profile page
- add tests for vehicles API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec664636c832a820df050b90366c8