### PR TITLE
Add fleet option when creating quotations

### DIFF
--- a/__tests__/quotesService.test.js
+++ b/__tests__/quotesService.test.js
@@ -36,9 +36,18 @@ test('createQuote inserts quote', async () => {
     default: { query: queryMock },
   }));
   const { createQuote } = await import('../services/quotesService.js');
-  const data = { customer_id: 1, job_id: 2, total_amount: 50, status: 'new' };
+  const data = {
+    customer_id: 1,
+    fleet_id: 2,
+    job_id: 3,
+    total_amount: 50,
+    status: 'new',
+  };
   const result = await createQuote(data);
-  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/INSERT INTO quotes/), [1, 2, 50, 'new']);
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/INSERT INTO quotes/),
+    [1, 2, 3, 50, 'new']
+  );
   expect(result).toEqual({ id: 3, ...data });
 });
 
@@ -48,9 +57,18 @@ test('updateQuote updates row', async () => {
     default: { query: queryMock },
   }));
   const { updateQuote } = await import('../services/quotesService.js');
-  const data = { customer_id: 4, job_id: 5, total_amount: 6, status: 'sent' };
-  const result = await updateQuote(7, data);
-  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/UPDATE quotes/), [4, 5, 6, 'sent', 7]);
+  const data = {
+    customer_id: 4,
+    fleet_id: 5,
+    job_id: 6,
+    total_amount: 7,
+    status: 'sent',
+  };
+  const result = await updateQuote(8, data);
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/UPDATE quotes/),
+    [4, 5, 6, 7, 'sent', 8]
+  );
   expect(result).toEqual({ ok: true });
 });
 

