### PR TITLE
Add fleets service and API

### DIFF
--- a/__tests__/fleets-api.test.js
+++ b/__tests__/fleets-api.test.js
@@ -1,0 +1,100 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('fleets index returns list of fleets', async () => {
+  const fleets = [{ id: 1 }];
+  const getAllMock = jest.fn().mockResolvedValue(fleets);
+  jest.unstable_mockModule('../services/fleetsService.js', () => ({
+    getAllFleets: getAllMock,
+    getFleetById: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/fleets/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(fleets);
+  expect(getAllMock).toHaveBeenCalledTimes(1);
+});
+
+test('fleets index rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/fleetsService.js', () => ({
+    getAllFleets: jest.fn(),
+    getFleetById: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/fleets/index.js');
+  const req = { method: 'POST', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('fleets index handles errors', async () => {
+  const error = new Error('fail');
+  const getAllMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/fleetsService.js', () => ({
+    getAllFleets: getAllMock,
+    getFleetById: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/fleets/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+
+test('fleet detail returns fleet by id', async () => {
+  const fleet = { id: 1 };
+  const getMock = jest.fn().mockResolvedValue(fleet);
+  jest.unstable_mockModule('../services/fleetsService.js', () => ({
+    getFleetById: getMock,
+    getAllFleets: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/fleets/[id].js');
+  const req = { method: 'GET', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(fleet);
+  expect(getMock).toHaveBeenCalledWith('1');
+});
+
+test('fleet detail rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/fleetsService.js', () => ({
+    getFleetById: jest.fn(),
+    getAllFleets: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/fleets/[id].js');
+  const req = { method: 'POST', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('fleet detail handles errors', async () => {
+  const error = new Error('oops');
+  const getMock = jest.fn().mockRejectedValue(error);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/fleetsService.js', () => ({
+    getFleetById: getMock,
+    getAllFleets: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/fleets/[id].js');
+  const req = { method: 'GET', query: { id: '2' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});

--- a/__tests__/fleetsService.test.js
+++ b/__tests__/fleetsService.test.js
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('getAllFleets fetches fleets', async () => {
+  const rows = [{ id: 1 }];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getAllFleets } = await import('../services/fleetsService.js');
+  const result = await getAllFleets();
+  expect(queryMock).toHaveBeenCalledTimes(1);
+  expect(queryMock.mock.calls[0][0]).toMatch(/FROM fleets/);
+  expect(result).toEqual(rows);
+});
+
+test('getFleetById fetches single fleet', async () => {
+  const row = { id: 2 };
+  const queryMock = jest.fn().mockResolvedValue([[row]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getFleetById } = await import('../services/fleetsService.js');
+  const result = await getFleetById(2);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/WHERE id=\?/), [2]);
+  expect(result).toEqual(row);
+});

--- a/pages/api/fleets/[id].js
+++ b/pages/api/fleets/[id].js
@@ -1,0 +1,16 @@
+import { getFleetById } from '../../../services/fleetsService.js';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const fleet = await getFleetById(id);
+      return res.status(200).json(fleet);
+    }
+    res.setHeader('Allow', ['GET']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/fleets/index.js
+++ b/pages/api/fleets/index.js
@@ -1,0 +1,15 @@
+import { getAllFleets } from '../../../services/fleetsService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const fleets = await getAllFleets();
+      return res.status(200).json(fleets);
+    }
+    res.setHeader('Allow', ['GET']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/office/vehicles/view/[id].js
+++ b/pages/office/vehicles/view/[id].js
@@ -11,6 +11,7 @@ export default function VehicleViewPage() {
   const [vehicle, setVehicle] = useState(null);
   const [client, setClient] = useState(null);
   const [documents, setDocuments] = useState([]);
+  const [fleet, setFleet] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -26,6 +27,11 @@ export default function VehicleViewPage() {
           const cRes = await fetch(`/api/clients/${v.customer_id}`);
           if (!cRes.ok) throw new Error();
           setClient(await cRes.json());
+        }
+        if (v.fleet_id) {
+          const fRes = await fetch(`/api/fleets/${v.fleet_id}`);
+          if (!fRes.ok) throw new Error();
+          setFleet(await fRes.json());
         }
         const docs = await fetchDocuments('vehicle', id);
         setDocuments(docs);
@@ -81,7 +87,7 @@ export default function VehicleViewPage() {
           <p><strong>Make:</strong> {vehicle.make}</p>
           <p><strong>Model:</strong> {vehicle.model}</p>
           <p><strong>Color:</strong> {vehicle.color}</p>
-          <p><strong>Fleet ID:</strong> {vehicle.fleet_id || 'N/A'}</p>
+          <p><strong>Fleet:</strong> {fleet ? fleet.company_name : (vehicle.fleet_id || 'N/A')}</p>
         </Card>
         <Card>
           <h2 className="text-xl font-semibold mb-4">Documents</h2>

--- a/services/fleetsService.js
+++ b/services/fleetsService.js
@@ -1,0 +1,18 @@
+import pool from '../lib/db.js';
+
+export async function getAllFleets() {
+  const [rows] = await pool.query(
+    `SELECT id, company_name, account_rep, payment_terms
+       FROM fleets ORDER BY id`
+  );
+  return rows;
+}
+
+export async function getFleetById(id) {
+  const [[row]] = await pool.query(
+    `SELECT id, company_name, account_rep, payment_terms
+       FROM fleets WHERE id=?`,
+    [id]
+  );
+  return row || null;
+}


### PR DESCRIPTION
## Summary
- implement `fleetsService` for DB access
- add `/api/fleets` and `/api/fleets/[id]` routes
- fetch and display fleet company name on vehicle detail page
- test new service and endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68609c50df2c832a99be2969db0b10e5