### PR TITLE
Add auth check for job-requests API

### DIFF
--- a/__tests__/job-requests-api.test.js
+++ b/__tests__/job-requests-api.test.js
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// GET unauthorized
+
+test('job requests index returns 401 when unauthenticated', async () => {
+  jest.unstable_mockModule('../services/jobRequestsService.js', () => ({
+    getAllJobRequests: jest.fn(),
+    createJobRequest: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => null,
+    verifyToken: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/job-requests/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(401);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+});
+
+// GET success
+
+test('job requests index returns requests when authenticated', async () => {
+  const rows = [{ id: 1 }];
+  const listMock = jest.fn().mockResolvedValue(rows);
+  jest.unstable_mockModule('../services/jobRequestsService.js', () => ({
+    getAllJobRequests: listMock,
+    createJobRequest: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 1 }),
+    verifyToken: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/job-requests/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(listMock).toHaveBeenCalledTimes(1);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(rows);
+});

--- a/pages/api/job-requests/index.js
+++ b/pages/api/job-requests/index.js
@@ -1,10 +1,12 @@
 import { createJobRequest, getAllJobRequests } from '../../../services/jobRequestsService.js';
-import { verifyToken } from '../../../lib/auth.js';
+import { verifyToken, getTokenFromReq } from '../../../lib/auth.js';
 import { parse } from 'cookie';
 
 export default async function handler(req, res) {
   try {
     if (req.method === 'GET') {
+      const t = getTokenFromReq(req);
+      if (!t) return res.status(401).json({ error: 'Unauthorized' });
       const requests = await getAllJobRequests();
       return res.status(200).json(requests);
     }

--- a/pages/office/job-requests/index.js
+++ b/pages/office/job-requests/index.js
@@ -6,8 +6,8 @@ export default function JobRequestsPage() {
   const [requests, setRequests] = useState([]);
 
   useEffect(() => {
-    fetch('/api/job-requests')
-      .then(r => r.json())
+    fetch('/api/job-requests', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : Promise.reject()))
       .then(setRequests)
       .catch(() => setRequests([]));
   }, []);


### PR DESCRIPTION
## Summary
- enforce authentication for GET /api/job-requests
- fetch credentials on office job requests page
- cover authorized vs unauthorized access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860b1ee56f4832aa3d401825ccffca7