### PR TITLE
Add quotes and invoices API

### DIFF
--- a/__tests__/invoices-api.test.js
+++ b/__tests__/invoices-api.test.js
@@ -1,0 +1,154 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// GET /invoices success
+
+test('invoices index returns list of invoices', async () => {
+  const invoices = [{ id: 1 }];
+  const getAllMock = jest.fn().mockResolvedValue(invoices);
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getAllInvoices: getAllMock,
+    createInvoice: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/invoices/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(invoices);
+  expect(getAllMock).toHaveBeenCalledTimes(1);
+});
+
+test('invoices index creates invoice', async () => {
+  const newInvoice = { id: 2 };
+  const createMock = jest.fn().mockResolvedValue(newInvoice);
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getAllInvoices: jest.fn(),
+    createInvoice: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/invoices/index.js');
+  const req = { method: 'POST', body: { amount: 5 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(newInvoice);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+});
+
+test('invoices index rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getAllInvoices: jest.fn(),
+    createInvoice: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/invoices/index.js');
+  const req = { method: 'PUT', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','POST']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method PUT Not Allowed');
+});
+
+test('invoices index handles errors', async () => {
+  const error = new Error('db fail');
+  const getAllMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getAllInvoices: getAllMock,
+    createInvoice: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/invoices/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+
+test('invoice detail returns invoice by id', async () => {
+  const invoice = { id: 1 };
+  const getMock = jest.fn().mockResolvedValue(invoice);
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getInvoiceById: getMock,
+    updateInvoice: jest.fn(),
+    deleteInvoice: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/invoices/[id].js');
+  const req = { method: 'GET', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(invoice);
+  expect(getMock).toHaveBeenCalledWith('1');
+});
+
+test('invoice update returns updated data', async () => {
+  const updated = { ok: true };
+  const updateMock = jest.fn().mockResolvedValue(updated);
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getInvoiceById: jest.fn(),
+    updateInvoice: updateMock,
+    deleteInvoice: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/invoices/[id].js');
+  const req = { method: 'PUT', query: { id: '2' }, body: { amount: 10 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(updated);
+  expect(updateMock).toHaveBeenCalledWith('2', req.body);
+});
+
+test('invoice delete succeeds', async () => {
+  const deleteMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getInvoiceById: jest.fn(),
+    updateInvoice: jest.fn(),
+    deleteInvoice: deleteMock,
+  }));
+  const { default: handler } = await import('../pages/api/invoices/[id].js');
+  const req = { method: 'DELETE', query: { id: '3' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(204);
+  expect(res.end).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalledWith('3');
+});
+
+test('invoice detail rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getInvoiceById: jest.fn(),
+    updateInvoice: jest.fn(),
+    deleteInvoice: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/invoices/[id].js');
+  const req = { method: 'POST', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','PUT','DELETE']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('invoice detail handles errors', async () => {
+  const error = new Error('fail');
+  const getMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getInvoiceById: getMock,
+    updateInvoice: jest.fn(),
+    deleteInvoice: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/invoices/[id].js');
+  const req = { method: 'GET', query: { id: '4' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});

--- a/__tests__/quotes-api.test.js
+++ b/__tests__/quotes-api.test.js
@@ -1,0 +1,154 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// GET /quotes success
+
+test('quotes index returns list of quotes', async () => {
+  const quotes = [{ id: 1 }];
+  const getAllMock = jest.fn().mockResolvedValue(quotes);
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getAllQuotes: getAllMock,
+    createQuote: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quotes/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(quotes);
+  expect(getAllMock).toHaveBeenCalledTimes(1);
+});
+
+test('quotes index creates quote', async () => {
+  const newQuote = { id: 2 };
+  const createMock = jest.fn().mockResolvedValue(newQuote);
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getAllQuotes: jest.fn(),
+    createQuote: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/quotes/index.js');
+  const req = { method: 'POST', body: { job_id: 1 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(newQuote);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+});
+
+test('quotes index rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getAllQuotes: jest.fn(),
+    createQuote: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quotes/index.js');
+  const req = { method: 'PUT', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','POST']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method PUT Not Allowed');
+});
+
+test('quotes index handles errors', async () => {
+  const error = new Error('db fail');
+  const getAllMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getAllQuotes: getAllMock,
+    createQuote: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quotes/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+
+test('quote detail returns quote by id', async () => {
+  const quote = { id: 1 };
+  const getMock = jest.fn().mockResolvedValue(quote);
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getQuoteById: getMock,
+    updateQuote: jest.fn(),
+    deleteQuote: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quotes/[id].js');
+  const req = { method: 'GET', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(quote);
+  expect(getMock).toHaveBeenCalledWith('1');
+});
+
+test('quote update returns updated data', async () => {
+  const updated = { ok: true };
+  const updateMock = jest.fn().mockResolvedValue(updated);
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getQuoteById: jest.fn(),
+    updateQuote: updateMock,
+    deleteQuote: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quotes/[id].js');
+  const req = { method: 'PUT', query: { id: '2' }, body: { total_amount: 5 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(updated);
+  expect(updateMock).toHaveBeenCalledWith('2', req.body);
+});
+
+test('quote delete succeeds', async () => {
+  const deleteMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getQuoteById: jest.fn(),
+    updateQuote: jest.fn(),
+    deleteQuote: deleteMock,
+  }));
+  const { default: handler } = await import('../pages/api/quotes/[id].js');
+  const req = { method: 'DELETE', query: { id: '3' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(204);
+  expect(res.end).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalledWith('3');
+});
+
+test('quote detail rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getQuoteById: jest.fn(),
+    updateQuote: jest.fn(),
+    deleteQuote: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quotes/[id].js');
+  const req = { method: 'POST', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','PUT','DELETE']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('quote detail handles errors', async () => {
+  const error = new Error('fail');
+  const getMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getQuoteById: getMock,
+    updateQuote: jest.fn(),
+    deleteQuote: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quotes/[id].js');
+  const req = { method: 'GET', query: { id: '4' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});

--- a/pages/api/invoices/[id].js
+++ b/pages/api/invoices/[id].js
@@ -1,0 +1,24 @@
+import { getInvoiceById, updateInvoice, deleteInvoice } from '../../../services/invoicesService.js';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const invoice = await getInvoiceById(id);
+      return res.status(200).json(invoice);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateInvoice(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await deleteInvoice(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/invoices/index.js
+++ b/pages/api/invoices/index.js
@@ -1,0 +1,19 @@
+import { getAllInvoices, createInvoice } from '../../../services/invoicesService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const invoices = await getAllInvoices();
+      return res.status(200).json(invoices);
+    }
+    if (req.method === 'POST') {
+      const newInvoice = await createInvoice(req.body);
+      return res.status(201).json(newInvoice);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/quotes/[id].js
+++ b/pages/api/quotes/[id].js
@@ -1,0 +1,24 @@
+import { getQuoteById, updateQuote, deleteQuote } from '../../../services/quotesService.js';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const quote = await getQuoteById(id);
+      return res.status(200).json(quote);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateQuote(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await deleteQuote(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/quotes/index.js
+++ b/pages/api/quotes/index.js
@@ -1,0 +1,19 @@
+import { getAllQuotes, createQuote } from '../../../services/quotesService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const quotes = await getAllQuotes();
+      return res.status(200).json(quotes);
+    }
+    if (req.method === 'POST') {
+      const newQuote = await createQuote(req.body);
+      return res.status(201).json(newQuote);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}


### PR DESCRIPTION
## Summary
- expose Quotes and Invoices endpoints
- implement CRUD handlers for those APIs
- add unit tests for new endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68608d4e4348832aa575d67fd4436fd6