### PR TITLE
Update logout logic to check portal cookies

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import logout from '../lib/logout.js';
 
 export function Header() {
   const [user, setUser] = useState(null);
@@ -10,11 +11,7 @@ export function Header() {
   }, []);
   async function handleLogout() {
     try {
-      await Promise.all([
-        fetch('/api/auth/logout', { credentials: 'include' }),
-        fetch('/api/portal/fleet/logout', { credentials: 'include' }),
-        fetch('/api/portal/local/logout', { credentials: 'include' }),
-      ]);
+      await logout();
     } finally {
       router.push('/login');
     }

--- a/components/useIdleLogout.js
+++ b/components/useIdleLogout.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
+import logout from '../lib/logout.js';
 
 export default function useIdleLogout(timeoutMs = 15 * 60 * 1000) {
   const router = useRouter();
@@ -10,11 +11,7 @@ export default function useIdleLogout(timeoutMs = 15 * 60 * 1000) {
       if (timer.current) clearTimeout(timer.current);
       timer.current = setTimeout(async () => {
         try {
-          await Promise.all([
-            fetch('/api/auth/logout', { credentials: 'include' }),
-            fetch('/api/portal/fleet/logout', { credentials: 'include' }),
-            fetch('/api/portal/local/logout', { credentials: 'include' }),
-          ]);
+          await logout();
         } finally {
           router.push('/login');
         }

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -1,0 +1,11 @@
+export default async function logout() {
+  const cookies = document.cookie.split(';').map(c => c.trim());
+  const calls = [fetch('/api/auth/logout', { credentials: 'include' })];
+  if (cookies.some(c => c.startsWith('fleet_token='))) {
+    calls.push(fetch('/api/portal/fleet/logout', { credentials: 'include' }));
+  }
+  if (cookies.some(c => c.startsWith('local_token='))) {
+    calls.push(fetch('/api/portal/local/logout', { credentials: 'include' }));
+  }
+  await Promise.all(calls);
+}

--- a/pages/fleet/home.js
+++ b/pages/fleet/home.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import logout from '../../lib/logout.js';
 
 function VehiclesIcon() {
   return (
@@ -90,10 +91,7 @@ export default function FleetHome() {
 
   async function handleLogout() {
     try {
-      await Promise.all([
-        fetch('/api/portal/fleet/logout', { credentials: 'include' }),
-        fetch('/api/auth/logout', { credentials: 'include' }),
-      ]);
+      await logout();
     } finally {
       router.push('/fleet/login');
     }

--- a/pages/fleet/index.js
+++ b/pages/fleet/index.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import logout from '../../lib/logout.js';
 import { fetchVehicles } from '../../lib/vehicles';
 import { fetchInvoices } from '../../lib/invoices';
 import { PortalDashboard } from '../../components/PortalDashboard';
@@ -14,8 +15,7 @@ export default function FleetDashboard() {
 
   async function handleLogout() {
     try {
-      await fetch('/api/portal/fleet/logout', { credentials: 'include' });
-      await fetch('/api/auth/logout', { credentials: 'include' });
+      await logout();
     } finally {
       router.push('/fleet/login');
     }

--- a/pages/fleet/request-job.js
+++ b/pages/fleet/request-job.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { fetchVehicles } from '../../lib/vehicles';
+import logout from '../../lib/logout.js';
 
 export default function FleetRequestJob() {
   const router = useRouter();
@@ -12,8 +13,7 @@ export default function FleetRequestJob() {
 
   async function handleLogout() {
     try {
-      await fetch('/api/portal/fleet/logout', { credentials: 'include' });
-      await fetch('/api/auth/logout', { credentials: 'include' });
+      await logout();
     } finally {
       router.push('/fleet/login');
     }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import logout from '../lib/logout.js';
 import Head from 'next/head';
 import Link from 'next/link';
 
@@ -94,11 +95,7 @@ export default function Home() {
   // Logout handler
   async function handleLogout() {
     try {
-      await Promise.all([
-        fetch('/api/auth/logout', { credentials: 'include' }),
-        fetch('/api/portal/fleet/logout', { credentials: 'include' }),
-        fetch('/api/portal/local/logout', { credentials: 'include' }),
-      ]);
+      await logout();
     } catch (err) {
       console.error('Logout failed', err);
     } finally {

--- a/pages/local/index.js
+++ b/pages/local/index.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { fetchVehicles } from '../../lib/vehicles';
 import { fetchInvoices } from '../../lib/invoices';
 import { PortalDashboard } from '../../components/PortalDashboard';
+import logout from '../../lib/logout.js';
 
 export default function LocalDashboard() {
   const router = useRouter();
@@ -14,8 +15,7 @@ export default function LocalDashboard() {
 
   async function handleLogout() {
     try {
-      await fetch('/api/portal/local/logout', { credentials: 'include' });
-      await fetch('/api/auth/logout', { credentials: 'include' });
+      await logout();
     } finally {
       router.push('/local/login');
     }

--- a/pages/local/request-job.js
+++ b/pages/local/request-job.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { fetchVehicles } from '../../lib/vehicles';
+import logout from '../../lib/logout.js';
 
 export default function LocalRequestJob() {
   const router = useRouter();
@@ -12,8 +13,7 @@ export default function LocalRequestJob() {
 
   async function handleLogout() {
     try {
-      await fetch('/api/portal/local/logout', { credentials: 'include' });
-      await fetch('/api/auth/logout', { credentials: 'include' });
+      await logout();
     } finally {
       router.push('/local/login');
     }

--- a/pages/office/index.js
+++ b/pages/office/index.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import logout from '../../lib/logout.js';
 import Head from 'next/head';
 import Link from 'next/link';
 import { fetchClients } from '../../lib/clients';
@@ -201,11 +202,7 @@ export default function OfficeHome() {
 
   async function handleLogout() {
     try {
-      await Promise.all([
-        fetch('/api/auth/logout', { credentials: 'include' }),
-        fetch('/api/portal/fleet/logout', { credentials: 'include' }),
-        fetch('/api/portal/local/logout', { credentials: 'include' }),
-      ]);
+      await logout();
     } finally {
       router.push('/login');
     }


### PR DESCRIPTION
## Summary
- extract logout logic into `lib/logout.js`
- use cookie-aware logout in idle timer and header
- update all pages to call the new helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68631835bbc4832aab125a1a7acf984d