### PR TITLE
Add logout endpoints for portal

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -10,7 +10,11 @@ export function Header() {
   }, []);
   async function handleLogout() {
     try {
-      await fetch('/api/auth/logout', { credentials: 'include' });
+      await Promise.all([
+        fetch('/api/auth/logout', { credentials: 'include' }),
+        fetch('/api/portal/fleet/logout', { credentials: 'include' }),
+        fetch('/api/portal/local/logout', { credentials: 'include' }),
+      ]);
     } finally {
       router.push('/login');
     }

--- a/components/useIdleLogout.js
+++ b/components/useIdleLogout.js
@@ -10,7 +10,11 @@ export default function useIdleLogout(timeoutMs = 15 * 60 * 1000) {
       if (timer.current) clearTimeout(timer.current);
       timer.current = setTimeout(async () => {
         try {
-          await fetch('/api/auth/logout', { credentials: 'include' });
+          await Promise.all([
+            fetch('/api/auth/logout', { credentials: 'include' }),
+            fetch('/api/portal/fleet/logout', { credentials: 'include' }),
+            fetch('/api/portal/local/logout', { credentials: 'include' }),
+          ]);
         } finally {
           router.push('/login');
         }

--- a/pages/api/portal/fleet/logout.js
+++ b/pages/api/portal/fleet/logout.js
@@ -1,0 +1,5 @@
+export default function handler(req, res) {
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+  res.setHeader('Set-Cookie', `fleet_token=; HttpOnly; Path=/; Max-Age=0${secure}`);
+  res.status(200).json({ ok: true });
+}

--- a/pages/api/portal/local/logout.js
+++ b/pages/api/portal/local/logout.js
@@ -1,0 +1,5 @@
+export default function handler(req, res) {
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+  res.setHeader('Set-Cookie', `local_token=; HttpOnly; Path=/; Max-Age=0${secure}`);
+  res.status(200).json({ ok: true });
+}

--- a/pages/fleet/index.js
+++ b/pages/fleet/index.js
@@ -12,6 +12,15 @@ export default function FleetDashboard() {
   const [quotes, setQuotes] = useState([]);
   const [invoices, setInvoices] = useState([]);
 
+  async function handleLogout() {
+    try {
+      await fetch('/api/portal/fleet/logout', { credentials: 'include' });
+      await fetch('/api/auth/logout', { credentials: 'include' });
+    } finally {
+      router.push('/fleet/login');
+    }
+  }
+
   useEffect(() => {
     (async () => {
       const res = await fetch('/api/portal/fleet/me');
@@ -35,14 +44,19 @@ export default function FleetDashboard() {
   if (!fleet) return <p className="p-8">Loading…</p>;
 
   return (
-    <PortalDashboard
-      title={`${fleet.company_name} Dashboard`}
-      requestJobPath="/fleet/request-job"
-      vehicles={vehicles}
-      jobs={jobs}
-      quotes={quotes}
-      setQuotes={setQuotes}
-      invoices={invoices}
-    />
+    <>
+      <div className="p-4 text-right">
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      <PortalDashboard
+        title={`${fleet.company_name} Dashboard`}
+        requestJobPath="/fleet/request-job"
+        vehicles={vehicles}
+        jobs={jobs}
+        quotes={quotes}
+        setQuotes={setQuotes}
+        invoices={invoices}
+      />
+    </>
   );
 }

--- a/pages/fleet/request-job.js
+++ b/pages/fleet/request-job.js
@@ -10,6 +10,15 @@ export default function FleetRequestJob() {
   const [description, setDescription] = useState('');
   const [message, setMessage] = useState('');
 
+  async function handleLogout() {
+    try {
+      await fetch('/api/portal/fleet/logout', { credentials: 'include' });
+      await fetch('/api/auth/logout', { credentials: 'include' });
+    } finally {
+      router.push('/fleet/login');
+    }
+  }
+
   useEffect(() => {
     (async () => {
       const res = await fetch('/api/portal/fleet/me');
@@ -39,7 +48,10 @@ export default function FleetRequestJob() {
 
   return (
     <div className="p-8">
-      <h1 className="text-2xl font-bold mb-4">New Job Request</h1>
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">New Job Request</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
       {message && <p className="text-green-600 mb-2">{message}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-sm">
         <select value={vehicleId} onChange={e => setVehicleId(e.target.value)} className="input w-full" required>

--- a/pages/index.js
+++ b/pages/index.js
@@ -94,7 +94,11 @@ export default function Home() {
   // Logout handler
   async function handleLogout() {
     try {
-      await fetch('/api/auth/logout', { credentials: 'include' });
+      await Promise.all([
+        fetch('/api/auth/logout', { credentials: 'include' }),
+        fetch('/api/portal/fleet/logout', { credentials: 'include' }),
+        fetch('/api/portal/local/logout', { credentials: 'include' }),
+      ]);
     } catch (err) {
       console.error('Logout failed', err);
     } finally {

--- a/pages/local/index.js
+++ b/pages/local/index.js
@@ -12,6 +12,15 @@ export default function LocalDashboard() {
   const [quotes, setQuotes] = useState([]);
   const [invoices, setInvoices] = useState([]);
 
+  async function handleLogout() {
+    try {
+      await fetch('/api/portal/local/logout', { credentials: 'include' });
+      await fetch('/api/auth/logout', { credentials: 'include' });
+    } finally {
+      router.push('/local/login');
+    }
+  }
+
   useEffect(() => {
     (async () => {
       const res = await fetch('/api/portal/local/me');
@@ -34,14 +43,19 @@ export default function LocalDashboard() {
   if (!client) return <p className="p-8">Loading…</p>;
 
   return (
-    <PortalDashboard
-      title={`Welcome ${client.first_name}`}
-      requestJobPath="/local/request-job"
-      vehicles={vehicles.filter(v => !v.fleet_id)}
-      jobs={jobs}
-      quotes={quotes}
-      setQuotes={setQuotes}
-      invoices={invoices}
-    />
+    <>
+      <div className="p-4 text-right">
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      <PortalDashboard
+        title={`Welcome ${client.first_name}`}
+        requestJobPath="/local/request-job"
+        vehicles={vehicles.filter(v => !v.fleet_id)}
+        jobs={jobs}
+        quotes={quotes}
+        setQuotes={setQuotes}
+        invoices={invoices}
+      />
+    </>
   );
 }

--- a/pages/local/request-job.js
+++ b/pages/local/request-job.js
@@ -10,6 +10,15 @@ export default function LocalRequestJob() {
   const [description, setDescription] = useState('');
   const [message, setMessage] = useState('');
 
+  async function handleLogout() {
+    try {
+      await fetch('/api/portal/local/logout', { credentials: 'include' });
+      await fetch('/api/auth/logout', { credentials: 'include' });
+    } finally {
+      router.push('/local/login');
+    }
+  }
+
   useEffect(() => {
     (async () => {
       const res = await fetch('/api/portal/local/me');
@@ -39,7 +48,10 @@ export default function LocalRequestJob() {
 
   return (
     <div className="p-8">
-      <h1 className="text-2xl font-bold mb-4">New Job Request</h1>
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">New Job Request</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
       {message && <p className="text-green-600 mb-2">{message}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-sm">
         <select value={vehicleId} onChange={e => setVehicleId(e.target.value)} className="input w-full" required>

--- a/pages/office/index.js
+++ b/pages/office/index.js
@@ -201,7 +201,11 @@ export default function OfficeHome() {
 
   async function handleLogout() {
     try {
-      await fetch('/api/auth/logout', { credentials: 'include' });
+      await Promise.all([
+        fetch('/api/auth/logout', { credentials: 'include' }),
+        fetch('/api/portal/fleet/logout', { credentials: 'include' }),
+        fetch('/api/portal/local/logout', { credentials: 'include' }),
+      ]);
     } finally {
       router.push('/login');
     }


### PR DESCRIPTION
## Summary
- add logout endpoints for fleet and local portals
- call these new endpoints during idle logout and header logout
- clear portal cookies when logging out from admin pages
- show logout buttons on portal pages

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863111f0844832a9f2eed0f0ded706b