### PR TITLE
Add generic document support

### DIFF
--- a/docs/docs/db_schema.md
+++ b/docs/docs/db_schema.md
@@ -490,6 +490,17 @@
 | `fleet_id` | int(11) DEFAULT NULL |
 | `license_plate` | (`license_plate`) |
 
+## Table: `documents`
+
+| Column | Definition |
+|--------|------------|
+| `id` | int(11) NOT NULL AUTO_INCREMENT |
+| `entity_type` | enum('client','vehicle') NOT NULL |
+| `entity_id` | int(11) NOT NULL |
+| `filename` | varchar(512) NOT NULL |
+| `url` | text NOT NULL |
+| `uploaded_at` | datetime DEFAULT current_timestamp() |
+
 ## Table: `virtual_titles`
 
 | Column | Definition |

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -1,0 +1,5 @@
+export async function fetchDocuments(entity_type, entity_id) {
+  const res = await fetch(`/api/documents?entity_type=${entity_type}&entity_id=${entity_id}`);
+  if (!res.ok) throw new Error('Failed to fetch documents');
+  return res.json();
+}

--- a/migrations/20251201_create_documents.sql
+++ b/migrations/20251201_create_documents.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS documents (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  entity_type ENUM('client','vehicle') NOT NULL,
+  entity_id INT NOT NULL,
+  filename VARCHAR(512) NOT NULL,
+  url TEXT NOT NULL,
+  uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/pages/api/documents/index.js
+++ b/pages/api/documents/index.js
@@ -1,0 +1,36 @@
+import { getDocuments, createDocument } from '../../../services/documentsService.js';
+
+export default async function handler(req, res) {
+  const entity_type = req.query.entity_type || req.body.entity_type;
+  const entity_id = req.query.entity_id || req.body.entity_id;
+
+  if (req.method === 'GET') {
+    if (!entity_type || !entity_id) {
+      return res.status(400).json({ error: 'entity_type and entity_id required' });
+    }
+    try {
+      const docs = await getDocuments(entity_type, entity_id);
+      return res.status(200).json(docs);
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+
+  if (req.method === 'POST') {
+    const { filename, url } = req.body || {};
+    if (!entity_type || !entity_id || !filename || !url) {
+      return res.status(400).json({ error: 'Missing required fields' });
+    }
+    try {
+      const doc = await createDocument({ entity_type, entity_id, filename, url });
+      return res.status(201).json(doc);
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}

--- a/pages/office/clients/view/[id].js
+++ b/pages/office/clients/view/[id].js
@@ -4,12 +4,14 @@ import Link from 'next/link';
 import { Layout } from '../../../../components/Layout';
 import { Card } from '../../../../components/Card';
 import { fetchVehicles } from '../../../../lib/vehicles';
+import { fetchDocuments } from '../../../../lib/documents';
 
 export default function ClientViewPage() {
   const router = useRouter();
   const { id } = router.query;
   const [client, setClient] = useState(null);
   const [vehicles, setVehicles] = useState([]);
+  const [documents, setDocuments] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -23,6 +25,8 @@ export default function ClientViewPage() {
         setClient(data);
         const vs = await fetchVehicles(id);
         setVehicles(vs);
+        const docs = await fetchDocuments('client', id);
+        setDocuments(docs);
       } catch (err) {
         setError('Failed to load');
       } finally {
@@ -88,6 +92,22 @@ export default function ClientViewPage() {
                 </div>
               ))}
             </div>
+          )}
+        </Card>
+        <Card>
+          <h2 className="text-xl font-semibold mb-4">Documents</h2>
+          {documents.length === 0 ? (
+            <p>No documents</p>
+          ) : (
+            <ul className="list-disc pl-5 space-y-1">
+              {documents.map(doc => (
+                <li key={doc.id}>
+                  <a href={doc.url} className="underline text-blue-600" download>
+                    {doc.filename}
+                  </a>
+                </li>
+              ))}
+            </ul>
           )}
         </Card>
       </div>

--- a/pages/office/vehicles/view/[id].js
+++ b/pages/office/vehicles/view/[id].js
@@ -3,12 +3,14 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { Layout } from '../../../../components/Layout';
 import { Card } from '../../../../components/Card';
+import { fetchDocuments } from '../../../../lib/documents';
 
 export default function VehicleViewPage() {
   const router = useRouter();
   const { id } = router.query;
   const [vehicle, setVehicle] = useState(null);
   const [client, setClient] = useState(null);
+  const [documents, setDocuments] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -25,6 +27,8 @@ export default function VehicleViewPage() {
           if (!cRes.ok) throw new Error();
           setClient(await cRes.json());
         }
+        const docs = await fetchDocuments('vehicle', id);
+        setDocuments(docs);
       } catch (err) {
         setError('Failed to load');
       } finally {
@@ -76,6 +80,22 @@ export default function VehicleViewPage() {
           <p><strong>Model:</strong> {vehicle.model}</p>
           <p><strong>Color:</strong> {vehicle.color}</p>
           <p><strong>Fleet ID:</strong> {vehicle.fleet_id || 'N/A'}</p>
+        </Card>
+        <Card>
+          <h2 className="text-xl font-semibold mb-4">Documents</h2>
+          {documents.length === 0 ? (
+            <p>No documents</p>
+          ) : (
+            <ul className="list-disc pl-5 space-y-1">
+              {documents.map(doc => (
+                <li key={doc.id}>
+                  <a href={doc.url} className="underline text-blue-600" download>
+                    {doc.filename}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
         </Card>
       </div>
     </Layout>

--- a/services/documentsService.js
+++ b/services/documentsService.js
@@ -1,0 +1,21 @@
+import pool from '../lib/db.js';
+
+export async function getDocuments(entity_type, entity_id) {
+  const [rows] = await pool.query(
+    `SELECT id, entity_type, entity_id, filename, url, uploaded_at
+       FROM documents
+      WHERE entity_type=? AND entity_id=?
+      ORDER BY uploaded_at DESC`,
+    [entity_type, entity_id]
+  );
+  return rows;
+}
+
+export async function createDocument({ entity_type, entity_id, filename, url }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO documents (entity_type, entity_id, filename, url)
+     VALUES (?,?,?,?)`,
+    [entity_type, entity_id, filename, url]
+  );
+  return { id: insertId, entity_type, entity_id, filename, url };
+}


### PR DESCRIPTION
## Summary
- add migration for `documents`
- add service and API route for managing documents
- list client and vehicle documents on their detail pages
- document the new table in db schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686091eacd70832a8a6c871f6c09eb24