### PR TITLE
Add parts service and autocomplete

### DIFF
--- a/components/PartAutocomplete.js
+++ b/components/PartAutocomplete.js
@@ -1,0 +1,78 @@
+import { useState, useEffect } from 'react';
+
+export default function PartAutocomplete({ onSelect }) {
+  const [term, setTerm] = useState('');
+  const [results, setResults] = useState([]);
+  const [showAdd, setShowAdd] = useState(false);
+
+  useEffect(() => {
+    if (!term) return setResults([]);
+    let cancel = false;
+    fetch(`/api/parts?q=${encodeURIComponent(term)}`)
+      .then(r => (r.ok ? r.json() : []))
+      .then(data => {
+        if (cancel) return;
+        setResults(data);
+        setShowAdd(data.length === 0);
+      })
+      .catch(() => {
+        if (cancel) return;
+        setResults([]);
+        setShowAdd(true);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [term]);
+
+  const addPart = async () => {
+    try {
+      const res = await fetch('/api/parts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ part_number: term, description: term }),
+      });
+      const created = await res.json();
+      setResults([created]);
+      setShowAdd(false);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="relative">
+      <input
+        className="input w-full"
+        value={term}
+        onChange={e => setTerm(e.target.value)}
+        placeholder="Part number or description"
+      />
+      {term && (
+        <div className="absolute z-10 bg-white shadow rounded w-full text-black">
+          {results.map(p => (
+            <div
+              key={p.id}
+              className="px-2 py-1 cursor-pointer hover:bg-gray-200"
+              onClick={() => {
+                onSelect && onSelect(p);
+                setTerm('');
+                setResults([]);
+              }}
+            >
+              {p.part_number} - {p.description}
+            </div>
+          ))}
+          {showAdd && (
+            <div
+              className="px-2 py-1 cursor-pointer hover:bg-gray-200"
+              onClick={addPart}
+            >
+              Add Part "{term}"
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/migrations/20251202_create_parts.sql
+++ b/migrations/20251202_create_parts.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS parts (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  part_number VARCHAR(100) NOT NULL UNIQUE,
+  description TEXT,
+  unit_cost DECIMAL(10,2)
+);

--- a/pages/api/parts/index.js
+++ b/pages/api/parts/index.js
@@ -1,0 +1,20 @@
+import { searchParts, createPart } from '../../../services/partsService';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const { q } = req.query || {};
+      const parts = await searchParts(q || '');
+      return res.status(200).json(parts);
+    }
+    if (req.method === 'POST') {
+      const newPart = await createPart(req.body);
+      return res.status(201).json(newPart);
+    }
+    res.setHeader('Allow', ['GET', 'POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/office/jobs/new.js
+++ b/pages/office/jobs/new.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import { Layout } from '../../../components/Layout';
+import PartAutocomplete from '../../../components/PartAutocomplete';
 
 export default function NewJobPage() {
   const { query } = useRouter();
@@ -8,6 +9,10 @@ export default function NewJobPage() {
     <Layout>
       <h1 className="text-2xl font-semibold mb-4">New Job</h1>
       <p className="text-sm">Placeholder page for creating a job.</p>
+      <div className="max-w-sm mt-4">
+        <label className="block mb-1">Add Part</label>
+        <PartAutocomplete onSelect={p => console.log('selected', p)} />
+      </div>
       {query.client_id && (
         <p className="text-sm">Client ID: {query.client_id}</p>
       )}

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import { Layout } from '../../../components/Layout';
+import PartAutocomplete from '../../../components/PartAutocomplete';
 
 export default function NewQuotationPage() {
   const { query } = useRouter();
@@ -8,6 +9,10 @@ export default function NewQuotationPage() {
     <Layout>
       <h1 className="text-2xl font-semibold mb-4">New Quote</h1>
       <p className="text-sm">Placeholder page for creating a quote.</p>
+      <div className="max-w-sm mt-4">
+        <label className="block mb-1">Add Part</label>
+        <PartAutocomplete onSelect={p => console.log('selected', p)} />
+      </div>
       {query.client_id && (
         <p className="text-sm">Client ID: {query.client_id}</p>
       )}

--- a/services/partsService.js
+++ b/services/partsService.js
@@ -1,0 +1,30 @@
+import pool from '../lib/db.js';
+
+export async function searchParts(query) {
+  const q = `%${query}%`;
+  const [rows] = query
+    ? await pool.query(
+        `SELECT id, part_number, description, unit_cost
+           FROM parts
+          WHERE part_number LIKE ? OR description LIKE ?
+          ORDER BY part_number
+          LIMIT 20`,
+        [q, q]
+      )
+    : await pool.query(
+        `SELECT id, part_number, description, unit_cost
+           FROM parts
+          ORDER BY part_number
+          LIMIT 20`
+      );
+  return rows;
+}
+
+export async function createPart({ part_number, description, unit_cost }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO parts (part_number, description, unit_cost)
+     VALUES (?,?,?)`,
+    [part_number, description || null, unit_cost || null]
+  );
+  return { id: insertId, part_number, description, unit_cost };
+}


### PR DESCRIPTION
## Summary
- add parts SQL migration
- implement parts service layer
- expose `/api/parts` for searching and creating parts
- implement a small autocomplete component for parts
- show the part autocomplete on new job and quotation pages

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a0cb7144832a9f873d35a42267cf