### PR TITLE
Add engineer links to sidebar

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -48,7 +48,21 @@ export function Sidebar() {
         >
           Garage Vision
         </a>
-        {userRole === "developer" && (
+        {userRole === "engineer" && (
+          <>
+            <a
+              href="/engineer"
+              className="bg-red-800 text-white font-bold rounded-full px-4 py-2 shadow hover:bg-red-900 block text-center w-full"
+              onClick={() => setOpen(false)}
+            >
+              Engineer Portal
+            </a>
+            <a href="/engineer/wiki" {...linkProps}>
+              Wiki
+            </a>
+          </>
+        )}
+        {(userRole === "developer" || userRole === "admin") && (
           <>
             <a
               href="/dev"
@@ -57,16 +71,10 @@ export function Sidebar() {
             >
               Dev Portal
             </a>
-            <a
-              href="/dev/projects"
-              {...linkProps}
-            >
+            <a href="/dev/projects" {...linkProps}>
               Projects
             </a>
-            <a
-              href="/dev/dashboard"
-              {...linkProps}
-            >
+            <a href="/dev/dashboard" {...linkProps}>
               Dashboard
             </a>
             <a href="/office" {...linkProps}>


### PR DESCRIPTION
## Summary
- support engineer role in `Sidebar`
- show Engineer Portal and Wiki links
- restrict dev/admin links to non-engineer roles

## Testing
- `npm run lint` *(fails: @next/next/no-html-link-for-pages error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68605e438808832aa10a43e135cfb8dc