### PR TITLE
Update vehicle card text colors

### DIFF
--- a/pages/office/vehicles/index.js
+++ b/pages/office/vehicles/index.js
@@ -60,14 +60,14 @@ const VehiclesPage = () => {
           <div className="grid gap-4 sm:grid-cols-2">
             {filtered.map(v => (
               <div key={v.id} className="item-card">
-                <h2 className="font-semibold text-[var(--color-text-primary)] dark:text-black text-lg mb-1">
+                <h2 className="font-semibold text-black text-lg mb-1">
                   {v.licence_plate}
                 </h2>
-                <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">
+                <p className="text-sm text-black">
                   {v.make} {v.model}
                 </p>
-                <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">{v.color}</p>
-                <p className="text-sm text-[var(--color-text-secondary)] dark:text-black">{v.customer_name}</p>
+                <p className="text-sm text-black">{v.color}</p>
+                <p className="text-sm text-black">{v.customer_name}</p>
                 <div className="mt-3 flex flex-wrap gap-2">
                   <Link href={`/office/vehicles/view/${v.id}`} className="button px-4 text-sm">
                     View


### PR DESCRIPTION
## Summary
- tweak `.item-card` headings to use `text-black`
- align vehicle detail text with new color scheme

## Testing
- `npm test`
- `npm run lint` *(fails: The "path" argument must be of type string)*

------
https://chatgpt.com/codex/tasks/task_e_6860691cd404832a847480ae2ca453b2