### PR TITLE
Add company settings migration

### DIFF
--- a/migrations/20250901_create_company_settings.sql
+++ b/migrations/20250901_create_company_settings.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS company_settings (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  logo_url VARCHAR(255),
+  company_name VARCHAR(255),
+  address TEXT,
+  phone VARCHAR(50),
+  website VARCHAR(255),
+  social_links JSON,
+  terms TEXT
+);


### PR DESCRIPTION
## Summary
- add SQL migration for `company_settings`
- run migrations (fails without DB)

## Testing
- `npm run migrate` *(fails: ECONNREFUSED)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68604ff43aa0832abda2bd5095a9b52c