### PR TITLE
Ensure card text is black in both themes

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -1,6 +1,6 @@
 export function Card({ children, className = '' }) {
   return (
-    <div className={`p-4 bg-[var(--color-surface)] rounded-2xl shadow ${className}`}>
+    <div className={`text-black dark:text-black p-4 bg-[var(--color-surface)] rounded-2xl shadow ${className}`}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- keep card text black regardless of theme by adding `text-black dark:text-black`

## Testing
- `npm test` *(fails: cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_6860677e72ac832ab7064e3e93d16af0