### PR TITLE
Add tests for engineer APIs

### DIFF
--- a/__tests__/engineer-holiday-requests-api.test.js
+++ b/__tests__/engineer-holiday-requests-api.test.js
@@ -1,0 +1,148 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// GET success
+
+test('holiday requests list own requests', async () => {
+  const rows = [{ id: 1 }];
+  const listMock = jest.fn().mockResolvedValue(rows);
+  jest.unstable_mockModule('../services/holidayRequestsService.js', () => ({
+    listRequests: listMock,
+    submitRequest: jest.fn(),
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 1 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/holiday-requests/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(listMock).toHaveBeenCalledWith(1);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(rows);
+});
+
+// POST success
+
+test('holiday requests submit creates request', async () => {
+  const created = { id: 2 };
+  const submitMock = jest.fn().mockResolvedValue(created);
+  jest.unstable_mockModule('../services/holidayRequestsService.js', () => ({
+    listRequests: jest.fn(),
+    submitRequest: submitMock,
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 2 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/holiday-requests/index.js');
+  const req = { method: 'POST', body: { start_date: '2024-01-01', end_date: '2024-01-05', status: 'pending' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(submitMock).toHaveBeenCalledWith({
+    employee_id: 2,
+    start_date: '2024-01-01',
+    end_date: '2024-01-05',
+    status: 'pending',
+  });
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(created);
+});
+
+// authentication and role checks
+
+test('holiday requests returns 401 when unauthenticated', async () => {
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn() },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => null,
+  }));
+  const { default: handler } = await import('../pages/api/engineer/holiday-requests/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(401);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+});
+
+test('holiday requests returns 403 for non-engineer role', async () => {
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'user' }]]);
+  jest.unstable_mockModule('../services/holidayRequestsService.js', () => ({
+    listRequests: jest.fn(),
+    submitRequest: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 3 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/holiday-requests/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+});
+
+// unsupported method
+
+test('holiday requests rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/holidayRequestsService.js', () => ({
+    listRequests: jest.fn(),
+    submitRequest: jest.fn(),
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 4 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/holiday-requests/index.js');
+  const req = { method: 'PUT', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET', 'POST']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method PUT Not Allowed');
+});
+
+// error handling
+
+test('holiday requests handles service errors', async () => {
+  const error = new Error('oops');
+  const listMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/holidayRequestsService.js', () => ({
+    listRequests: listMock,
+    submitRequest: jest.fn(),
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 5 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/holiday-requests/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+

--- a/__tests__/engineer-jobs-api.test.js
+++ b/__tests__/engineer-jobs-api.test.js
@@ -1,0 +1,115 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// GET /engineer/jobs success
+
+test('engineer jobs returns active jobs for engineer', async () => {
+  const jobs = [{ id: 1 }];
+  const listMock = jest.fn().mockResolvedValue(jobs);
+  jest.unstable_mockModule('../services/jobsService.js', () => ({
+    listActiveJobsForEngineer: listMock,
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 1 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/jobs/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(listMock).toHaveBeenCalledWith(1);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(jobs);
+});
+
+// authentication and role checks
+
+test('engineer jobs returns 401 when unauthenticated', async () => {
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn() },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => null,
+  }));
+  const { default: handler } = await import('../pages/api/engineer/jobs/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(401);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+});
+
+test('engineer jobs returns 403 for non-engineer role', async () => {
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'manager' }]]);
+  jest.unstable_mockModule('../services/jobsService.js', () => ({
+    listActiveJobsForEngineer: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 2 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/jobs/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+});
+
+// unsupported method
+
+test('engineer jobs rejects unsupported method', async () => {
+  const listMock = jest.fn();
+  jest.unstable_mockModule('../services/jobsService.js', () => ({
+    listActiveJobsForEngineer: listMock,
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 3 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/jobs/index.js');
+  const req = { method: 'POST', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+// error handling
+
+test('engineer jobs handles errors from service', async () => {
+  const error = new Error('fail');
+  const listMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/jobsService.js', () => ({
+    listActiveJobsForEngineer: listMock,
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 4 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/jobs/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+

--- a/__tests__/engineer-time-entries-api.test.js
+++ b/__tests__/engineer-time-entries-api.test.js
@@ -1,0 +1,143 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// clock-in success
+
+test('time entries clock in creates entry', async () => {
+  const entry = { id: 1 };
+  const clockInMock = jest.fn().mockResolvedValue(entry);
+  jest.unstable_mockModule('../services/timeEntriesService.js', () => ({
+    clockIn: clockInMock,
+    clockOut: jest.fn(),
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 1 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/time-entries/index.js');
+  const req = { method: 'POST', query: { action: 'clock-in' }, body: { job_id: 5 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(clockInMock).toHaveBeenCalledWith(5, 1);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(entry);
+});
+
+// clock-out success
+
+test('time entries clock out updates entry', async () => {
+  const entry = { id: 2 };
+  const clockOutMock = jest.fn().mockResolvedValue(entry);
+  jest.unstable_mockModule('../services/timeEntriesService.js', () => ({
+    clockIn: jest.fn(),
+    clockOut: clockOutMock,
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 2 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/time-entries/index.js');
+  const req = { method: 'POST', query: { action: 'clock-out' }, body: { entry_id: 7 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(clockOutMock).toHaveBeenCalledWith(7);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(entry);
+});
+
+// authentication and role checks
+
+test('time entries returns 401 when unauthenticated', async () => {
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn() },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => null,
+  }));
+  const { default: handler } = await import('../pages/api/engineer/time-entries/index.js');
+  const req = { method: 'POST', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(401);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+});
+
+test('time entries returns 403 for non-engineer role', async () => {
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'viewer' }]]);
+  jest.unstable_mockModule('../services/timeEntriesService.js', () => ({
+    clockIn: jest.fn(),
+    clockOut: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 3 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/time-entries/index.js');
+  const req = { method: 'POST', query: { action: 'clock-in' }, body: { job_id: 1 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+});
+
+// unsupported method
+
+test('time entries rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/timeEntriesService.js', () => ({
+    clockIn: jest.fn(),
+    clockOut: jest.fn(),
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 4 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/time-entries/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['POST']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method GET Not Allowed');
+});
+
+// error handling
+
+test('time entries handles service errors', async () => {
+  const error = new Error('oops');
+  const clockInMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/timeEntriesService.js', () => ({
+    clockIn: clockInMock,
+    clockOut: jest.fn(),
+  }));
+  const queryMock = jest.fn().mockResolvedValue([[{ name: 'engineer' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 5 }),
+  }));
+  const { default: handler } = await import('../pages/api/engineer/time-entries/index.js');
+  const req = { method: 'POST', query: { action: 'clock-in' }, body: { job_id: 9 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+


### PR DESCRIPTION
## Summary
- add tests covering engineer job, time entry and holiday request APIs
- verify role checks and unsupported methods
- handle service errors with mocked modules

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68605faec984832aa8d92583323b3365