### PR TITLE
Add quotes and invoices services with tests

### DIFF
--- a/__tests__/invoicesService.test.js
+++ b/__tests__/invoicesService.test.js
@@ -1,0 +1,66 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('getAllInvoices fetches invoices', async () => {
+  const rows = [{ id: 1 }];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getAllInvoices } = await import('../services/invoicesService.js');
+  const result = await getAllInvoices();
+  expect(queryMock).toHaveBeenCalledTimes(1);
+  expect(queryMock.mock.calls[0][0]).toMatch(/FROM invoices/);
+  expect(result).toEqual(rows);
+});
+
+test('getInvoiceById fetches single invoice', async () => {
+  const row = { id: 2 };
+  const queryMock = jest.fn().mockResolvedValue([[row]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getInvoiceById } = await import('../services/invoicesService.js');
+  const result = await getInvoiceById(2);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/WHERE id=\?/), [2]);
+  expect(result).toEqual(row);
+});
+
+test('createInvoice inserts invoice', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 3 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { createInvoice } = await import('../services/invoicesService.js');
+  const data = { job_id: 1, customer_id: 2, amount: 99, due_date: '2024-06-01', status: 'open' };
+  const result = await createInvoice(data);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/INSERT INTO invoices/), [1, 2, 99, '2024-06-01', 'open']);
+  expect(result).toEqual({ id: 3, ...data });
+});
+
+test('updateInvoice updates row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { updateInvoice } = await import('../services/invoicesService.js');
+  const data = { job_id: 4, customer_id: 5, amount: 8, due_date: '2024-07-01', status: 'paid' };
+  const result = await updateInvoice(6, data);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/UPDATE invoices/), [4, 5, 8, '2024-07-01', 'paid', 6]);
+  expect(result).toEqual({ ok: true });
+});
+
+test('deleteInvoice removes row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { deleteInvoice } = await import('../services/invoicesService.js');
+  const result = await deleteInvoice(7);
+  expect(queryMock).toHaveBeenCalledWith('DELETE FROM invoices WHERE id=?', [7]);
+  expect(result).toEqual({ ok: true });
+});

--- a/__tests__/quotesService.test.js
+++ b/__tests__/quotesService.test.js
@@ -1,0 +1,66 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('getAllQuotes fetches quotes', async () => {
+  const rows = [{ id: 1 }];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getAllQuotes } = await import('../services/quotesService.js');
+  const result = await getAllQuotes();
+  expect(queryMock).toHaveBeenCalledTimes(1);
+  expect(queryMock.mock.calls[0][0]).toMatch(/FROM quotes/);
+  expect(result).toEqual(rows);
+});
+
+test('getQuoteById fetches single quote', async () => {
+  const row = { id: 2 };
+  const queryMock = jest.fn().mockResolvedValue([[row]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getQuoteById } = await import('../services/quotesService.js');
+  const result = await getQuoteById(2);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/WHERE id=\?/), [2]);
+  expect(result).toEqual(row);
+});
+
+test('createQuote inserts quote', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 3 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { createQuote } = await import('../services/quotesService.js');
+  const data = { customer_id: 1, job_id: 2, total_amount: 50, status: 'new' };
+  const result = await createQuote(data);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/INSERT INTO quotes/), [1, 2, 50, 'new']);
+  expect(result).toEqual({ id: 3, ...data });
+});
+
+test('updateQuote updates row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { updateQuote } = await import('../services/quotesService.js');
+  const data = { customer_id: 4, job_id: 5, total_amount: 6, status: 'sent' };
+  const result = await updateQuote(7, data);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/UPDATE quotes/), [4, 5, 6, 'sent', 7]);
+  expect(result).toEqual({ ok: true });
+});
+
+test('deleteQuote removes row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { deleteQuote } = await import('../services/quotesService.js');
+  const result = await deleteQuote(8);
+  expect(queryMock).toHaveBeenCalledWith('DELETE FROM quotes WHERE id=?', [8]);
+  expect(result).toEqual({ ok: true });
+});

--- a/services/invoicesService.js
+++ b/services/invoicesService.js
@@ -1,0 +1,50 @@
+import pool from '../lib/db.js';
+
+export async function getAllInvoices() {
+  const [rows] = await pool.query(
+    `SELECT id, job_id, customer_id, amount, due_date, status, created_ts
+       FROM invoices ORDER BY id`
+  );
+  return rows;
+}
+
+export async function getInvoiceById(id) {
+  const [[row]] = await pool.query(
+    `SELECT id, job_id, customer_id, amount, due_date, status, created_ts
+       FROM invoices WHERE id=?`,
+    [id]
+  );
+  return row || null;
+}
+
+export async function createInvoice({ job_id, customer_id, amount, due_date, status }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO invoices
+      (job_id, customer_id, amount, due_date, status)
+     VALUES (?,?,?,?,?)`,
+    [job_id || null, customer_id || null, amount || null, due_date || null, status || null]
+  );
+  return { id: insertId, job_id, customer_id, amount, due_date, status };
+}
+
+export async function updateInvoice(
+  id,
+  { job_id, customer_id, amount, due_date, status }
+) {
+  await pool.query(
+    `UPDATE invoices SET
+       job_id=?,
+       customer_id=?,
+       amount=?,
+       due_date=?,
+       status=?
+     WHERE id=?`,
+    [job_id || null, customer_id || null, amount || null, due_date || null, status || null, id]
+  );
+  return { ok: true };
+}
+
+export async function deleteInvoice(id) {
+  await pool.query('DELETE FROM invoices WHERE id=?', [id]);
+  return { ok: true };
+}

--- a/services/quotesService.js
+++ b/services/quotesService.js
@@ -1,0 +1,49 @@
+import pool from '../lib/db.js';
+
+export async function getAllQuotes() {
+  const [rows] = await pool.query(
+    `SELECT id, customer_id, job_id, total_amount, status, created_ts
+       FROM quotes ORDER BY id`
+  );
+  return rows;
+}
+
+export async function getQuoteById(id) {
+  const [[row]] = await pool.query(
+    `SELECT id, customer_id, job_id, total_amount, status, created_ts
+       FROM quotes WHERE id=?`,
+    [id]
+  );
+  return row || null;
+}
+
+export async function createQuote({ customer_id, job_id, total_amount, status }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO quotes
+      (customer_id, job_id, total_amount, status)
+     VALUES (?,?,?,?)`,
+    [customer_id || null, job_id || null, total_amount || null, status || null]
+  );
+  return { id: insertId, customer_id, job_id, total_amount, status };
+}
+
+export async function updateQuote(
+  id,
+  { customer_id, job_id, total_amount, status }
+) {
+  await pool.query(
+    `UPDATE quotes SET
+       customer_id=?,
+       job_id=?,
+       total_amount=?,
+       status=?
+     WHERE id=?`,
+    [customer_id || null, job_id || null, total_amount || null, status || null, id]
+  );
+  return { ok: true };
+}
+
+export async function deleteQuote(id) {
+  await pool.query('DELETE FROM quotes WHERE id=?', [id]);
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- implement CRUD service modules for quotes and invoices
- create Jest tests verifying each service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860895b18b4832aa6da116c06c570e6