### PR TITLE
Add fleet/local portals and job requests

### DIFF
--- a/migrations/20251205_create_job_requests.sql
+++ b/migrations/20251205_create_job_requests.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS job_requests (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  fleet_id INT,
+  client_id INT,
+  vehicle_id INT,
+  description TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_job_requests_fleet FOREIGN KEY (fleet_id) REFERENCES fleets(id),
+  CONSTRAINT fk_job_requests_client FOREIGN KEY (client_id) REFERENCES clients(id),
+  CONSTRAINT fk_job_requests_vehicle FOREIGN KEY (vehicle_id) REFERENCES vehicles(id)
+);

--- a/pages/api/invoices/index.js
+++ b/pages/api/invoices/index.js
@@ -1,13 +1,22 @@
-import { getAllInvoices, createInvoice } from '../../../services/invoicesService.js';
+import * as service from '../../../services/invoicesService.js';
 
 export default async function handler(req, res) {
   try {
     if (req.method === 'GET') {
-      const invoices = await getAllInvoices();
+      const { customer_id, fleet_id, status } = req.query || {};
+      if (fleet_id) {
+        const rows = await service.getInvoicesByFleet?.(fleet_id, status) ?? [];
+        return res.status(200).json(rows);
+      }
+      if (customer_id) {
+        const rows = await service.getInvoicesByCustomer?.(customer_id, status) ?? [];
+        return res.status(200).json(rows);
+      }
+      const invoices = await service.getAllInvoices();
       return res.status(200).json(invoices);
     }
     if (req.method === 'POST') {
-      const newInvoice = await createInvoice(req.body);
+      const newInvoice = await service.createInvoice(req.body);
       return res.status(201).json(newInvoice);
     }
     res.setHeader('Allow', ['GET','POST']);

--- a/pages/api/job-requests/index.js
+++ b/pages/api/job-requests/index.js
@@ -1,0 +1,37 @@
+import { createJobRequest, getAllJobRequests } from '../../../services/jobRequestsService.js';
+import { verifyToken } from '../../../lib/auth.js';
+import { parse } from 'cookie';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const requests = await getAllJobRequests();
+      return res.status(200).json(requests);
+    }
+    if (req.method === 'POST') {
+      const cookies = parse(req.headers.cookie || '');
+      const token = cookies.fleet_token || cookies.local_token;
+      if (!token) return res.status(401).json({ error: 'Unauthorized' });
+      let payload;
+      try {
+        payload = verifyToken(token);
+      } catch {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      const { vehicle_id, description } = req.body || {};
+      const data = {
+        fleet_id: payload.fleet_id || null,
+        client_id: payload.client_id || null,
+        vehicle_id,
+        description,
+      };
+      const reqRec = await createJobRequest(data);
+      return res.status(201).json(reqRec);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/jobs/index.js
+++ b/pages/api/jobs/index.js
@@ -1,9 +1,18 @@
-import { getAllJobs } from '../../../services/jobsService.js';
+import * as service from '../../../services/jobsService.js';
 
 export default async function handler(req, res) {
   try {
     if (req.method === 'GET') {
-      const jobs = await getAllJobs();
+      const { fleet_id, customer_id } = req.query || {};
+      if (fleet_id) {
+        const jobs = await service.getJobsByFleet?.(fleet_id) ?? [];
+        return res.status(200).json(jobs);
+      }
+      if (customer_id) {
+        const jobs = await service.getJobsByCustomer?.(customer_id) ?? [];
+        return res.status(200).json(jobs);
+      }
+      const jobs = await service.getAllJobs();
       return res.status(200).json(jobs);
     }
     res.setHeader('Allow', ['GET']);

--- a/pages/api/portal/fleet/login.js
+++ b/pages/api/portal/fleet/login.js
@@ -1,0 +1,12 @@
+import pool from '../../../../lib/db';
+import { signToken } from '../../../../lib/auth';
+
+export default async function handler(req, res) {
+  const { company_name } = req.body || {};
+  const [rows] = await pool.query('SELECT id FROM fleets WHERE company_name=?', [company_name]);
+  if (!rows.length) return res.status(401).json({ error: 'Invalid credentials' });
+  const token = signToken({ fleet_id: rows[0].id });
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+  res.setHeader('Set-Cookie', `fleet_token=${token}; HttpOnly; Path=/; Max-Age=3600; SameSite=Strict${secure}`);
+  res.status(200).json({ ok: true });
+}

--- a/pages/api/portal/fleet/me.js
+++ b/pages/api/portal/fleet/me.js
@@ -1,0 +1,17 @@
+import pool from '../../../../lib/db';
+import { verifyToken } from '../../../../lib/auth';
+import { parse } from 'cookie';
+
+export default async function handler(req, res) {
+  const cookies = parse(req.headers.cookie || '');
+  if (!cookies.fleet_token) return res.status(401).json({ error: 'Unauthorized' });
+  let payload;
+  try {
+    payload = verifyToken(cookies.fleet_token);
+  } catch {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const [[row]] = await pool.query('SELECT id, company_name FROM fleets WHERE id=?', [payload.fleet_id]);
+  if (!row) return res.status(404).json({ error: 'Not found' });
+  res.status(200).json(row);
+}

--- a/pages/api/portal/local/login.js
+++ b/pages/api/portal/local/login.js
@@ -1,0 +1,12 @@
+import pool from '../../../../lib/db';
+import { signToken } from '../../../../lib/auth';
+
+export default async function handler(req, res) {
+  const { email } = req.body || {};
+  const [rows] = await pool.query('SELECT id FROM clients WHERE email=?', [email]);
+  if (!rows.length) return res.status(401).json({ error: 'Invalid credentials' });
+  const token = signToken({ client_id: rows[0].id });
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+  res.setHeader('Set-Cookie', `local_token=${token}; HttpOnly; Path=/; Max-Age=3600; SameSite=Strict${secure}`);
+  res.status(200).json({ ok: true });
+}

--- a/pages/api/portal/local/me.js
+++ b/pages/api/portal/local/me.js
@@ -1,0 +1,20 @@
+import pool from '../../../../lib/db';
+import { verifyToken } from '../../../../lib/auth';
+import { parse } from 'cookie';
+
+export default async function handler(req, res) {
+  const cookies = parse(req.headers.cookie || '');
+  if (!cookies.local_token) return res.status(401).json({ error: 'Unauthorized' });
+  let payload;
+  try {
+    payload = verifyToken(cookies.local_token);
+  } catch {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const [[row]] = await pool.query(
+    'SELECT id, first_name, last_name, email FROM clients WHERE id=?',
+    [payload.client_id]
+  );
+  if (!row) return res.status(404).json({ error: 'Not found' });
+  res.status(200).json(row);
+}

--- a/pages/api/quotes/index.js
+++ b/pages/api/quotes/index.js
@@ -1,13 +1,22 @@
-import { getAllQuotes, createQuote } from '../../../services/quotesService.js';
+import * as service from '../../../services/quotesService.js';
 
 export default async function handler(req, res) {
   try {
     if (req.method === 'GET') {
-      const quotes = await getAllQuotes();
+      const { fleet_id, customer_id } = req.query || {};
+      if (fleet_id) {
+        const rows = await service.getQuotesByFleet?.(fleet_id) ?? [];
+        return res.status(200).json(rows);
+      }
+      if (customer_id) {
+        const rows = await service.getQuotesByCustomer?.(customer_id) ?? [];
+        return res.status(200).json(rows);
+      }
+      const quotes = await service.getAllQuotes();
       return res.status(200).json(quotes);
     }
     if (req.method === 'POST') {
-      const newQuote = await createQuote(req.body);
+      const newQuote = await service.createQuote(req.body);
       return res.status(201).json(newQuote);
     }
     res.setHeader('Allow', ['GET','POST']);

--- a/pages/fleet/index.js
+++ b/pages/fleet/index.js
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { fetchVehicles } from '../../lib/vehicles';
+import { fetchQuotes, updateQuote } from '../../lib/quotes';
+import { fetchInvoices } from '../../lib/invoices';
+
+export default function FleetDashboard() {
+  const router = useRouter();
+  const [fleet, setFleet] = useState(null);
+  const [vehicles, setVehicles] = useState([]);
+  const [jobs, setJobs] = useState([]);
+  const [quotes, setQuotes] = useState([]);
+  const [invoices, setInvoices] = useState([]);
+  const [filter, setFilter] = useState('all');
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/fleet/me');
+      if (!res.ok) return router.replace('/fleet/login');
+      const f = await res.json();
+      setFleet(f);
+      const [veh, j, q, inv] = await Promise.all([
+        fetchVehicles(null, f.id),
+        fetch(`/api/jobs?fleet_id=${f.id}`).then(r => r.json()),
+        fetch(`/api/quotes?fleet_id=${f.id}`).then(r => r.json()),
+        fetch(`/api/invoices?fleet_id=${f.id}`).then(r => r.json()),
+      ]);
+      setVehicles(veh);
+      setJobs(j);
+      setQuotes(q);
+      setInvoices(inv);
+    })();
+  }, [router]);
+
+  async function acceptQuote(id) {
+    await updateQuote(id, { status: 'accepted' });
+    setQuotes(quotes.map(q => (q.id === id ? { ...q, status: 'accepted' } : q)));
+  }
+
+  const invFiltered = invoices.filter(i =>
+    filter === 'all' ? true : i.status === filter
+  );
+
+  if (!fleet) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="p-8 space-y-6">
+      <h1 className="text-2xl font-bold">{fleet.company_name} Dashboard</h1>
+      <Link href="/fleet/request-job" className="button">New Job Request</Link>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Vehicles</h2>
+        <ul className="list-disc ml-6">
+          {vehicles.map(v => (
+            <li key={v.id}>{v.licence_plate} {v.make} {v.model}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Open Jobs</h2>
+        <ul className="list-disc ml-6">
+          {jobs.map(j => (
+            <li key={j.id}>Job #{j.id} - {j.status}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Quotes</h2>
+        <ul className="list-disc ml-6">
+          {quotes.map(q => (
+            <li key={q.id} className="mb-1">
+              Quote #{q.id} - {q.status}
+              {q.status !== 'accepted' && (
+                <button onClick={() => acceptQuote(q.id)} className="ml-2 underline">
+                  Accept
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Invoices</h2>
+        <select value={filter} onChange={e => setFilter(e.target.value)} className="input mb-2">
+          <option value="all">All</option>
+          <option value="paid">Paid</option>
+          <option value="unpaid">Unpaid</option>
+        </select>
+        <ul className="list-disc ml-6">
+          {invFiltered.map(inv => (
+            <li key={inv.id}>Invoice #{inv.id} - {inv.status}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/pages/fleet/login.js
+++ b/pages/fleet/login.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function FleetLogin() {
+  const router = useRouter();
+  const [company, setCompany] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const res = await fetch('/api/portal/fleet/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ company_name: company }),
+    });
+    if (res.ok) {
+      router.push('/fleet');
+    } else {
+      setError('Login failed');
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white/20 p-8 rounded-xl shadow-xl">
+        <h1 className="text-2xl font-bold mb-2 text-center">Fleet Login</h1>
+        {error && <p className="text-red-300">{error}</p>}
+        <input
+          type="text"
+          placeholder="Company Name"
+          className="input w-full"
+          value={company}
+          onChange={e => setCompany(e.target.value)}
+        />
+        <button type="submit" className="button w-full">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/fleet/request-job.js
+++ b/pages/fleet/request-job.js
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { fetchVehicles } from '../../lib/vehicles';
+
+export default function FleetRequestJob() {
+  const router = useRouter();
+  const [fleet, setFleet] = useState(null);
+  const [vehicles, setVehicles] = useState([]);
+  const [vehicleId, setVehicleId] = useState('');
+  const [description, setDescription] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/fleet/me');
+      if (!res.ok) return router.replace('/fleet/login');
+      const f = await res.json();
+      setFleet(f);
+      const veh = await fetchVehicles(null, f.id);
+      setVehicles(veh);
+    })();
+  }, [router]);
+
+  async function submit(e) {
+    e.preventDefault();
+    const res = await fetch('/api/job-requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ vehicle_id: vehicleId, description }),
+    });
+    if (res.ok) {
+      setMessage('Request submitted');
+      setVehicleId('');
+      setDescription('');
+    }
+  }
+
+  if (!fleet) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">New Job Request</h1>
+      {message && <p className="text-green-600 mb-2">{message}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-sm">
+        <select value={vehicleId} onChange={e => setVehicleId(e.target.value)} className="input w-full" required>
+          <option value="">Select Vehicle</option>
+          {vehicles.map(v => (
+            <option key={v.id} value={v.id}>{v.licence_plate}</option>
+          ))}
+        </select>
+        <textarea
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          className="input w-full"
+          placeholder="Description"
+        />
+        <button type="submit" className="button">Submit</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/local/index.js
+++ b/pages/local/index.js
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { fetchVehicles } from '../../lib/vehicles';
+import { fetchQuotes, updateQuote } from '../../lib/quotes';
+import { fetchInvoices } from '../../lib/invoices';
+
+export default function LocalDashboard() {
+  const router = useRouter();
+  const [client, setClient] = useState(null);
+  const [vehicles, setVehicles] = useState([]);
+  const [jobs, setJobs] = useState([]);
+  const [quotes, setQuotes] = useState([]);
+  const [invoices, setInvoices] = useState([]);
+  const [filter, setFilter] = useState('all');
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/local/me');
+      if (!res.ok) return router.replace('/local/login');
+      const c = await res.json();
+      setClient(c);
+      const [veh, j, q, inv] = await Promise.all([
+        fetchVehicles(c.id, null),
+        fetch(`/api/jobs?customer_id=${c.id}`).then(r => r.json()),
+        fetch(`/api/quotes?customer_id=${c.id}`).then(r => r.json()),
+        fetch(`/api/invoices?customer_id=${c.id}`).then(r => r.json()),
+      ]);
+      setVehicles(veh);
+      setJobs(j);
+      setQuotes(q);
+      setInvoices(inv);
+    })();
+  }, [router]);
+
+  async function acceptQuote(id) {
+    await updateQuote(id, { status: 'accepted' });
+    setQuotes(quotes.map(q => (q.id === id ? { ...q, status: 'accepted' } : q)));
+  }
+
+  const invFiltered = invoices.filter(i =>
+    filter === 'all' ? true : i.status === filter
+  );
+
+  if (!client) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="p-8 space-y-6">
+      <h1 className="text-2xl font-bold">Welcome {client.first_name}</h1>
+      <Link href="/local/request-job" className="button">New Job Request</Link>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Vehicles</h2>
+        <ul className="list-disc ml-6">
+          {vehicles.filter(v => !v.fleet_id).map(v => (
+            <li key={v.id}>{v.licence_plate} {v.make} {v.model}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Open Jobs</h2>
+        <ul className="list-disc ml-6">
+          {jobs.map(j => (
+            <li key={j.id}>Job #{j.id} - {j.status}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Quotes</h2>
+        <ul className="list-disc ml-6">
+          {quotes.map(q => (
+            <li key={q.id} className="mb-1">
+              Quote #{q.id} - {q.status}
+              {q.status !== 'accepted' && (
+                <button onClick={() => acceptQuote(q.id)} className="ml-2 underline">
+                  Accept
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Invoices</h2>
+        <select value={filter} onChange={e => setFilter(e.target.value)} className="input mb-2">
+          <option value="all">All</option>
+          <option value="paid">Paid</option>
+          <option value="unpaid">Unpaid</option>
+        </select>
+        <ul className="list-disc ml-6">
+          {invFiltered.map(inv => (
+            <li key={inv.id}>Invoice #{inv.id} - {inv.status}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/pages/local/login.js
+++ b/pages/local/login.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function LocalLogin() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const res = await fetch('/api/portal/local/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    if (res.ok) {
+      router.push('/local');
+    } else {
+      setError('Login failed');
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white/20 p-8 rounded-xl shadow-xl">
+        <h1 className="text-2xl font-bold mb-2 text-center">Client Login</h1>
+        {error && <p className="text-red-300">{error}</p>}
+        <input
+          type="email"
+          placeholder="Email"
+          className="input w-full"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <button type="submit" className="button w-full">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/local/request-job.js
+++ b/pages/local/request-job.js
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { fetchVehicles } from '../../lib/vehicles';
+
+export default function LocalRequestJob() {
+  const router = useRouter();
+  const [client, setClient] = useState(null);
+  const [vehicles, setVehicles] = useState([]);
+  const [vehicleId, setVehicleId] = useState('');
+  const [description, setDescription] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/local/me');
+      if (!res.ok) return router.replace('/local/login');
+      const c = await res.json();
+      setClient(c);
+      const veh = await fetchVehicles(c.id, null);
+      setVehicles(veh.filter(v => !v.fleet_id));
+    })();
+  }, [router]);
+
+  async function submit(e) {
+    e.preventDefault();
+    const res = await fetch('/api/job-requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ vehicle_id: vehicleId, description }),
+    });
+    if (res.ok) {
+      setMessage('Request submitted');
+      setVehicleId('');
+      setDescription('');
+    }
+  }
+
+  if (!client) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">New Job Request</h1>
+      {message && <p className="text-green-600 mb-2">{message}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-sm">
+        <select value={vehicleId} onChange={e => setVehicleId(e.target.value)} className="input w-full" required>
+          <option value="">Select Vehicle</option>
+          {vehicles.map(v => (
+            <option key={v.id} value={v.id}>{v.licence_plate}</option>
+          ))}
+        </select>
+        <textarea
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          className="input w-full"
+          placeholder="Description"
+        />
+        <button type="submit" className="button">Submit</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/office/index.js
+++ b/pages/office/index.js
@@ -315,6 +315,7 @@ export default function OfficeHome() {
           <DashboardCard href="/office/invoices" title="Invoices" Icon={InvoicesIcon} />
           <DashboardCard href="/office/job-cards" title="Job Cards" Icon={JobCardsIcon} />
           <DashboardCard href="/office/job-management" title="Job Management" Icon={JobManagementIcon} />
+          <DashboardCard href="/office/job-requests" title="Job Requests" Icon={JobManagementIcon} />
           <DashboardCard href="/office/live-screen" title="Live Screen" Icon={LiveScreenIcon} />
           <DashboardCard href="/office/parts" title="Parts" Icon={PartsIcon} />
           <DashboardCard href="/office/quotations" title="Quotations" Icon={QuotationsIcon} />

--- a/pages/office/job-requests/index.js
+++ b/pages/office/job-requests/index.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Layout } from '../../../components/Layout';
+
+export default function JobRequestsPage() {
+  const [requests, setRequests] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/job-requests')
+      .then(r => r.json())
+      .then(setRequests)
+      .catch(() => setRequests([]));
+  }, []);
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Job Requests</h1>
+      <Link href="/office" className="button mb-4 inline-block">Return to Office</Link>
+      <ul className="space-y-2">
+        {requests.map(r => (
+          <li key={r.id} className="p-2 rounded bg-gray-100 dark:bg-gray-800">
+            Request #{r.id} - Vehicle {r.vehicle_id} - {r.description}
+          </li>
+        ))}
+      </ul>
+    </Layout>
+  );
+}

--- a/services/invoicesService.js
+++ b/services/invoicesService.js
@@ -8,6 +8,26 @@ export async function getAllInvoices() {
   return rows;
 }
 
+export async function getInvoicesByCustomer(customer_id, status) {
+  const base = `SELECT id, job_id, customer_id, amount, due_date, status, created_ts FROM invoices WHERE customer_id=?`;
+  const [rows] = status
+    ? await pool.query(`${base} AND status=? ORDER BY id`, [customer_id, status])
+    : await pool.query(`${base} ORDER BY id`, [customer_id]);
+  return rows;
+}
+
+export async function getInvoicesByFleet(fleet_id, status) {
+  const base = `SELECT i.id, i.job_id, i.customer_id, i.amount, i.due_date, i.status, i.created_ts
+       FROM invoices i
+       JOIN jobs j ON i.job_id=j.id
+       JOIN vehicles v ON j.vehicle_id=v.id
+      WHERE v.fleet_id=?`;
+  const [rows] = status
+    ? await pool.query(`${base} AND i.status=? ORDER BY i.id`, [fleet_id, status])
+    : await pool.query(`${base} ORDER BY i.id`, [fleet_id]);
+  return rows;
+}
+
 export async function getInvoiceById(id) {
   const [[row]] = await pool.query(
     `SELECT id, job_id, customer_id, amount, due_date, status, created_ts

--- a/services/jobRequestsService.js
+++ b/services/jobRequestsService.js
@@ -1,0 +1,18 @@
+import pool from '../lib/db.js';
+
+export async function createJobRequest({ fleet_id, client_id, vehicle_id, description }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO job_requests (fleet_id, client_id, vehicle_id, description)
+     VALUES (?,?,?,?)`,
+    [fleet_id || null, client_id || null, vehicle_id || null, description || null]
+  );
+  return { id: insertId, fleet_id, client_id, vehicle_id, description };
+}
+
+export async function getAllJobRequests() {
+  const [rows] = await pool.query(
+    `SELECT id, fleet_id, client_id, vehicle_id, description, created_at
+       FROM job_requests ORDER BY id DESC`
+  );
+  return rows;
+}

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -8,6 +8,27 @@ export async function getAllJobs() {
   return rows;
 }
 
+export async function getJobsByFleet(fleet_id) {
+  const [rows] = await pool.query(
+    `SELECT j.id, j.customer_id, j.vehicle_id, j.scheduled_start, j.scheduled_end, j.status, j.bay, j.created_at
+       FROM jobs j
+       JOIN vehicles v ON j.vehicle_id = v.id
+      WHERE v.fleet_id=?
+      ORDER BY j.id`,
+    [fleet_id]
+  );
+  return rows;
+}
+
+export async function getJobsByCustomer(customer_id) {
+  const [rows] = await pool.query(
+    `SELECT id, customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay, created_at
+       FROM jobs WHERE customer_id=? ORDER BY id`,
+    [customer_id]
+  );
+  return rows;
+}
+
 export async function getJobById(id) {
   const [[row]] = await pool.query(
     `SELECT id, customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay, created_at

--- a/services/quotesService.js
+++ b/services/quotesService.js
@@ -8,6 +8,24 @@ export async function getAllQuotes() {
   return rows;
 }
 
+export async function getQuotesByFleet(fleet_id) {
+  const [rows] = await pool.query(
+    `SELECT id, customer_id, fleet_id, job_id, total_amount, status, created_ts
+       FROM quotes WHERE fleet_id=? ORDER BY id`,
+    [fleet_id]
+  );
+  return rows;
+}
+
+export async function getQuotesByCustomer(customer_id) {
+  const [rows] = await pool.query(
+    `SELECT id, customer_id, fleet_id, job_id, total_amount, status, created_ts
+       FROM quotes WHERE customer_id=? ORDER BY id`,
+    [customer_id]
+  );
+  return rows;
+}
+
 export async function getQuoteById(id) {
   const [[row]] = await pool.query(
     `SELECT id, customer_id, fleet_id, job_id, total_amount, status, created_ts


### PR DESCRIPTION
## Summary
- add DB migration and service for job request submissions
- expose job request API with token-based auth
- implement fleet and local portals with dashboards
- allow vehicle owners to submit job requests
- display job requests in office dashboard
- support filtering in quotes, jobs, and invoices APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860ac9f8f8c832ab0134c27365ec719