### PR TITLE
Ensure logout is POST-only and update idle logout hook

### DIFF
--- a/components/useIdleLogout.js
+++ b/components/useIdleLogout.js
@@ -10,7 +10,10 @@ export default function useIdleLogout(timeoutMs = 15 * 60 * 1000) {
       if (timer.current) clearTimeout(timer.current);
       timer.current = setTimeout(async () => {
         try {
-          await fetch('/api/auth/logout', { credentials: 'include' });
+          await fetch('/api/auth/logout', {
+            method: 'POST',
+            credentials: 'include',
+          });
         } finally {
           router.push('/login');
         }

--- a/pages/api/auth/logout.js
+++ b/pages/api/auth/logout.js
@@ -1,5 +1,11 @@
 export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
   const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
   res.setHeader('Set-Cookie', `auth_token=; HttpOnly; Path=/; Max-Age=0${secure}`);
-  res.status(200).json({ ok:true });
+  res.setHeader('Cache-Control', 'no-store');
+  res.status(200).json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- update `useIdleLogout` hook to send POST requests
- make `/api/auth/logout` accept only POST requests
- add no-store cache header to the logout endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862d5313d00832abd0d003bec57cbbc