### PR TITLE
Update item-card text colors to text-black

### DIFF
--- a/pages/office/clients/index.js
+++ b/pages/office/clients/index.js
@@ -59,11 +59,11 @@ const ClientsPage = () => {
         <div className="grid gap-4 sm:grid-cols-2">
           {filteredClients.map(c => (
             <div key={c.id} className="item-card">
-              <h2 className="font-semibold text-[var(--color-text-primary)] dark:text-black text-lg mb-1">
+              <h2 className="font-semibold text-black text-lg mb-1">
                 {`${c.first_name || ''} ${c.last_name || ''}`.trim() || 'Unnamed'}
               </h2>
-              <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">{c.email}</p>
-              <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">{c.mobile}</p>
+              <p className="text-sm text-black">{c.email}</p>
+              <p className="text-sm text-black">{c.mobile}</p>
               <div className="mt-3 flex flex-wrap gap-2">
                 <Link href={`/office/clients/view/${c.id}`} className="button px-4 text-sm">
                   View


### PR DESCRIPTION
## Summary
- ensure client item-card headings and paragraphs always use `text-black`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686067ef2d04832a9be384626a27bce7