### PR TITLE
Implement engineer redirect on login

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -47,13 +47,17 @@ export default function Login() {
      }
      
       // Fetch user info to determine role, then route accordingly
-      const meRes = await fetch('/api/auth/me', { credentials: 'include' });
-      if (meRes.ok) {
-        await meRes.json();
-        router.push('/');
-      } else {
-        router.push('/');
+      let dest = '/';
+      try {
+        const meRes = await fetch('/api/auth/me', { credentials: 'include' });
+        if (meRes.ok) {
+          const me = await meRes.json();
+          if (me && me.role === 'engineer') dest = '/engineer';
+        }
+      } catch {
+        /* ignore fetch errors and fallback to default */
       }
+      router.push(dest);
     } catch (err) {
       setError(err.message);
     } finally {


### PR DESCRIPTION
## Summary
- fetch `/api/auth/me` after logging in
- if the user role is engineer then redirect to `/engineer`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68605f39a3a4832a955c7d4c1371f994