--- a/lib/vehicles.js
+++ b/lib/vehicles.js
@@ -1,5 +1,10 @@
-export async function fetchVehicles(customer_id) {
-  const url = customer_id ? `/api/vehicles?customer_id=${customer_id}` : '/api/vehicles';
+export async function fetchVehicles(customer_id, fleet_id) {
+  let url = '/api/vehicles';
+  const params = new URLSearchParams();
+  if (customer_id) params.set('customer_id', customer_id);
+  if (fleet_id) params.set('fleet_id', fleet_id);
+  const q = params.toString();
+  if (q) url += `?${q}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error('Failed to fetch vehicles');
   return res.json();

--- a/migrations/20251203_add_quotes_fleet_id.sql
+++ b/migrations/20251203_add_quotes_fleet_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE quotes
+  ADD COLUMN fleet_id INT AFTER customer_id,
+  ADD CONSTRAINT fk_quotes_fleet FOREIGN KEY (fleet_id) REFERENCES fleets(id);

--- a/pages/api/vehicles/index.js
+++ b/pages/api/vehicles/index.js
@@ -3,8 +3,8 @@ import { getAllVehicles, createVehicle } from '../../../services/vehiclesService
 export default async function handler(req, res) {
   try {
     if (req.method === 'GET') {
-      const { customer_id } = req.query || {};
-      const vehicles = await getAllVehicles(customer_id);
+      const { customer_id, fleet_id } = req.query || {};
+      const vehicles = await getAllVehicles(customer_id, fleet_id);
       return res.status(200).json(vehicles);
     }
     if (req.method === 'POST') {

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Layout } from '../../../components/Layout';
 import { fetchClients } from '../../../lib/clients';
+import { fetchFleets } from '../../../lib/fleets';
 import { fetchVehicles } from '../../../lib/vehicles';
 import { createQuote } from '../../../lib/quotes';
 
@@ -11,9 +12,16 @@ export default function NewQuotationPage() {
   const router = useRouter();
   const [clients, setClients] = useState([]);
   const [vehicles, setVehicles] = useState([]);
-  const [form, setForm] = useState({ customer_id: '', vehicle_id: '' });
+  const [fleets, setFleets] = useState([]);
+  const [mode, setMode] = useState('client');
+  const [form, setForm] = useState({ customer_id: '', fleet_id: '', vehicle_id: '' });
   const [items, setItems] = useState([emptyItem]);
   const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setForm(f => ({ ...f, customer_id: '', fleet_id: '', vehicle_id: '' }));
+    setVehicles([]);
+  }, [mode]);
 
   useEffect(() => {
     fetchClients()
@@ -22,11 +30,24 @@ export default function NewQuotationPage() {
   }, []);
 
   useEffect(() => {
-    if (!form.customer_id) return setVehicles([]);
-    fetchVehicles(form.customer_id)
-      .then(setVehicles)
-      .catch(() => setVehicles([]));
-  }, [form.customer_id]);
+    fetchFleets()
+      .then(setFleets)
+      .catch(() => setError('Failed to load fleets'));
+  }, []);
+
+  useEffect(() => {
+    if (mode === 'client') {
+      if (!form.customer_id) return setVehicles([]);
+      fetchVehicles(form.customer_id, null)
+        .then(setVehicles)
+        .catch(() => setVehicles([]));
+    } else {
+      if (!form.fleet_id) return setVehicles([]);
+      fetchVehicles(null, form.fleet_id)
+        .then(setVehicles)
+        .catch(() => setVehicles([]));
+    }
+  }, [mode, form.customer_id, form.fleet_id]);
 
   const addItem = () => setItems(items => [...items, emptyItem]);
 
@@ -47,7 +68,8 @@ export default function NewQuotationPage() {
     e.preventDefault();
     try {
       await createQuote({
-        customer_id: form.customer_id,
+        customer_id: mode === 'client' ? form.customer_id : null,
+        fleet_id: mode === 'fleet' ? form.fleet_id : null,
         job_id: null,
         total_amount: total,
         status: 'new',
@@ -63,23 +85,59 @@ export default function NewQuotationPage() {
       <h1 className="text-2xl font-semibold mb-4">New Quote</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 mb-8 max-w-lg">
-        <div>
-          <label className="block mb-1">Client</label>
-          <select
-            className="input w-full"
-            value={form.customer_id}
-            onChange={e =>
-              setForm(f => ({ ...f, customer_id: e.target.value }))
-            }
+        <div className="mb-2 flex gap-2">
+          <button
+            type="button"
+            className={(mode === 'client' ? 'button' : 'button-secondary') + ' px-4'}
+            onClick={() => setMode('client')}
           >
-            <option value="">Select client</option>
-            {clients.map(c => (
-              <option key={c.id} value={c.id}>
-                {(c.first_name || '') + ' ' + (c.last_name || '')}
-              </option>
-            ))}
-          </select>
+            Client
+          </button>
+          <button
+            type="button"
+            className={(mode === 'fleet' ? 'button' : 'button-secondary') + ' px-4'}
+            onClick={() => setMode('fleet')}
+          >
+            Fleet
+          </button>
         </div>
+        {mode === 'client' ? (
+          <div>
+            <label className="block mb-1">Client</label>
+            <select
+              className="input w-full"
+              value={form.customer_id}
+              onChange={e =>
+                setForm(f => ({ ...f, customer_id: e.target.value, fleet_id: '' }))
+              }
+            >
+              <option value="">Select client</option>
+              {clients.map(c => (
+                <option key={c.id} value={c.id}>
+                  {(c.first_name || '') + ' ' + (c.last_name || '')}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <div>
+            <label className="block mb-1">Fleet</label>
+            <select
+              className="input w-full"
+              value={form.fleet_id}
+              onChange={e =>
+                setForm(f => ({ ...f, fleet_id: e.target.value, customer_id: '' }))
+              }
+            >
+              <option value="">Select fleet</option>
+              {fleets.map(f => (
+                <option key={f.id} value={f.id}>
+                  {f.company_name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
         <div>
           <label className="block mb-1">Vehicle</label>
           <select

--- a/services/quotesService.js
+++ b/services/quotesService.js
@@ -2,7 +2,7 @@ import pool from '../lib/db.js';
 
 export async function getAllQuotes() {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, job_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, total_amount, status, created_ts
        FROM quotes ORDER BY id`
   );
   return rows;
@@ -10,35 +10,49 @@ export async function getAllQuotes() {
 
 export async function getQuoteById(id) {
   const [[row]] = await pool.query(
-    `SELECT id, customer_id, job_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, total_amount, status, created_ts
        FROM quotes WHERE id=?`,
     [id]
   );
   return row || null;
 }
 
-export async function createQuote({ customer_id, job_id, total_amount, status }) {
+export async function createQuote({ customer_id, fleet_id, job_id, total_amount, status }) {
   const [{ insertId }] = await pool.query(
     `INSERT INTO quotes
-      (customer_id, job_id, total_amount, status)
-     VALUES (?,?,?,?)`,
-    [customer_id || null, job_id || null, total_amount || null, status || null]
+      (customer_id, fleet_id, job_id, total_amount, status)
+     VALUES (?,?,?,?,?)`,
+    [
+      customer_id || null,
+      fleet_id || null,
+      job_id || null,
+      total_amount || null,
+      status || null,
+    ]
   );
-  return { id: insertId, customer_id, job_id, total_amount, status };
+  return { id: insertId, customer_id, fleet_id, job_id, total_amount, status };
 }
 
 export async function updateQuote(
   id,
-  { customer_id, job_id, total_amount, status }
+  { customer_id, fleet_id, job_id, total_amount, status }
 ) {
   await pool.query(
     `UPDATE quotes SET
        customer_id=?,
+       fleet_id=?,
        job_id=?,
        total_amount=?,
        status=?
      WHERE id=?`,
-    [customer_id || null, job_id || null, total_amount || null, status || null, id]
+    [
+      customer_id || null,
+      fleet_id || null,
+      job_id || null,
+      total_amount || null,
+      status || null,
+      id,
+    ]
   );
   return { ok: true };
 }

--- a/services/vehiclesService.js
+++ b/services/vehiclesService.js
@@ -1,12 +1,14 @@
 import pool from '../lib/db.js';
 
-export async function getAllVehicles(customer_id) {
+export async function getAllVehicles(customer_id, fleet_id) {
   const base = `SELECT v.id, v.licence_plate, v.make, v.model, v.color, v.customer_id, v.fleet_id,
                        CONCAT(c.first_name, ' ', c.last_name) AS customer_name
                   FROM vehicles v
              LEFT JOIN clients c ON v.customer_id=c.id`;
   const [rows] = customer_id
     ? await pool.query(`${base} WHERE v.customer_id=? ORDER BY v.id`, [customer_id])
+    : fleet_id
+    ? await pool.query(`${base} WHERE v.fleet_id=? ORDER BY v.id`, [fleet_id])
     : await pool.query(`${base} ORDER BY v.id`);
   return rows;
 }


### PR DESCRIPTION
## Summary
- add migration for `quotes.fleet_id`
- update vehicles service/API to filter by fleet
- extend quotes service to save fleet ID
- fetch fleets and add Client/Fleet toggle on new quote page
- update related unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860a2a60244832a890d69e87e48a012