### PR TITLE
Ensure dark theme card text remains black

### DIFF
--- a/pages/office/clients/index.js
+++ b/pages/office/clients/index.js
@@ -59,11 +59,11 @@ const ClientsPage = () => {
         <div className="grid gap-4 sm:grid-cols-2">
           {filteredClients.map(c => (
             <div key={c.id} className="item-card">
-              <h2 className="font-semibold text-[var(--color-text-primary)] text-lg mb-1">
+              <h2 className="font-semibold text-[var(--color-text-primary)] dark:text-black text-lg mb-1">
                 {`${c.first_name || ''} ${c.last_name || ''}`.trim() || 'Unnamed'}
               </h2>
-              <p className="text-sm text-[var(--color-text-secondary)]">{c.email}</p>
-              <p className="text-sm text-[var(--color-text-secondary)]">{c.mobile}</p>
+              <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">{c.email}</p>
+              <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">{c.mobile}</p>
               <div className="mt-3 flex flex-wrap gap-2">
                 <Link href={`/office/clients/view/${c.id}`} className="button px-4 text-sm">
                   View

--- a/pages/office/vehicles/index.js
+++ b/pages/office/vehicles/index.js
@@ -60,14 +60,14 @@ const VehiclesPage = () => {
           <div className="grid gap-4 sm:grid-cols-2">
             {filtered.map(v => (
               <div key={v.id} className="item-card">
-                <h2 className="font-semibold text-[var(--color-text-primary)] text-lg mb-1">
+                <h2 className="font-semibold text-[var(--color-text-primary)] dark:text-black text-lg mb-1">
                   {v.licence_plate}
                 </h2>
-                <p className="text-sm text-[var(--color-text-secondary)]">
+                <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">
                   {v.make} {v.model}
                 </p>
-                <p className="text-sm text-[var(--color-text-secondary)]">{v.color}</p>
-                <p className="text-sm text-[var(--color-text-secondary)]">{v.customer_name}</p>
+                <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">{v.color}</p>
+                <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">{v.customer_name}</p>
                 <div className="mt-3 flex flex-wrap gap-2">
                   <Link href={`/office/vehicles/view/${v.id}`} className="button px-4 text-sm">
                     View


### PR DESCRIPTION
## Summary
- keep item text legible in dark theme

## Testing
- `npm test` *(fails: cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685f439ca7c4832a9427b2b9440c0d95