### PR TITLE
Add live screen with job data

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -1,0 +1,6 @@
+export async function fetchJobs() {
+  const res = await fetch('/api/jobs');
+  if (!res.ok) throw new Error('Failed to fetch jobs');
+  return res.json();
+}
+

--- a/pages/api/jobs/index.js
+++ b/pages/api/jobs/index.js
@@ -1,0 +1,15 @@
+import { getAllJobs } from '../../../services/jobsService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const jobs = await getAllJobs();
+      return res.status(200).json(jobs);
+    }
+    res.setHeader('Allow', ['GET']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/office/index.js
+++ b/pages/office/index.js
@@ -122,6 +122,16 @@ function CompanySettingsIcon() {
   );
 }
 
+function LiveScreenIcon() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor" className="mb-2">
+      <path d="M3 4h18v12H3z" />
+      <path d="M8 20h8" />
+      <path d="M12 16v4" />
+    </svg>
+  );
+}
+
 function useCurrentUser() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -305,6 +315,7 @@ export default function OfficeHome() {
           <DashboardCard href="/office/invoices" title="Invoices" Icon={InvoicesIcon} />
           <DashboardCard href="/office/job-cards" title="Job Cards" Icon={JobCardsIcon} />
           <DashboardCard href="/office/job-management" title="Job Management" Icon={JobManagementIcon} />
+          <DashboardCard href="/office/live-screen" title="Live Screen" Icon={LiveScreenIcon} />
           <DashboardCard href="/office/parts" title="Parts" Icon={PartsIcon} />
           <DashboardCard href="/office/quotations" title="Quotations" Icon={QuotationsIcon} />
           <DashboardCard href="/office/reporting" title="Reporting" Icon={ReportingIcon} />

--- a/pages/office/live-screen/index.js
+++ b/pages/office/live-screen/index.js
@@ -1,0 +1,94 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { Layout } from '../../../components/Layout';
+import { fetchQuotes } from '../../../lib/quotes';
+import { fetchJobs } from '../../../lib/jobs';
+import { fetchInvoices } from '../../../lib/invoices';
+
+const LiveScreenPage = () => {
+  const [quotes, setQuotes] = useState([]);
+  const [jobs, setJobs] = useState([]);
+  const [invoices, setInvoices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = () => {
+    setLoading(true);
+    Promise.all([fetchQuotes(), fetchJobs(), fetchInvoices()])
+      .then(([q, j, i]) => {
+        setQuotes(q);
+        setJobs(j);
+        setInvoices(i);
+      })
+      .catch(() => setError('Failed to load data'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const openQuotes = useMemo(
+    () => quotes.filter(q => !['job-card', 'completed', 'invoiced'].includes(q.status)),
+    [quotes]
+  );
+
+  const unpaidInvoices = useMemo(
+    () => invoices.filter(inv => (inv.status || '').toLowerCase() === 'unpaid'),
+    [invoices]
+  );
+
+  const jobStatusCounts = useMemo(() => {
+    const counts = {};
+    jobs.forEach(j => {
+      const s = j.status || 'unknown';
+      counts[s] = (counts[s] || 0) + 1;
+    });
+    return counts;
+  }, [jobs]);
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Live Screen</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      {loading ? (
+        <p>Loading…</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-3">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-4 shadow">
+            <h2 className="text-lg font-semibold mb-2">
+              Open Quotes ({openQuotes.length})
+            </h2>
+            <ul className="space-y-1 max-h-60 overflow-y-auto">
+              {openQuotes.map(q => (
+                <li key={q.id}>Quote #{q.id} – {q.status}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-4 shadow">
+            <h2 className="text-lg font-semibold mb-2">Jobs</h2>
+            <ul className="space-y-1">
+              {Object.entries(jobStatusCounts).map(([s, c]) => (
+                <li key={s} className="capitalize">{s}: {c}</li>
+              ))}
+            </ul>
+            <ul className="space-y-1 max-h-60 overflow-y-auto mt-2">
+              {jobs.map(j => (
+                <li key={j.id}>Job #{j.id} – {j.status}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-4 shadow">
+            <h2 className="text-lg font-semibold mb-2">
+              Unpaid Invoices ({unpaidInvoices.length})
+            </h2>
+            <ul className="space-y-1 max-h-60 overflow-y-auto">
+              {unpaidInvoices.map(inv => (
+                <li key={inv.id}>Invoice #{inv.id}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+};
+
+export default LiveScreenPage;


### PR DESCRIPTION
## Summary
- add live-screen page in office section
- fetch jobs via new API
- show live counts for quotes, jobs and invoices
- link to Live Screen from the office navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860a8f7b178832a957e39f34a5e2d2d