### PR TITLE
Implement engineer API endpoints

### DIFF
--- a/__tests__/engineer-features.test.js
+++ b/__tests__/engineer-features.test.js
@@ -1,0 +1,72 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('engineer jobs returns active jobs', async () => {
+  const jobs = [{ id: 1 }];
+  const listMock = jest.fn().mockResolvedValue(jobs);
+  jest.unstable_mockModule('../services/jobsService.js', () => ({
+    listActiveJobsForEngineer: listMock,
+  }));
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn().mockResolvedValueOnce([[{ name: 'engineer' }]]) },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 1 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/jobs/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(listMock).toHaveBeenCalledWith(1);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(jobs);
+});
+
+test('time entries clock in creates entry', async () => {
+  const entry = { id: 2 };
+  const clockInMock = jest.fn().mockResolvedValue(entry);
+  jest.unstable_mockModule('../services/timeEntriesService.js', () => ({
+    clockIn: clockInMock,
+    clockOut: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn().mockResolvedValue([[{ name: 'engineer' }]]) },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 2 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/time-entries/index.js');
+  const req = { method: 'POST', query: { action: 'clock-in' }, body: { job_id: 5 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(clockInMock).toHaveBeenCalledWith(5, 2);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(entry);
+});
+
+test('holiday requests list own entries', async () => {
+  const rows = [{ id: 3 }];
+  const listMock = jest.fn().mockResolvedValue(rows);
+  jest.unstable_mockModule('../services/holidayRequestsService.js', () => ({
+    listRequests: listMock,
+    submitRequest: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn().mockResolvedValue([[{ name: 'engineer' }]]) },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 3 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/holiday-requests/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(listMock).toHaveBeenCalledWith(3);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(rows);
+});
+

--- a/pages/api/engineer/holiday-requests/index.js
+++ b/pages/api/engineer/holiday-requests/index.js
@@ -1,0 +1,39 @@
+import pool from '../../../../lib/db';
+import { getTokenFromReq } from '../../../../lib/auth';
+import { listRequests, submitRequest } from '../../../../services/holidayRequestsService.js';
+
+export default async function handler(req, res) {
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const [[roleRow]] = await pool.query(
+    `SELECT r.name FROM user_roles ur
+       JOIN roles r ON ur.role_id = r.id
+     WHERE ur.user_id = ?`,
+    [t.sub]
+  );
+  if (!roleRow || roleRow.name !== 'engineer') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  try {
+    if (req.method === 'GET') {
+      const requests = await listRequests(t.sub);
+      return res.status(200).json(requests);
+    }
+    if (req.method === 'POST') {
+      const { start_date, end_date, status } = req.body;
+      const created = await submitRequest({
+        employee_id: t.sub,
+        start_date,
+        end_date,
+        status,
+      });
+      return res.status(201).json(created);
+    }
+    res.setHeader('Allow', ['GET', 'POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/engineer/jobs/index.js
+++ b/pages/api/engineer/jobs/index.js
@@ -1,0 +1,29 @@
+import pool from '../../../../lib/db';
+import { getTokenFromReq } from '../../../../lib/auth';
+import { listActiveJobsForEngineer } from '../../../../services/jobsService.js';
+
+export default async function handler(req, res) {
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const [[roleRow]] = await pool.query(
+    `SELECT r.name FROM user_roles ur
+       JOIN roles r ON ur.role_id = r.id
+     WHERE ur.user_id = ?`,
+    [t.sub]
+  );
+  if (!roleRow || roleRow.name !== 'engineer') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  try {
+    if (req.method === 'GET') {
+      const jobs = await listActiveJobsForEngineer(t.sub);
+      return res.status(200).json(jobs);
+    }
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/engineer/time-entries/index.js
+++ b/pages/api/engineer/time-entries/index.js
@@ -1,0 +1,43 @@
+import pool from '../../../../lib/db';
+import { getTokenFromReq } from '../../../../lib/auth';
+import { clockIn, clockOut } from '../../../../services/timeEntriesService.js';
+
+export default async function handler(req, res) {
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const [[roleRow]] = await pool.query(
+    `SELECT r.name FROM user_roles ur
+       JOIN roles r ON ur.role_id = r.id
+     WHERE ur.user_id = ?`,
+    [t.sub]
+  );
+  if (!roleRow || roleRow.name !== 'engineer') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const action = req.query.action;
+  try {
+    if (action === 'clock-in') {
+      const { job_id } = req.body;
+      if (!job_id) return res.status(400).json({ error: 'job_id required' });
+      const entry = await clockIn(job_id, t.sub);
+      return res.status(201).json(entry);
+    }
+    if (action === 'clock-out') {
+      const { entry_id } = req.body;
+      if (!entry_id) return res.status(400).json({ error: 'entry_id required' });
+      const entry = await clockOut(entry_id);
+      if (!entry) return res.status(404).json({ error: 'Not found' });
+      return res.status(200).json(entry);
+    }
+    return res.status(400).json({ error: 'Invalid action' });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -59,3 +59,16 @@ export async function removeAssignment(id) {
   await pool.query('DELETE FROM job_assignments WHERE id=?', [id]);
   return { ok: true };
 }
+
+export async function listActiveJobsForEngineer(user_id) {
+  const [rows] = await pool.query(
+    `SELECT j.id, j.customer_id, j.vehicle_id, j.scheduled_start, j.scheduled_end,
+            j.status, j.bay, j.created_at
+       FROM jobs j
+       JOIN job_assignments ja ON j.id = ja.job_id
+      WHERE ja.user_id=? AND j.status='active'
+      ORDER BY j.id`,
+    [user_id]
+  );
+  return rows;
+}


### PR DESCRIPTION
## Summary
- allow engineers to list their active jobs
- add clock in/out API using time entries service
- add holiday request API for engineers
- include unit tests for new endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68605bbc7354832a866ef2a5a7b53f0b