### PR TITLE
Update sidebar developer links

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -48,33 +48,37 @@ export function Sidebar() {
         >
           Garage Vision
         </a>
-        <a
-          href="/dev"
-          className="bg-red-800 text-white font-bold rounded-full px-4 py-2 shadow hover:bg-red-900 block text-center w-full"
-          onClick={() => setOpen(false)}
-        >
-          Dev Portal
-        </a>
-        <a
-          href="/office"
-          className="bg-red-800 text-white font-bold rounded-full px-4 py-2 shadow hover:bg-red-900 block text-center w-full"
-          onClick={() => setOpen(false)}
-        >
-          Office
-        </a>
-        <a href="/dev/projects" {...linkProps}>
-          Projects
-        </a>
-        <a href="/dev/dashboard" {...linkProps}>
-          Dashboard
-        </a>
-        <a href="/chat" {...linkProps}>
-          Chat
-        </a>
-        {["admin", "developer"].includes(userRole) && (
-          <a href="/admin/users" {...linkProps}>
-            Users
-          </a>
+        {userRole === "developer" && (
+          <>
+            <a
+              href="/dev"
+              className="bg-red-800 text-white font-bold rounded-full px-4 py-2 shadow hover:bg-red-900 block text-center w-full"
+              onClick={() => setOpen(false)}
+            >
+              Dev Portal
+            </a>
+            <a
+              href="/dev/projects"
+              {...linkProps}
+            >
+              Projects
+            </a>
+            <a
+              href="/dev/dashboard"
+              {...linkProps}
+            >
+              Dashboard
+            </a>
+            <a href="/office" {...linkProps}>
+              Office
+            </a>
+            <a href="/chat" {...linkProps}>
+              Chat
+            </a>
+            <a href="/admin/users" {...linkProps}>
+              Users
+            </a>
+          </>
         )}
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- show developer-only links in the sidebar when user role is `developer`

## Testing
- `npm test` *(fails: cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685f42875bbc832a9387a37b357c8c5c