### PR TITLE
Add office reporting dashboard

### DIFF
--- a/__tests__/reporting-api.test.js
+++ b/__tests__/reporting-api.test.js
@@ -1,0 +1,148 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('finance report endpoint returns data', async () => {
+  const report = { invoice_count: 1 };
+  const getMock = jest.fn().mockResolvedValue(report);
+  jest.unstable_mockModule('../services/reportingService.js', () => ({
+    getFinanceReport: getMock,
+    getEngineerPerformanceReport: jest.fn(),
+    getBusinessPerformanceReport: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/reporting/finance.js');
+  const req = { method: 'GET', query: { start: 'a', end: 'b' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(report);
+  expect(getMock).toHaveBeenCalledWith('a', 'b');
+});
+
+test('finance report endpoint rejects method', async () => {
+  jest.unstable_mockModule('../services/reportingService.js', () => ({
+    getFinanceReport: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/reporting/finance.js');
+  const req = { method: 'POST', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('finance report endpoint handles errors', async () => {
+  const err = new Error('fail');
+  const getMock = jest.fn().mockRejectedValue(err);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/reportingService.js', () => ({
+    getFinanceReport: getMock,
+  }));
+  const { default: handler } = await import('../pages/api/reporting/finance.js');
+  const req = { method: 'GET', query: { start: 'a', end: 'b' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+
+// engineer performance
+
+test('engineer performance endpoint returns data', async () => {
+  const report = [{ username: 'a', hours: 1 }];
+  const getMock = jest.fn().mockResolvedValue(report);
+  jest.unstable_mockModule('../services/reportingService.js', () => ({
+    getEngineerPerformanceReport: getMock,
+    getFinanceReport: jest.fn(),
+    getBusinessPerformanceReport: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/reporting/engineer-performance.js');
+  const req = { method: 'GET', query: { start: 's', end: 'e' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(report);
+  expect(getMock).toHaveBeenCalledWith('s', 'e');
+});
+
+test('engineer performance endpoint rejects method', async () => {
+  jest.unstable_mockModule('../services/reportingService.js', () => ({
+    getEngineerPerformanceReport: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/reporting/engineer-performance.js');
+  const req = { method: 'POST', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('engineer performance endpoint handles errors', async () => {
+  const err = new Error('boom');
+  const getMock = jest.fn().mockRejectedValue(err);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/reportingService.js', () => ({
+    getEngineerPerformanceReport: getMock,
+  }));
+  const { default: handler } = await import('../pages/api/reporting/engineer-performance.js');
+  const req = { method: 'GET', query: { start: 's', end: 'e' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});
+
+// business performance
+
+test('business performance endpoint returns data', async () => {
+  const report = { jobs_created: 1 };
+  const getMock = jest.fn().mockResolvedValue(report);
+  jest.unstable_mockModule('../services/reportingService.js', () => ({
+    getBusinessPerformanceReport: getMock,
+    getFinanceReport: jest.fn(),
+    getEngineerPerformanceReport: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/reporting/business-performance.js');
+  const req = { method: 'GET', query: { start: 's', end: 'e' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(report);
+  expect(getMock).toHaveBeenCalledWith('s', 'e');
+});
+
+test('business performance endpoint rejects method', async () => {
+  jest.unstable_mockModule('../services/reportingService.js', () => ({
+    getBusinessPerformanceReport: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/reporting/business-performance.js');
+  const req = { method: 'POST', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('business performance endpoint handles errors', async () => {
+  const err = new Error('bad');
+  const getMock = jest.fn().mockRejectedValue(err);
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/reportingService.js', () => ({
+    getBusinessPerformanceReport: getMock,
+  }));
+  const { default: handler } = await import('../pages/api/reporting/business-performance.js');
+  const req = { method: 'GET', query: { start: 's', end: 'e' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});

--- a/__tests__/reportingService.test.js
+++ b/__tests__/reportingService.test.js
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('getFinanceReport runs query', async () => {
+  const row = { invoice_count: 2 };
+  const queryMock = jest.fn().mockResolvedValue([[row]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getFinanceReport } = await import('../services/reportingService.js');
+  const result = await getFinanceReport('a', 'b');
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/FROM invoices/), ['a', 'b']);
+  expect(result).toEqual(row);
+});
+
+test('getEngineerPerformanceReport runs query', async () => {
+  const rows = [{ username: 'x', hours: 1 }];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getEngineerPerformanceReport } = await import('../services/reportingService.js');
+  const result = await getEngineerPerformanceReport('s', 'e');
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/FROM time_entries/), ['s', 'e']);
+  expect(result).toEqual(rows);
+});
+
+test('getBusinessPerformanceReport runs query', async () => {
+  const row = { jobs_created: 1 };
+  const queryMock = jest.fn().mockResolvedValue([[row]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getBusinessPerformanceReport } = await import('../services/reportingService.js');
+  const result = await getBusinessPerformanceReport('s', 'e');
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/FROM jobs/), ['s', 'e']);
+  expect(result).toEqual(row);
+});

--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -1,0 +1,17 @@
+export async function fetchFinanceReport(start, end) {
+  const res = await fetch(`/api/reporting/finance?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`);
+  if (!res.ok) throw new Error('Failed to fetch finance report');
+  return res.json();
+}
+
+export async function fetchEngineerPerformance(start, end) {
+  const res = await fetch(`/api/reporting/engineer-performance?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`);
+  if (!res.ok) throw new Error('Failed to fetch engineer performance');
+  return res.json();
+}
+
+export async function fetchBusinessPerformance(start, end) {
+  const res = await fetch(`/api/reporting/business-performance?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`);
+  if (!res.ok) throw new Error('Failed to fetch business performance');
+  return res.json();
+}

--- a/pages/api/reporting/business-performance.js
+++ b/pages/api/reporting/business-performance.js
@@ -1,0 +1,16 @@
+import { getBusinessPerformanceReport } from '../../../services/reportingService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method !== 'GET') {
+      res.setHeader('Allow', ['GET']);
+      return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+    const { start, end } = req.query;
+    const report = await getBusinessPerformanceReport(start, end);
+    return res.status(200).json(report);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/reporting/engineer-performance.js
+++ b/pages/api/reporting/engineer-performance.js
@@ -1,0 +1,16 @@
+import { getEngineerPerformanceReport } from '../../../services/reportingService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method !== 'GET') {
+      res.setHeader('Allow', ['GET']);
+      return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+    const { start, end } = req.query;
+    const report = await getEngineerPerformanceReport(start, end);
+    return res.status(200).json(report);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/reporting/finance.js
+++ b/pages/api/reporting/finance.js
@@ -1,0 +1,16 @@
+import { getFinanceReport } from '../../../services/reportingService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method !== 'GET') {
+      res.setHeader('Allow', ['GET']);
+      return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+    const { start, end } = req.query;
+    const report = await getFinanceReport(start, end);
+    return res.status(200).json(report);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/office/reporting/index.js
+++ b/pages/office/reporting/index.js
@@ -1,11 +1,149 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Layout } from '../../../components/Layout';
+import { fetchFinanceReport, fetchEngineerPerformance, fetchBusinessPerformance } from '../../../lib/reporting';
 
-const ReportingPage = () => (
-  <Layout>
-    <h1 className="text-xl font-semibold">Reporting</h1>
-    {/* TODO: Dashboard charts and metrics */}
-  </Layout>
-);
+function formatDate(d) {
+  return d.toISOString().substring(0, 10);
+}
+
+const ReportingPage = () => {
+  const [range, setRange] = useState('today');
+  const [customStart, setCustomStart] = useState(formatDate(new Date()));
+  const [customEnd, setCustomEnd] = useState(formatDate(new Date()));
+  const [finance, setFinance] = useState(null);
+  const [engineers, setEngineers] = useState([]);
+  const [business, setBusiness] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  function computeDates() {
+    const now = new Date();
+    let start, end;
+    if (range === 'today') {
+      start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      end = new Date(start);
+      end.setDate(start.getDate() + 1);
+    } else if (range === 'week') {
+      const day = (now.getDay() + 6) % 7;
+      start = new Date(now);
+      start.setDate(now.getDate() - day);
+      start.setHours(0, 0, 0, 0);
+      end = new Date(start);
+      end.setDate(start.getDate() + 7);
+    } else if (range === 'month') {
+      start = new Date(now.getFullYear(), now.getMonth(), 1);
+      end = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    } else {
+      if (!customStart || !customEnd) return null;
+      start = new Date(customStart);
+      end = new Date(customEnd);
+      end.setDate(end.getDate() + 1);
+    }
+    return { start: start.toISOString(), end: end.toISOString() };
+  }
+
+  useEffect(() => {
+    const dates = computeDates();
+    if (!dates) return;
+    setLoading(true);
+    Promise.all([
+      fetchFinanceReport(dates.start, dates.end),
+      fetchEngineerPerformance(dates.start, dates.end),
+      fetchBusinessPerformance(dates.start, dates.end),
+    ])
+      .then(([fin, eng, biz]) => {
+        setFinance(fin);
+        setEngineers(eng);
+        setBusiness(biz);
+        setError(null);
+      })
+      .catch(err => {
+        console.error(err);
+        setError('Failed to load reports');
+      })
+      .finally(() => setLoading(false));
+  }, [range, customStart, customEnd]);
+
+  return (
+    <Layout>
+      <h1 className="text-xl font-semibold mb-4">Reporting</h1>
+      <div className="mb-6 space-x-2">
+        <select value={range} onChange={e => setRange(e.target.value)} className="input inline-block w-auto">
+          <option value="today">Today</option>
+          <option value="week">This Week</option>
+          <option value="month">This Month</option>
+          <option value="custom">Custom</option>
+        </select>
+        {range === 'custom' && (
+          <>
+            <input type="date" value={customStart} onChange={e => setCustomStart(e.target.value)} className="input inline-block w-auto" />
+            <input type="date" value={customEnd} onChange={e => setCustomEnd(e.target.value)} className="input inline-block w-auto" />
+          </>
+        )}
+      </div>
+      {loading && <p>Loading…</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      {!loading && !error && (
+        <>
+          <h2 className="text-lg font-semibold mt-4 mb-2">Finance</h2>
+          {finance && (
+            <table className="mb-4 table-auto">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1">Invoices</th>
+                  <th className="px-2 py-1">Total</th>
+                  <th className="px-2 py-1">Paid</th>
+                  <th className="px-2 py-1">Unpaid</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="px-2 py-1">{finance.invoice_count}</td>
+                  <td className="px-2 py-1">€{finance.total_amount}</td>
+                  <td className="px-2 py-1">€{finance.total_paid}</td>
+                  <td className="px-2 py-1">€{finance.total_unpaid}</td>
+                </tr>
+              </tbody>
+            </table>
+          )}
+          <h2 className="text-lg font-semibold mt-4 mb-2">Engineer Performance</h2>
+          <table className="mb-4 table-auto">
+            <thead>
+              <tr>
+                <th className="px-2 py-1">Engineer</th>
+                <th className="px-2 py-1">Hours</th>
+              </tr>
+            </thead>
+            <tbody>
+              {engineers.map(e => (
+                <tr key={e.username}>
+                  <td className="px-2 py-1">{e.username}</td>
+                  <td className="px-2 py-1">{e.hours}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <h2 className="text-lg font-semibold mt-4 mb-2">Business Performance</h2>
+          {business && (
+            <table className="mb-4 table-auto">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1">Jobs Created</th>
+                  <th className="px-2 py-1">Jobs Completed</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="px-2 py-1">{business.jobs_created}</td>
+                  <td className="px-2 py-1">{business.jobs_completed}</td>
+                </tr>
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </Layout>
+  );
+};
 
 export default ReportingPage;

--- a/services/reportingService.js
+++ b/services/reportingService.js
@@ -1,0 +1,39 @@
+import pool from '../lib/db.js';
+
+export async function getFinanceReport(start, end) {
+  const [[row]] = await pool.query(
+    `SELECT COUNT(*) AS invoice_count,
+            COALESCE(SUM(amount),0) AS total_amount,
+            COALESCE(SUM(CASE WHEN status='paid' THEN amount END),0) AS total_paid,
+            COALESCE(SUM(CASE WHEN status='unpaid' THEN amount END),0) AS total_unpaid
+       FROM invoices
+      WHERE created_ts >= ? AND created_ts < ?`,
+    [start, end]
+  );
+  return row || { invoice_count: 0, total_amount: 0, total_paid: 0, total_unpaid: 0 };
+}
+
+export async function getEngineerPerformanceReport(start, end) {
+  const [rows] = await pool.query(
+    `SELECT u.username,
+            ROUND(SUM(TIME_TO_SEC(te.duration))/3600, 2) AS hours
+       FROM time_entries te
+       JOIN users u ON te.user_id = u.id
+      WHERE te.start_ts >= ? AND te.start_ts < ?
+   GROUP BY te.user_id
+   ORDER BY hours DESC`,
+    [start, end]
+  );
+  return rows;
+}
+
+export async function getBusinessPerformanceReport(start, end) {
+  const [[row]] = await pool.query(
+    `SELECT COUNT(*) AS jobs_created,
+            SUM(status='completed') AS jobs_completed
+       FROM jobs
+      WHERE created_at >= ? AND created_at < ?`,
+    [start, end]
+  );
+  return row || { jobs_created: 0, jobs_completed: 0 };
+}


### PR DESCRIPTION
## Summary
- build office reporting page with finance, engineer, and business reports
- add reporting service and API endpoints
- expose functions to fetch reporting info client-side
- test new API routes and service logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860aac08e44832ab3dab15dcbf652d7