### PR TITLE
Add fleet filters to client and vehicle lists

### DIFF
--- a/lib/fleets.js
+++ b/lib/fleets.js
@@ -1,0 +1,5 @@
+export async function fetchFleets() {
+  const res = await fetch('/api/fleets');
+  if (!res.ok) throw new Error('Failed to fetch fleets');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add `fetchFleets` helper
- load fleets and filter by fleet for Vehicles page
- load fleets/vehicles and filter by fleet for Clients page
- add dropdowns to choose fleet company

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68609d8893cc832ab5a2d7b341637367