### PR TITLE
Add engineer portal pages

### DIFF
--- a/pages/engineer/index.js
+++ b/pages/engineer/index.js
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { Layout } from '../../components/Layout';
+import { Card } from '../../components/Card';
+
+export default function EngineerHome() {
+  const [jobs, setJobs] = useState([]);
+  const [selectedJob, setSelectedJob] = useState('');
+  const [entry, setEntry] = useState(null);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const r = await fetch('/api/engineer/jobs', { credentials: 'include' });
+        if (!r.ok) throw new Error('Failed to load jobs');
+        const data = await r.json();
+        setJobs(Array.isArray(data) ? data : []);
+        if (data.length) setSelectedJob(data[0].id);
+      } catch (err) {
+        setError(err.message);
+      }
+    }
+    load();
+  }, []);
+
+  async function clockIn() {
+    if (!selectedJob) return;
+    try {
+      const r = await fetch('/api/engineer/time-entries?action=clock-in', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ job_id: selectedJob }),
+      });
+      if (r.ok) {
+        const e = await r.json();
+        setEntry(e);
+        setMessage('Clocked in');
+      }
+    } catch {
+      setMessage('Clock in failed');
+    }
+  }
+
+  async function clockOut() {
+    if (!entry) return;
+    try {
+      const r = await fetch('/api/engineer/time-entries?action=clock-out', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ entry_id: entry.id }),
+      });
+      if (r.ok) {
+        await r.json();
+        setEntry(null);
+        setMessage('Clocked out');
+      }
+    } catch {
+      setMessage('Clock out failed');
+    }
+  }
+
+  async function requestHoliday() {
+    const start = prompt('Start date (YYYY-MM-DD)');
+    const end = start ? prompt('End date (YYYY-MM-DD)') : null;
+    if (!start || !end) return;
+    try {
+      await fetch('/api/engineer/holiday-requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ start_date: start, end_date: end }),
+      });
+      setMessage('Holiday request submitted');
+    } catch {
+      setMessage('Request failed');
+    }
+  }
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Engineer Portal</h1>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
+      <Card className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Allocated Jobs</h2>
+        {!jobs.length ? (
+          <p>No jobs assigned.</p>
+        ) : (
+          <div>
+            <select
+              className="input mb-4 w-full text-black dark:text-white"
+              value={selectedJob}
+              onChange={(e) => setSelectedJob(Number(e.target.value))}
+            >
+              {jobs.map((j) => (
+                <option key={j.id} value={j.id}>
+                  Job #{j.id}
+                </option>
+              ))}
+            </select>
+            <ul className="list-disc pl-5 space-y-1">
+              {jobs.map((j) => (
+                <li key={j.id}>Job #{j.id}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </Card>
+      {message && <p className="mb-4 text-green-500">{message}</p>}
+      <div className="flex space-x-4 action-buttons">
+        <button onClick={clockIn}>Clock In</button>
+        <button onClick={clockOut}>Clock Out</button>
+        <button onClick={requestHoliday}>Request Holiday</button>
+      </div>
+    </Layout>
+  );
+}

--- a/pages/engineer/wiki.js
+++ b/pages/engineer/wiki.js
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { Layout } from '../../components/Layout';
+import { Card } from '../../components/Card';
+
+function daysInMonth(year, month) {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+export default function EngineerWiki() {
+  const [jobs, setJobs] = useState([]);
+  const [requests, setRequests] = useState([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [jRes, hRes] = await Promise.all([
+          fetch('/api/engineer/jobs', { credentials: 'include' }),
+          fetch('/api/engineer/holiday-requests', { credentials: 'include' }),
+        ]);
+        if (!jRes.ok || !hRes.ok) throw new Error('Failed to load data');
+        const jData = await jRes.json();
+        const hData = await hRes.json();
+        setJobs(Array.isArray(jData) ? jData : []);
+        setRequests(Array.isArray(hData) ? hData : []);
+      } catch (err) {
+        setError(err.message);
+      }
+    }
+    load();
+  }, []);
+
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const numDays = daysInMonth(year, month);
+  const days = Array.from({ length: numDays }, (_, i) => new Date(year, month, i + 1));
+
+  function isHoliday(date) {
+    return requests.some((r) => {
+      const s = new Date(r.start_date);
+      const e = new Date(r.end_date);
+      return date >= s && date <= e;
+    });
+  }
+
+  function jobsForDay(date) {
+    return jobs.filter((j) => {
+      if (!j.scheduled_start) return false;
+      const d = new Date(j.scheduled_start);
+      return d.toDateString() === date.toDateString();
+    });
+  }
+
+  const daysTaken = requests.reduce((acc, r) => {
+    const s = new Date(r.start_date);
+    const e = new Date(r.end_date);
+    const diff = Math.round((e - s) / 86400000) + 1;
+    return acc + diff;
+  }, 0);
+  const remaining = 20 - daysTaken;
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Engineer Wiki</h1>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
+      <Card className="mb-6">Holiday allowance remaining: {remaining} days</Card>
+      <div className="grid grid-cols-7 gap-2 text-sm">
+        {days.map((d) => (
+          <Card key={d.toISOString()} className="p-2">
+            <div className="font-semibold mb-1">{d.getDate()}</div>
+            {isHoliday(d) ? (
+              <div className="text-red-500">Holiday</div>
+            ) : (
+              jobsForDay(d).map((j) => (
+                <div key={j.id}>Job #{j.id}</div>
+              ))
+            )}
+          </Card>
+        ))}
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- create `pages/engineer/` directory with a dashboard and wiki
- engineer dashboard lists allocated jobs and offers clock in/out and holiday buttons
- wiki page renders a simple monthly calendar with holiday allowance and job info

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68605d4a8ea0832aa02f0b3aa8423350