### PR TITLE
Fix dark theme tile text color

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -1,6 +1,6 @@
 export function Card({ children, className = '' }) {
   return (
-    <div className={`text-black dark:text-black p-4 bg-[var(--color-surface)] rounded-2xl shadow ${className}`}>
+    <div className={`text-black dark:text-white p-4 bg-[var(--color-surface)] rounded-2xl shadow ${className}`}>
       {children}
     </div>
   );

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -145,16 +145,16 @@ export default function Users() {
               <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                 <thead className="bg-[var(--color-surface)] dark:bg-[var(--color-surface)]">
                   <tr>
-                    <th className="px-6 py-3 text-left text-sm font-medium text-black">
+                    <th className="px-6 py-3 text-left text-sm font-medium text-black dark:text-white">
                       Username
                     </th>
-                    <th className="px-6 py-3 text-left text-sm font-medium text-black">
+                    <th className="px-6 py-3 text-left text-sm font-medium text-black dark:text-white">
                       Email
                     </th>
-                    <th className="px-6 py-3 text-left text-sm font-medium text-black">
+                    <th className="px-6 py-3 text-left text-sm font-medium text-black dark:text-white">
                       Role
                     </th>
-                    <th className="px-6 py-3 text-left text-sm font-medium text-black">
+                    <th className="px-6 py-3 text-left text-sm font-medium text-black dark:text-white">
                       Actions
                     </th>
                   </tr>
@@ -162,10 +162,10 @@ export default function Users() {
                 <tbody className="bg-[var(--color-surface)] dark:bg-[var(--color-surface)] divide-y divide-gray-200 dark:divide-gray-700">
                   {users.map((u) => (
                     <tr key={u.id} className="hover:bg-gray-100 dark:hover:bg-gray-800 transition">
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-black">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-black dark:text-white">
                         {u.username}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-black">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-black dark:text-white">
                         {u.email}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm">

--- a/pages/dev/projects/[id].js
+++ b/pages/dev/projects/[id].js
@@ -146,10 +146,10 @@ export default function ProjectDetail() {
               {tasks.map(t => (
                 <Card key={t.id} className="group relative">
                   <Link href={`/dev/tasks/${t.id}`} className="block">
-                    <h3 className="text-xl font-semibold text-black">
+                    <h3 className="text-xl font-semibold text-black dark:text-white">
                       {t.title}
                     </h3>
-                    <p className="mt-1 text-black">
+                    <p className="mt-1 text-black dark:text-white">
                       Status: {t.status}
                     </p>
                   </Link>

--- a/pages/office/clients/index.js
+++ b/pages/office/clients/index.js
@@ -59,11 +59,11 @@ const ClientsPage = () => {
         <div className="grid gap-4 sm:grid-cols-2">
           {filteredClients.map(c => (
             <div key={c.id} className="item-card">
-              <h2 className="font-semibold text-black text-lg mb-1">
+              <h2 className="font-semibold text-black dark:text-white text-lg mb-1">
                 {`${c.first_name || ''} ${c.last_name || ''}`.trim() || 'Unnamed'}
               </h2>
-              <p className="text-sm text-black">{c.email}</p>
-              <p className="text-sm text-black">{c.mobile}</p>
+              <p className="text-sm text-black dark:text-white">{c.email}</p>
+              <p className="text-sm text-black dark:text-white">{c.mobile}</p>
               <div className="mt-3 flex flex-wrap gap-2">
                 <Link href={`/office/clients/view/${c.id}`} className="button px-4 text-sm">
                   View

--- a/pages/office/engineers/index.js
+++ b/pages/office/engineers/index.js
@@ -58,10 +58,10 @@ const EngineersPage = () => {
           <div className="grid gap-4 sm:grid-cols-2">
             {filtered.map(e => (
               <div key={e.id} className="item-card">
-                <h2 className="font-semibold text-black text-lg mb-1">
+                <h2 className="font-semibold text-black dark:text-white text-lg mb-1">
                   {e.username}
                 </h2>
-                <p className="text-sm text-black">
+                <p className="text-sm text-black dark:text-white">
                   {e.email || '—'}
                 </p>
                 <div className="mt-3 flex flex-wrap gap-2">

--- a/pages/office/vehicles/index.js
+++ b/pages/office/vehicles/index.js
@@ -60,14 +60,14 @@ const VehiclesPage = () => {
           <div className="grid gap-4 sm:grid-cols-2">
             {filtered.map(v => (
               <div key={v.id} className="item-card">
-                <h2 className="font-semibold text-black text-lg mb-1">
+                <h2 className="font-semibold text-black dark:text-white text-lg mb-1">
                   {v.licence_plate}
                 </h2>
-                <p className="text-sm text-black">
+                <p className="text-sm text-black dark:text-white">
                   {v.make} {v.model}
                 </p>
-                <p className="text-sm text-black">{v.color}</p>
-                <p className="text-sm text-black">{v.customer_name}</p>
+                <p className="text-sm text-black dark:text-white">{v.color}</p>
+                <p className="text-sm text-black dark:text-white">{v.customer_name}</p>
                 <div className="mt-3 flex flex-wrap gap-2">
                   <Link href={`/office/vehicles/view/${v.id}`} className="button px-4 text-sm">
                     View

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -39,7 +39,7 @@
 }
 
 .item-card {
-  @apply bg-gray-100 text-black rounded-2xl p-4 shadow;
+  @apply bg-gray-100 dark:bg-gray-800 text-black dark:text-white rounded-2xl p-4 shadow;
 }
 
 .action-buttons button {


### PR DESCRIPTION
## Summary
- show white text inside `Card` on dark theme
- update `.item-card` for white dark-mode text
- fix listing pages to use `text-black dark:text-white`
- keep admin users table readable on dark mode
- update project tasks card text for dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860665d2b5c832a8f5c4afd1783d3a9