### PR TITLE
Add engineers management

### DIFF
--- a/__tests__/engineers-api.test.js
+++ b/__tests__/engineers-api.test.js
@@ -1,0 +1,154 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// GET /engineers success
+
+test('engineers index returns list of engineers', async () => {
+  const engineers = [{ id: 1, username: 'Bob' }];
+  const getAllMock = jest.fn().mockResolvedValue(engineers);
+  jest.unstable_mockModule('../services/engineersService.js', () => ({
+    getAllEngineers: getAllMock,
+    createEngineer: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/engineers/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(engineers);
+  expect(getAllMock).toHaveBeenCalledTimes(1);
+});
+
+test('engineers index creates engineer', async () => {
+  const newEngineer = { id: 2, username: 'Sam' };
+  const createMock = jest.fn().mockResolvedValue(newEngineer);
+  jest.unstable_mockModule('../services/engineersService.js', () => ({
+    getAllEngineers: jest.fn(),
+    createEngineer: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/engineers/index.js');
+  const req = { method: 'POST', body: { username: 'Sam' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(newEngineer);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+});
+
+test('engineers index rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/engineersService.js', () => ({
+    getAllEngineers: jest.fn(),
+    createEngineer: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/engineers/index.js');
+  const req = { method: 'PUT', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','POST']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method PUT Not Allowed');
+});
+
+test('engineers index handles errors', async () => {
+  const error = new Error('db fail');
+  const getAllMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/engineersService.js', () => ({
+    getAllEngineers: getAllMock,
+    createEngineer: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/engineers/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+
+test('engineer detail returns engineer by id', async () => {
+  const engineer = { id: 1, username: 'Eve' };
+  const getMock = jest.fn().mockResolvedValue(engineer);
+  jest.unstable_mockModule('../services/engineersService.js', () => ({
+    getEngineerById: getMock,
+    updateEngineer: jest.fn(),
+    deleteEngineer: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/engineers/[id].js');
+  const req = { method: 'GET', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(engineer);
+  expect(getMock).toHaveBeenCalledWith('1');
+});
+
+test('engineer update returns updated data', async () => {
+  const updated = { ok: true };
+  const updateMock = jest.fn().mockResolvedValue(updated);
+  jest.unstable_mockModule('../services/engineersService.js', () => ({
+    getEngineerById: jest.fn(),
+    updateEngineer: updateMock,
+    deleteEngineer: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/engineers/[id].js');
+  const req = { method: 'PUT', query: { id: '2' }, body: { username: 'Jim' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(updated);
+  expect(updateMock).toHaveBeenCalledWith('2', req.body);
+});
+
+test('engineer delete succeeds', async () => {
+  const deleteMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/engineersService.js', () => ({
+    getEngineerById: jest.fn(),
+    updateEngineer: jest.fn(),
+    deleteEngineer: deleteMock,
+  }));
+  const { default: handler } = await import('../pages/api/engineers/[id].js');
+  const req = { method: 'DELETE', query: { id: '3' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(204);
+  expect(res.end).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalledWith('3');
+});
+
+test('engineer detail rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/engineersService.js', () => ({
+    getEngineerById: jest.fn(),
+    updateEngineer: jest.fn(),
+    deleteEngineer: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/engineers/[id].js');
+  const req = { method: 'POST', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','PUT','DELETE']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('engineer detail handles errors', async () => {
+  const error = new Error('fail');
+  const getMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/engineersService.js', () => ({
+    getEngineerById: getMock,
+    updateEngineer: jest.fn(),
+    deleteEngineer: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/engineers/[id].js');
+  const req = { method: 'GET', query: { id: '4' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});

--- a/lib/engineers.js
+++ b/lib/engineers.js
@@ -1,0 +1,5 @@
+export async function fetchEngineers() {
+  const res = await fetch('/api/engineers');
+  if (!res.ok) throw new Error('Failed to fetch engineers');
+  return res.json();
+}

--- a/migrations/20250810_add_engineer_role.sql
+++ b/migrations/20250810_add_engineer_role.sql
@@ -1,0 +1,3 @@
+INSERT INTO roles (name)
+  SELECT 'engineer'
+  WHERE NOT EXISTS (SELECT 1 FROM roles WHERE name='engineer');

--- a/pages/api/auth/login.js
+++ b/pages/api/auth/login.js
@@ -2,10 +2,11 @@ import pool from '../../../lib/db';
 import { verifyPassword, signToken } from '../../../lib/auth';
 
 export default async function handler(req, res) {
-  const { email, password } = req.body;
+  const { identifier, email, username, password } = req.body;
+  const ident = identifier || email || username;
   const [rows] = await pool.query(
-    'SELECT id, password_hash FROM users WHERE email=?',
-    [email]
+    'SELECT id, password_hash FROM users WHERE email=? OR username=?',
+    [ident, ident]
   );
   if (!rows.length || !(await verifyPassword(password, rows[0].password_hash))) {
     return res.status(401).json({ error: 'Invalid credentials' });

--- a/pages/api/engineers/[id].js
+++ b/pages/api/engineers/[id].js
@@ -1,0 +1,24 @@
+import { getEngineerById, updateEngineer, deleteEngineer } from '../../../services/engineersService.js';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const engineer = await getEngineerById(id);
+      return res.status(200).json(engineer);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateEngineer(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await deleteEngineer(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/engineers/index.js
+++ b/pages/api/engineers/index.js
@@ -1,0 +1,19 @@
+import { getAllEngineers, createEngineer } from '../../../services/engineersService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const engineers = await getAllEngineers();
+      return res.status(200).json(engineers);
+    }
+    if (req.method === 'POST') {
+      const newEngineer = await createEngineer(req.body);
+      return res.status(201).json(newEngineer);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 export default function Login() {
   const router = useRouter();
   const [theme, setTheme] = useState('light');
-  const [email, setEmail] = useState('');
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -33,7 +33,7 @@ export default function Login() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ identifier, password }),
       });
        if (!res.ok) {
          let errMsg = 'Login failed';
@@ -82,11 +82,11 @@ export default function Login() {
           {error && <div className="text-red-500 mb-4">{error}</div>}
           <form onSubmit={handleSubmit} className="space-y-4">
             <input
-              type="email"
-              placeholder="Email"
+              type="text"
+              placeholder="Email or Username"
               className="input w-full"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
               required
             />
             <input

--- a/pages/office/engineers/[id].js
+++ b/pages/office/engineers/[id].js
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Layout } from '../../../components/Layout';
+
+const EditEngineerPage = () => {
+  const { id } = useRouter().query;
+  const [form, setForm] = useState({ username: '', email: '' });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/engineers/${id}`)
+      .then(r => r.json())
+      .then(data => setForm(data))
+      .catch(() => setError('Failed to load'))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`/api/engineers/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error();
+      router.push('/office/engineers');
+    } catch {
+      setError('Failed to update');
+    }
+  };
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  if (loading) return <Layout><p>Loading…</p></Layout>;
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Edit Engineer</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        {['username', 'email'].map(field => (
+          <div key={field}>
+            <label className="block mb-1">
+              {field.charAt(0).toUpperCase() + field.slice(1)}
+            </label>
+            <input
+              name={field}
+              value={form[field] || ''}
+              onChange={change}
+              className="w-full border px-3 py-2 rounded text-black"
+              required={field === 'username'}
+            />
+          </div>
+        ))}
+        <div>
+          <label className="block mb-1">New Password</label>
+          <input
+            type="password"
+            name="password"
+            onChange={change}
+            className="w-full border px-3 py-2 rounded text-black"
+          />
+        </div>
+        <button type="submit" className="button">Update</button>
+      </form>
+    </Layout>
+  );
+};
+
+export default EditEngineerPage;

--- a/pages/office/engineers/index.js
+++ b/pages/office/engineers/index.js
@@ -1,11 +1,90 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Layout } from '../../../components/Layout';
+import { fetchEngineers } from '../../../lib/engineers';
 
-const EngineersPage = () => (
-  <Layout>
-    <h1 className="text-xl font-semibold">Engineers</h1>
-    {/* TODO: Show engineer profiles */}
-  </Layout>
-);
+const EngineersPage = () => {
+  const [engineers, setEngineers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const load = () => {
+    setLoading(true);
+    fetchEngineers()
+      .then(setEngineers)
+      .catch(() => setError('Failed to load engineers'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const handleDelete = async id => {
+    if (!confirm('Delete this engineer?')) return;
+    await fetch(`/api/engineers/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  const filtered = engineers.filter(e => {
+    const q = searchQuery.toLowerCase();
+    return (
+      e.username.toLowerCase().includes(q) ||
+      (e.email || '').toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <Layout>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-semibold">Engineers</h1>
+        <Link href="/office/engineers/new" className="button">
+          + New Engineer
+        </Link>
+      </div>
+      <Link href="/office" className="button inline-block mb-4">
+        Return to Office
+      </Link>
+      {loading && <p>Loading…</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      {!loading && !error && (
+        <>
+          <input
+            type="text"
+            placeholder="Search…"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            className="input mb-4 w-full"
+          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            {filtered.map(e => (
+              <div key={e.id} className="item-card">
+                <h2 className="font-semibold text-[var(--color-text-primary)] dark:text-black text-lg mb-1">
+                  {e.username}
+                </h2>
+                <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">
+                  {e.email || '—'}
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Link href={`/office/engineers/view/${e.id}`} className="button px-4 text-sm">
+                    View
+                  </Link>
+                  <Link href={`/office/engineers/${e.id}`} className="button px-4 text-sm">
+                    Edit
+                  </Link>
+                  <button
+                    onClick={() => handleDelete(e.id)}
+                    className="button px-4 text-sm bg-red-600 hover:bg-red-700"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </Layout>
+  );
+};
 
 export default EngineersPage;

--- a/pages/office/engineers/new.js
+++ b/pages/office/engineers/new.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Layout } from '../../../components/Layout';
+
+const NewEngineerPage = () => {
+  const [form, setForm] = useState({ username: '', email: '', password: '' });
+  const [error, setError] = useState(null);
+  const router = useRouter();
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/engineers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error();
+      router.push('/office/engineers');
+    } catch {
+      setError('Failed to create engineer');
+    }
+  };
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">New Engineer</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        {['username', 'email', 'password'].map(field => (
+          <div key={field}>
+            <label className="block mb-1">
+              {field.charAt(0).toUpperCase() + field.slice(1)}
+            </label>
+            <input
+              type={field === 'password' ? 'password' : 'text'}
+              name={field}
+              value={form[field]}
+              onChange={change}
+              className="w-full border px-3 py-2 rounded text-black"
+              {...(field === 'password' ? { required: true } : { required: field === 'username' })}
+            />
+          </div>
+        ))}
+        <button type="submit" className="button">Save</button>
+      </form>
+    </Layout>
+  );
+};
+
+export default NewEngineerPage;

--- a/pages/office/engineers/view/[id].js
+++ b/pages/office/engineers/view/[id].js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { Layout } from '../../../../components/Layout';
+import { Card } from '../../../../components/Card';
+
+export default function EngineerViewPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [engineer, setEngineer] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    async function load() {
+      try {
+        const res = await fetch(`/api/engineers/${id}`);
+        if (!res.ok) throw new Error();
+        const data = await res.json();
+        setEngineer(data);
+      } catch {
+        setError('Failed to load');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id]);
+
+  const deleteEngineer = async () => {
+    if (!confirm('Delete this engineer?')) return;
+    await fetch(`/api/engineers/${id}`, { method: 'DELETE' });
+    router.push('/office/engineers');
+  };
+
+  if (loading) return <Layout><p>Loading…</p></Layout>;
+  if (error) return <Layout><p className="text-red-500">{error}</p></Layout>;
+
+  return (
+    <Layout>
+      <div className="mb-6 flex flex-wrap items-center gap-4">
+        <Link href={`/office/engineers/${id}`} className="button">Edit Engineer</Link>
+        <button onClick={deleteEngineer} className="button bg-red-600 hover:bg-red-700">Delete Engineer</button>
+        <Link href="/office/engineers" className="button">Back to Engineers</Link>
+      </div>
+      <Card>
+        <h2 className="text-xl font-semibold mb-4">Engineer Info</h2>
+        <p><strong>Username:</strong> {engineer.username}</p>
+        <p><strong>Email:</strong> {engineer.email || '—'}</p>
+      </Card>
+    </Layout>
+  );
+}

--- a/services/engineersService.js
+++ b/services/engineersService.js
@@ -1,0 +1,85 @@
+import pool from '../lib/db.js';
+import { hashPassword } from '../lib/auth.js';
+
+export async function getAllEngineers() {
+  const [rows] = await pool.query(
+    `SELECT u.id, u.username, u.email
+       FROM users u
+       JOIN user_roles ur ON u.id = ur.user_id
+       JOIN roles r ON ur.role_id = r.id
+      WHERE r.name = 'engineer'
+   ORDER BY u.username`
+  );
+  return rows;
+}
+
+export async function getEngineerById(id) {
+  const [[row]] = await pool.query(
+    `SELECT u.id, u.username, u.email
+       FROM users u
+       JOIN user_roles ur ON u.id = ur.user_id
+       JOIN roles r ON ur.role_id = r.id
+      WHERE r.name = 'engineer' AND u.id=?`,
+    [id]
+  );
+  return row || null;
+}
+
+export async function createEngineer({ username, email, password }) {
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    const hashed = await hashPassword(password);
+    const [{ insertId }] = await conn.query(
+      'INSERT INTO users (username, email, password_hash) VALUES (?, ?, ?)',
+      [username, email || null, hashed]
+    );
+    const [[roleRow]] = await conn.query(
+      'SELECT id FROM roles WHERE name = ?',
+      ['engineer']
+    );
+    if (roleRow) {
+      await conn.query(
+        'INSERT INTO user_roles (user_id, role_id) VALUES (?, ?)',
+        [insertId, roleRow.id]
+      );
+    }
+    await conn.commit();
+    return { id: insertId, username, email: email || null };
+  } catch (err) {
+    await conn.rollback();
+    throw err;
+  } finally {
+    conn.release();
+  }
+}
+
+export async function updateEngineer(id, { username, email, password }) {
+  let sql = 'UPDATE users SET username=?, email=?';
+  const params = [username, email || null];
+  if (password) {
+    sql += ', password_hash=?';
+    const hashed = await hashPassword(password);
+    params.push(hashed);
+  }
+  sql += ' WHERE id=?';
+  params.push(id);
+  await pool.query(sql, params);
+  return { ok: true };
+}
+
+export async function deleteEngineer(id) {
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    await conn.query('DELETE FROM user_roles WHERE user_id=?', [id]);
+    await conn.query('DELETE FROM users WHERE id=?', [id]);
+    await conn.commit();
+    return { ok: true };
+  } catch (err) {
+    await conn.rollback();
+    throw err;
+  } finally {
+    conn.release();
+  }
+}


### PR DESCRIPTION
## Summary
- allow login using username or email
- add engineer role migration
- implement engineers API backed by users table
- add React hooks and pages to manage engineers
- include tests for the new API endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860474bb0a0832a97ff026e7f4f5fcc