### PR TITLE
Add quotes/invoices migrations

### DIFF
--- a/migrations/20251101_create_quotes.sql
+++ b/migrations/20251101_create_quotes.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS quotes (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  customer_id INT,
+  job_id INT,
+  total_amount DECIMAL(10,2),
+  status VARCHAR(50),
+  created_ts DATETIME DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_quotes_customer FOREIGN KEY (customer_id) REFERENCES clients(id),
+  CONSTRAINT fk_quotes_job FOREIGN KEY (job_id) REFERENCES jobs(id)
+);

--- a/migrations/20251102_create_quote_items.sql
+++ b/migrations/20251102_create_quote_items.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS quote_items (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  quote_id INT NOT NULL,
+  description TEXT,
+  qty INT,
+  unit_price DECIMAL(10,2),
+  CONSTRAINT fk_quote_items_quote FOREIGN KEY (quote_id) REFERENCES quotes(id)
+);

--- a/migrations/20251103_create_invoices.sql
+++ b/migrations/20251103_create_invoices.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS invoices (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  job_id INT,
+  customer_id INT,
+  amount DECIMAL(10,2),
+  due_date DATE,
+  status VARCHAR(50),
+  created_ts DATETIME DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_invoices_job FOREIGN KEY (job_id) REFERENCES jobs(id),
+  CONSTRAINT fk_invoices_customer FOREIGN KEY (customer_id) REFERENCES clients(id)
+);

--- a/migrations/20251104_create_invoice_items.sql
+++ b/migrations/20251104_create_invoice_items.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS invoice_items (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  invoice_id INT NOT NULL,
+  description TEXT,
+  qty INT,
+  unit_price DECIMAL(10,2),
+  CONSTRAINT fk_invoice_items_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id)
+);

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -22,8 +22,9 @@ async function runMigrations() {
       run_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )`);
 
+    const migrationsDir = path.resolve(__dirname, '../migrations');
     const files = fs
-      .readdirSync(path.resolve('./migrations'))
+      .readdirSync(migrationsDir)
       .filter((f) => f.endsWith('.sql'))
       .sort();
 
@@ -38,7 +39,7 @@ async function runMigrations() {
       }
 
       const sql = fs.readFileSync(
-        path.resolve('./migrations', file),
+        path.join(migrationsDir, file),
         'utf8'
       );
       console.log(`Applying ${file}...`);


### PR DESCRIPTION
## Summary
- add migrations for quotes and invoices
- reference clients and jobs with foreign keys
- ensure migrate script resolves migrations dir reliably

## Testing
- `npm test` *(fails: cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686087f625e8832a9242b29ca8754247