### PR TITLE
Add fleet pages and API

### DIFF
--- a/__tests__/fleets-api.test.js
+++ b/__tests__/fleets-api.test.js
@@ -25,14 +25,15 @@ test('fleets index rejects unsupported method', async () => {
   jest.unstable_mockModule('../services/fleetsService.js', () => ({
     getAllFleets: jest.fn(),
     getFleetById: jest.fn(),
+    createFleet: jest.fn(),
   }));
   const { default: handler } = await import('../pages/api/fleets/index.js');
-  const req = { method: 'POST', headers: {} };
+  const req = { method: 'PUT', headers: {} };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
   await handler(req, res);
-  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','POST']);
   expect(res.status).toHaveBeenCalledWith(405);
-  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+  expect(res.end).toHaveBeenCalledWith('Method PUT Not Allowed');
 });
 
 test('fleets index handles errors', async () => {
@@ -72,14 +73,16 @@ test('fleet detail rejects unsupported method', async () => {
   jest.unstable_mockModule('../services/fleetsService.js', () => ({
     getFleetById: jest.fn(),
     getAllFleets: jest.fn(),
+    updateFleet: jest.fn(),
+    deleteFleet: jest.fn(),
   }));
   const { default: handler } = await import('../pages/api/fleets/[id].js');
-  const req = { method: 'POST', query: { id: '1' }, headers: {} };
+  const req = { method: 'PATCH', query: { id: '1' }, headers: {} };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
   await handler(req, res);
-  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET','PUT','DELETE']);
   expect(res.status).toHaveBeenCalledWith(405);
-  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+  expect(res.end).toHaveBeenCalledWith('Method PATCH Not Allowed');
 });
 
 test('fleet detail handles errors', async () => {

--- a/pages/api/fleets/[id].js
+++ b/pages/api/fleets/[id].js
@@ -7,10 +7,22 @@ export default async function handler(req, res) {
       const fleet = await getFleetById(id);
       return res.status(200).json(fleet);
     }
-    res.setHeader('Allow', ['GET']);
+    if (req.method === 'PUT') {
+      const { updateFleet } = await import('../../../services/fleetsService.js');
+      const updated = await updateFleet(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      const { deleteFleet } = await import('../../../services/fleetsService.js');
+      await deleteFleet(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+

--- a/pages/api/fleets/index.js
+++ b/pages/api/fleets/index.js
@@ -6,10 +6,17 @@ export default async function handler(req, res) {
       const fleets = await getAllFleets();
       return res.status(200).json(fleets);
     }
-    res.setHeader('Allow', ['GET']);
+    if (req.method === 'POST') {
+      const { createFleet } = await import('../../../services/fleetsService.js');
+      const fleet = await createFleet(req.body);
+      return res.status(201).json(fleet);
+    }
+    res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+

--- a/pages/office/fleets/[id].js
+++ b/pages/office/fleets/[id].js
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { Layout } from '../../../components/Layout';
+
+const EditFleetPage = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const [form, setForm] = useState({
+    company_name: '',
+    account_rep: '',
+    payment_terms: '',
+  });
+  const [vehicles, setVehicles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/fleets/${id}`)
+      .then(r => r.json())
+      .then(setForm)
+      .catch(() => setError('Failed to load'))
+      .finally(() => setLoading(false));
+    fetch('/api/vehicles')
+      .then(r => r.json())
+      .then(vs => setVehicles(vs.filter(v => String(v.fleet_id) === id)))
+      .catch(() => {});
+  }, [id]);
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`/api/fleets/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error();
+      router.push('/office/fleets');
+    } catch {
+      setError('Failed to update');
+    }
+  };
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const handleDeleteVehicle = async vid => {
+    if (!confirm('Delete this vehicle?')) return;
+    await fetch(`/api/vehicles/${vid}`, { method: 'DELETE' });
+    setVehicles(vs => vs.filter(v => v.id !== vid));
+  };
+
+  if (loading) return <Layout><p>Loading…</p></Layout>;
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Edit Fleet</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        {['company_name','account_rep','payment_terms'].map(field => (
+          <div key={field}>
+            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
+            <input
+              name={field}
+              value={form[field] || ''}
+              onChange={change}
+              className="w-full border px-3 py-2 rounded text-black"
+            />
+          </div>
+        ))}
+        <button type="submit" className="button">Update</button>
+      </form>
+      <div className="mt-8">
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="text-xl font-semibold">Vehicles</h2>
+          <div className="flex gap-4">
+            <Link href={`/office/vehicles/new?fleet_id=${id}`} className="underline">Add Vehicle</Link>
+          </div>
+        </div>
+        {vehicles.length === 0 ? (
+          <p>No vehicles</p>
+        ) : (
+          <table className="min-w-full bg-white border">
+            <thead>
+              <tr>
+                <th className="px-4 py-2 border text-black">Plate</th>
+                <th className="px-4 py-2 border text-black">Make</th>
+                <th className="px-4 py-2 border text-black">Model</th>
+                <th className="px-4 py-2 border text-black">Color</th>
+                <th className="px-4 py-2 border text-black">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {vehicles.map(v => (
+                <tr key={v.id}>
+                  <td className="px-4 py-2 border text-black">{v.licence_plate}</td>
+                  <td className="px-4 py-2 border text-black">{v.make}</td>
+                  <td className="px-4 py-2 border text-black">{v.model}</td>
+                  <td className="px-4 py-2 border text-black">{v.color}</td>
+                  <td className="px-4 py-2 border text-black">
+                    <Link href={`/office/vehicles/${v.id}`} className="mr-2 underline">Edit</Link>
+                    <button onClick={() => handleDeleteVehicle(v.id)} className="underline text-red-600">Delete</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </Layout>
+  );
+};
+
+export default EditFleetPage;
+

--- a/pages/office/fleets/index.js
+++ b/pages/office/fleets/index.js
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Layout } from '../../../components/Layout';
+import { fetchFleets } from '../../../lib/fleets';
+
+const FleetsPage = () => {
+  const [fleets, setFleets] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const load = () => {
+    setLoading(true);
+    fetchFleets()
+      .then(setFleets)
+      .catch(() => setError('Failed to load fleets'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const handleDelete = async id => {
+    if (!confirm('Delete this fleet?')) return;
+    await fetch(`/api/fleets/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  const filtered = fleets.filter(f => {
+    const q = searchQuery.toLowerCase();
+    return (
+      f.company_name.toLowerCase().includes(q) ||
+      (f.account_rep || '').toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <Layout>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-semibold">Fleets</h1>
+        <Link href="/office/fleets/new" className="button">
+          + New Fleet
+        </Link>
+      </div>
+      <Link href="/office" className="button inline-block mb-4">
+        Return to Office
+      </Link>
+      {loading && <p>Loading…</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      {!loading && !error && (
+        <>
+          <input
+            type="text"
+            placeholder="Search…"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            className="input mb-4 w-full"
+          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            {filtered.map(f => (
+              <div key={f.id} className="item-card">
+                <h2 className="font-semibold text-black dark:text-white text-lg mb-1">
+                  {f.company_name}
+                </h2>
+                <p className="text-sm text-black dark:text-white">
+                  {f.account_rep || '—'}
+                </p>
+                <p className="text-sm text-black dark:text-white">
+                  {f.payment_terms || '—'}
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Link href={`/office/fleets/${f.id}`} className="button px-4 text-sm">
+                    Edit
+                  </Link>
+                  <button
+                    onClick={() => handleDelete(f.id)}
+                    className="button px-4 text-sm bg-red-600 hover:bg-red-700"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </Layout>
+  );
+};
+
+export default FleetsPage;
+

--- a/pages/office/fleets/new.js
+++ b/pages/office/fleets/new.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Layout } from '../../../components/Layout';
+
+const NewFleetPage = () => {
+  const router = useRouter();
+  const [form, setForm] = useState({
+    company_name: '',
+    account_rep: '',
+    payment_terms: '',
+  });
+  const [error, setError] = useState(null);
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/fleets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error();
+      router.push('/office/fleets');
+    } catch {
+      setError('Failed to create fleet');
+    }
+  };
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">New Fleet</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        {['company_name','account_rep','payment_terms'].map(field => (
+          <div key={field}>
+            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
+            <input
+              name={field}
+              value={form[field]}
+              onChange={change}
+              className="w-full border px-3 py-2 rounded text-black"
+            />
+          </div>
+        ))}
+        <button type="submit" className="button">Save</button>
+      </form>
+    </Layout>
+  );
+};
+
+export default NewFleetPage;
+

--- a/pages/office/index.js
+++ b/pages/office/index.js
@@ -105,6 +105,14 @@ function VehiclesIcon() {
   );
 }
 
+function FleetsIcon() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor" className="mb-2">
+      <path d="M4 6h16v4H4zM4 14h16v4H4z" />
+    </svg>
+  );
+}
+
 function CompanySettingsIcon() {
   return (
     <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor" className="mb-2">
@@ -301,6 +309,7 @@ export default function OfficeHome() {
           <DashboardCard href="/office/quotations" title="Quotations" Icon={QuotationsIcon} />
           <DashboardCard href="/office/reporting" title="Reporting" Icon={ReportingIcon} />
           <DashboardCard href="/office/scheduling" title="Scheduling" Icon={SchedulingIcon} />
+          <DashboardCard href="/office/fleets" title="Fleets" Icon={FleetsIcon} />
           <DashboardCard href="/office/vehicles" title="Vehicles" Icon={VehiclesIcon} />
           <DashboardCard href="/office/company-settings" title="Company Settings" Icon={CompanySettingsIcon} />
         </div>

--- a/services/fleetsService.js
+++ b/services/fleetsService.js
@@ -16,3 +16,25 @@ export async function getFleetById(id) {
   );
   return row || null;
 }
+export async function createFleet({ company_name, account_rep, payment_terms }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO fleets (company_name, account_rep, payment_terms)
+     VALUES (?,?,?)`,
+    [company_name, account_rep || null, payment_terms || null],
+  );
+  return { id: insertId, company_name, account_rep, payment_terms };
+}
+
+export async function updateFleet(id, { company_name, account_rep, payment_terms }) {
+  await pool.query(
+    `UPDATE fleets SET company_name=?, account_rep=?, payment_terms=? WHERE id=?`,
+    [company_name, account_rep || null, payment_terms || null, id],
+  );
+  return { ok: true };
+}
+
+export async function deleteFleet(id) {
+  await pool.query('DELETE FROM fleets WHERE id=?', [id]);
+  return { ok: true };
+}
+


### PR DESCRIPTION
## Summary
- add service CRUD for fleets
- expose fleet API endpoints
- add office fleet management pages
- link fleets from dashboard
- adjust tests for new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68609ea7a660832aaaf4f670cc847aaf