### PR TITLE
Improve quote item entry

### DIFF
--- a/components/PartAutocomplete.js
+++ b/components/PartAutocomplete.js
@@ -1,9 +1,13 @@
 import { useState, useEffect } from 'react';
 
-export default function PartAutocomplete({ onSelect }) {
-  const [term, setTerm] = useState('');
+export default function PartAutocomplete({ value, onChange, onSelect }) {
+  const [term, setTerm] = useState(value || '');
   const [results, setResults] = useState([]);
   const [showAdd, setShowAdd] = useState(false);
+
+  useEffect(() => {
+    if (value !== undefined) setTerm(value);
+  }, [value]);
 
   useEffect(() => {
     if (!term) return setResults([]);
@@ -45,7 +49,10 @@ export default function PartAutocomplete({ onSelect }) {
       <input
         className="input w-full"
         value={term}
-        onChange={e => setTerm(e.target.value)}
+        onChange={e => {
+          setTerm(e.target.value);
+          onChange && onChange(e.target.value);
+        }}
         placeholder="Part number or description"
       />
       {term && (
@@ -56,7 +63,12 @@ export default function PartAutocomplete({ onSelect }) {
               className="px-2 py-1 cursor-pointer hover:bg-gray-200"
               onClick={() => {
                 onSelect && onSelect(p);
-                setTerm('');
+                if (value === undefined) {
+                  setTerm('');
+                } else {
+                  setTerm(p.part_number);
+                  onChange && onChange(p.part_number);
+                }
                 setResults([]);
               }}
             >

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -5,8 +5,9 @@ import { fetchClients } from '../../../lib/clients';
 import { fetchFleets } from '../../../lib/fleets';
 import { fetchVehicles } from '../../../lib/vehicles';
 import { createQuote } from '../../../lib/quotes';
+import PartAutocomplete from '../../../components/PartAutocomplete';
 
-const emptyItem = { description: '', qty: 1, price: 0 };
+const emptyItem = { part_number: '', description: '', qty: 1, price: 0 };
 
 export default function NewQuotationPage() {
   const router = useRouter();
@@ -156,11 +157,20 @@ export default function NewQuotationPage() {
           </select>
         </div>
         <div>
-          <h2 className="font-semibold mb-2">Items</h2>
+          <h2 className="font-semibold mb-2">Item Details</h2>
           {items.map((it, i) => (
-            <div key={i} className="grid grid-cols-4 gap-2 mb-2">
+            <div key={i} className="grid grid-cols-5 gap-2 mb-2">
+              <PartAutocomplete
+                value={it.part_number}
+                onChange={v => changeItem(i, 'part_number', v)}
+                onSelect={p => {
+                  changeItem(i, 'part_number', p.part_number);
+                  changeItem(i, 'description', p.description || '');
+                  changeItem(i, 'price', p.unit_cost || 0);
+                }}
+              />
               <input
-                className="input col-span-2"
+                className="input"
                 placeholder="Description"
                 value={it.description}
                 onChange={e => changeItem(i, 'description', e.target.value)}
@@ -175,17 +185,23 @@ export default function NewQuotationPage() {
               <input
                 type="number"
                 className="input"
-                placeholder="Price"
+                placeholder="Unit cost"
                 value={it.price}
                 onChange={e => changeItem(i, 'price', e.target.value)}
               />
+              <div className="flex items-center px-2 border rounded bg-gray-50">
+                €{(Number(it.qty) * Number(it.price)).toFixed(2)}
+              </div>
             </div>
           ))}
           <button type="button" onClick={addItem} className="button-secondary px-4">
             Add Item
           </button>
         </div>
-        <p className="font-semibold">Total: €{total.toFixed(2)}</p>
+        <div>
+          <h2 className="font-semibold mb-2">Summary</h2>
+          <p className="font-semibold">Total: €{total.toFixed(2)}</p>
+        </div>
         <button type="submit" className="button">
           Create Quote
         </button>


### PR DESCRIPTION
## Summary
- allow setting part numbers using autocomplete
- show line totals per item and add totals section
- refine `PartAutocomplete` for controlled usage

## Testing
- `npm test` *(fails: cannot find module 'jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a3d6dd94832a944960b25121c7a5