### PR TITLE
Add fleet sidebar and reorganize dashboard layout

### DIFF
--- a/components/FleetNav.js
+++ b/components/FleetNav.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export function FleetNav() {
+  const links = [
+    { href: '#jobs', label: 'Jobs' },
+    { href: '#quotes', label: 'Quotes' },
+    { href: '#invoices', label: 'Invoices' },
+    { href: '#vehicles', label: 'Vehicles' },
+  ];
+  return (
+    <nav className="fleet-nav">
+      {links.map(link => (
+        <a key={link.href} href={link.href} className="fleet-nav-link">
+          {link.label}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -68,58 +68,63 @@ export function PortalDashboard({
         </select>
       </div>
 
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {filteredVehicles.map(v => (
-          <Card key={v.id} className="hover:shadow-xl transition-shadow">
-            <div className="p-4">
-              <h2 className="text-xl font-medium">{v.licence_plate}</h2>
-              <p className="text-sm text-gray-200">{v.make} {v.model}</p>
-              <Link href={`/vehicles/${v.id}`} className="button-secondary mt-3 inline-block text-center">View Details</Link>
-            </div>
-          </Card>
-        ))}
+      <div className="lg:flex lg:space-x-6">
+        <div className="lg:w-1/3 space-y-6">
+          <section id="jobs">
+            <h2 className="text-xl font-semibold mb-2">Open Jobs</h2>
+            <ul className="list-disc ml-6">
+              {jobs.map(j => (
+                <li key={j.id}>Job #{j.id} - {j.status}</li>
+              ))}
+            </ul>
+          </section>
+          <section id="quotes">
+            <h2 className="text-xl font-semibold mb-2">Quotes</h2>
+            <ul className="list-disc ml-6">
+              {quotes.map(q => (
+                <li key={q.id} className="mb-1">
+                  Quote #{q.id} - {q.status}
+                  {q.status !== 'accepted' && (
+                    <button onClick={() => acceptQuote(q.id)} className="ml-2 underline">
+                      Accept
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+          <section id="invoices">
+            <h2 className="text-xl font-semibold mb-2">Invoices</h2>
+            <select
+              value={filter}
+              onChange={e => setFilter(e.target.value)}
+              className="input mb-2"
+            >
+              <option value="all">All</option>
+              <option value="paid">Paid</option>
+              <option value="unpaid">Unpaid</option>
+            </select>
+            <ul className="list-disc ml-6">
+              {invFiltered.map(inv => (
+                <li key={inv.id}>Invoice #{inv.id} - {inv.status}</li>
+              ))}
+            </ul>
+          </section>
+        </div>
+        <div className="flex-1">
+          <div id="vehicles" className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {filteredVehicles.map(v => (
+              <Card key={v.id} className="hover:shadow-xl transition-shadow">
+                <div className="p-3">
+                  <h2 className="text-lg font-medium">{v.licence_plate}</h2>
+                  <p className="text-sm text-gray-200">{v.make} {v.model}</p>
+                  <Link href={`/vehicles/${v.id}`} className="button-secondary mt-2 inline-block text-center">View Details</Link>
+                </div>
+              </Card>
+            ))}
+          </div>
+        </div>
       </div>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-2">Open Jobs</h2>
-        <ul className="list-disc ml-6">
-          {jobs.map(j => (
-            <li key={j.id}>Job #{j.id} - {j.status}</li>
-          ))}
-        </ul>
-      </section>
-      <section>
-        <h2 className="text-xl font-semibold mb-2">Quotes</h2>
-        <ul className="list-disc ml-6">
-          {quotes.map(q => (
-            <li key={q.id} className="mb-1">
-              Quote #{q.id} - {q.status}
-              {q.status !== 'accepted' && (
-                <button onClick={() => acceptQuote(q.id)} className="ml-2 underline">
-                  Accept
-                </button>
-              )}
-            </li>
-          ))}
-        </ul>
-      </section>
-      <section>
-        <h2 className="text-xl font-semibold mb-2">Invoices</h2>
-        <select
-          value={filter}
-          onChange={e => setFilter(e.target.value)}
-          className="input mb-2"
-        >
-          <option value="all">All</option>
-          <option value="paid">Paid</option>
-          <option value="unpaid">Unpaid</option>
-        </select>
-        <ul className="list-disc ml-6">
-          {invFiltered.map(inv => (
-            <li key={inv.id}>Invoice #{inv.id} - {inv.status}</li>
-          ))}
-        </ul>
-      </section>
     </div>
   );
 }

--- a/pages/fleet/index.js
+++ b/pages/fleet/index.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { fetchVehicles } from '../../lib/vehicles';
 import { fetchInvoices } from '../../lib/invoices';
 import { PortalDashboard } from '../../components/PortalDashboard';
+import { FleetNav } from '../../components/FleetNav';
 
 export default function FleetDashboard() {
   const router = useRouter();
@@ -35,14 +36,19 @@ export default function FleetDashboard() {
   if (!fleet) return <p className="p-8">Loading…</p>;
 
   return (
-    <PortalDashboard
-      title={`${fleet.company_name} Dashboard`}
-      requestJobPath="/fleet/request-job"
-      vehicles={vehicles}
-      jobs={jobs}
-      quotes={quotes}
-      setQuotes={setQuotes}
-      invoices={invoices}
-    />
+    <div className="flex space-x-4">
+      <FleetNav />
+      <div className="flex-1">
+        <PortalDashboard
+          title={`${fleet.company_name} Dashboard`}
+          requestJobPath="/fleet/request-job"
+          vehicles={vehicles}
+          jobs={jobs}
+          quotes={quotes}
+          setQuotes={setQuotes}
+          invoices={invoices}
+        />
+      </div>
+    </div>
   );
 }

--- a/pages/local/index.js
+++ b/pages/local/index.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { fetchVehicles } from '../../lib/vehicles';
 import { fetchInvoices } from '../../lib/invoices';
 import { PortalDashboard } from '../../components/PortalDashboard';
+import { FleetNav } from '../../components/FleetNav';
 
 export default function LocalDashboard() {
   const router = useRouter();
@@ -34,14 +35,19 @@ export default function LocalDashboard() {
   if (!client) return <p className="p-8">Loading…</p>;
 
   return (
-    <PortalDashboard
-      title={`Welcome ${client.first_name}`}
-      requestJobPath="/local/request-job"
-      vehicles={vehicles.filter(v => !v.fleet_id)}
-      jobs={jobs}
-      quotes={quotes}
-      setQuotes={setQuotes}
-      invoices={invoices}
-    />
+    <div className="flex space-x-4">
+      <FleetNav />
+      <div className="flex-1">
+        <PortalDashboard
+          title={`Welcome ${client.first_name}`}
+          requestJobPath="/local/request-job"
+          vehicles={vehicles.filter(v => !v.fleet_id)}
+          jobs={jobs}
+          quotes={quotes}
+          setQuotes={setQuotes}
+          invoices={invoices}
+        />
+      </div>
+    </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -53,3 +53,11 @@ body {
   color: #e2e8f0;
   font-family: 'Inter', system-ui, sans-serif;
 }
+
+/* Fleet dashboard sidebar */
+.fleet-nav {
+  @apply sticky top-20 space-y-2 w-32 hidden lg:block;
+}
+.fleet-nav-link {
+  @apply block bg-gray-200 text-[var(--color-text-primary)] rounded-full px-4 py-2 shadow hover:bg-gray-300 text-center;
+}


### PR DESCRIPTION
## Summary
- reorganize vehicle dashboard layout to place Jobs, Quotes and Invoices alongside vehicle cards
- add a new `FleetNav` sidebar and integrate it with fleet/local pages
- shrink vehicle card styling and grid layout
- style sidebar links in `globals.css`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6862bf804528832a8008037c1264962a