### PR TITLE
Add service modules for jobs and tracking

### DIFF
--- a/services/holidayRequestsService.js
+++ b/services/holidayRequestsService.js
@@ -1,0 +1,24 @@
+import pool from '../lib/db.js';
+
+export async function listRequests(employee_id) {
+  const [rows] = employee_id
+    ? await pool.query(
+        `SELECT id, employee_id, start_date, end_date, status, created_ts
+           FROM holiday_requests WHERE employee_id=? ORDER BY id`,
+        [employee_id]
+      )
+    : await pool.query(
+        `SELECT id, employee_id, start_date, end_date, status, created_ts
+           FROM holiday_requests ORDER BY id`
+      );
+  return rows;
+}
+
+export async function submitRequest({ employee_id, start_date, end_date, status }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO holiday_requests (employee_id, start_date, end_date, status)
+     VALUES (?,?,?,?)`,
+    [employee_id || null, start_date || null, end_date || null, status || 'pending']
+  );
+  return { id: insertId, employee_id, start_date, end_date, status: status || 'pending' };
+}

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -1,0 +1,61 @@
+import pool from '../lib/db.js';
+
+export async function getAllJobs() {
+  const [rows] = await pool.query(
+    `SELECT id, customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay, created_at
+       FROM jobs ORDER BY id`
+  );
+  return rows;
+}
+
+export async function getJobById(id) {
+  const [[row]] = await pool.query(
+    `SELECT id, customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay, created_at
+       FROM jobs WHERE id=?`,
+    [id]
+  );
+  return row || null;
+}
+
+export async function createJob({ customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO jobs (customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay)
+     VALUES (?,?,?,?,?,?)`,
+    [customer_id || null, vehicle_id || null, scheduled_start || null, scheduled_end || null, status || null, bay || null]
+  );
+  return { id: insertId, customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay };
+}
+
+export async function updateJob(id, { customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay }) {
+  await pool.query(
+    `UPDATE jobs SET customer_id=?, vehicle_id=?, scheduled_start=?, scheduled_end=?, status=?, bay=? WHERE id=?`,
+    [customer_id || null, vehicle_id || null, scheduled_start || null, scheduled_end || null, status || null, bay || null, id]
+  );
+  return { ok: true };
+}
+
+export async function deleteJob(id) {
+  await pool.query('DELETE FROM jobs WHERE id=?', [id]);
+  return { ok: true };
+}
+
+export async function getAssignments(job_id) {
+  const [rows] = await pool.query(
+    `SELECT id, job_id, user_id, assigned_at FROM job_assignments WHERE job_id=? ORDER BY id`,
+    [job_id]
+  );
+  return rows;
+}
+
+export async function assignUser(job_id, user_id) {
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO job_assignments (job_id, user_id) VALUES (?, ?)',
+    [job_id, user_id]
+  );
+  return { id: insertId, job_id, user_id };
+}
+
+export async function removeAssignment(id) {
+  await pool.query('DELETE FROM job_assignments WHERE id=?', [id]);
+  return { ok: true };
+}

--- a/services/timeEntriesService.js
+++ b/services/timeEntriesService.js
@@ -1,0 +1,37 @@
+import pool from '../lib/db.js';
+
+export async function listTimeEntries(job_id) {
+  const [rows] = job_id
+    ? await pool.query(
+        `SELECT id, job_id, user_id, start_ts, end_ts, duration FROM time_entries WHERE job_id=? ORDER BY id`,
+        [job_id]
+      )
+    : await pool.query(
+        `SELECT id, job_id, user_id, start_ts, end_ts, duration FROM time_entries ORDER BY id`
+      );
+  return rows;
+}
+
+export async function clockIn(job_id, user_id) {
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO time_entries (job_id, user_id, start_ts) VALUES (?, ?, NOW())',
+    [job_id, user_id]
+  );
+  const [[row]] = await pool.query(
+    'SELECT id, job_id, user_id, start_ts, end_ts, duration FROM time_entries WHERE id=?',
+    [insertId]
+  );
+  return row;
+}
+
+export async function clockOut(entry_id) {
+  await pool.query(
+    `UPDATE time_entries SET end_ts=NOW(), duration=TIMEDIFF(NOW(), start_ts) WHERE id=? AND end_ts IS NULL`,
+    [entry_id]
+  );
+  const [[row]] = await pool.query(
+    'SELECT id, job_id, user_id, start_ts, end_ts, duration FROM time_entries WHERE id=?',
+    [entry_id]
+  );
+  return row || null;
+}


### PR DESCRIPTION
## Summary
- create `jobsService.js` for jobs CRUD and assignments
- create `timeEntriesService.js` to clock in/out and list entries
- create `holidayRequestsService.js` to manage employee holiday requests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68605aa4da4c832aafc9a569072b25d4