### PR TITLE
Implement company settings endpoint

### DIFF
--- a/pages/api/company-settings/index.js
+++ b/pages/api/company-settings/index.js
@@ -1,0 +1,19 @@
+import { getSettings, updateSettings } from '../../../services/companySettingsService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const settings = await getSettings();
+      return res.status(200).json(settings);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateSettings(req.body);
+      return res.status(200).json(updated);
+    }
+    res.setHeader('Allow', ['GET','PUT']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/services/companySettingsService.js
+++ b/services/companySettingsService.js
@@ -1,0 +1,52 @@
+import pool from '../lib/db.js';
+
+export async function getSettings() {
+  const [[row]] = await pool.query(
+    `SELECT id, logo_url, company_name, address, phone, website, social_links, terms
+       FROM company_settings ORDER BY id LIMIT 1`
+  );
+  return row || null;
+}
+
+export async function updateSettings({
+  logo_url,
+  company_name,
+  address,
+  phone,
+  website,
+  social_links,
+  terms,
+}) {
+  const current = await getSettings();
+  if (current) {
+    await pool.query(
+      `UPDATE company_settings SET logo_url=?, company_name=?, address=?, phone=?, website=?, social_links=?, terms=? WHERE id=?`,
+      [logo_url || null, company_name || null, address || null, phone || null, website || null, social_links || null, terms || null, current.id]
+    );
+    return {
+      id: current.id,
+      logo_url,
+      company_name,
+      address,
+      phone,
+      website,
+      social_links,
+      terms,
+    };
+  }
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO company_settings (logo_url, company_name, address, phone, website, social_links, terms)
+     VALUES (?,?,?,?,?,?,?)`,
+    [logo_url || null, company_name || null, address || null, phone || null, website || null, social_links || null, terms || null]
+  );
+  return {
+    id: insertId,
+    logo_url,
+    company_name,
+    address,
+    phone,
+    website,
+    social_links,
+    terms,
+  };
+}


### PR DESCRIPTION
## Summary
- add service for company settings
- expose `/api/company-settings` endpoint to fetch/update settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686052552198832a863f882c367760c0