### PR TITLE
Add suppliers and purchase order system

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@
 All database schema changes are stored as `.sql` files in the `migrations/`
 directory. The migration script executes them sequentially and records the
 results so it can be run repeatedly without errors.
+
+## New Endpoints
+
+- `/api/suppliers` - list and create suppliers.
+- `/api/suppliers/[id]` - view, update and delete a supplier.
+- `/api/purchase-orders` - create purchase orders with items.
+- `/api/quote-items` - create or fetch quote items.

--- a/__tests__/purchase-orders-api.test.js
+++ b/__tests__/purchase-orders-api.test.js
@@ -1,0 +1,20 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('purchase orders index creates order', async () => {
+  const createMock = jest.fn().mockResolvedValue({ id: 1 });
+  const addItemMock = jest.fn();
+  jest.unstable_mockModule('../services/purchaseOrdersService.js', () => ({
+    createPurchaseOrder: createMock,
+    addPurchaseOrderItem: addItemMock,
+  }));
+  const { default: handler } = await import('../pages/api/purchase-orders/index.js');
+  const req = { method: 'POST', body: { order: { supplier_id: 1 }, items: [{ part_id: 2 }] }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(createMock).toHaveBeenCalledWith(req.body.order);
+  expect(addItemMock).toHaveBeenCalledWith({ purchase_order_id: 1, part_id: 2 });
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith({ id: 1 });
+});

--- a/__tests__/purchaseOrdersService.test.js
+++ b/__tests__/purchaseOrdersService.test.js
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('createPurchaseOrder inserts order', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 5 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { createPurchaseOrder } = await import('../services/purchaseOrdersService.js');
+  const data = { job_id: 1, supplier_id: 2, status: 'new' };
+  const result = await createPurchaseOrder(data);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/INSERT INTO purchase_orders/), [1, 2, 'new']);
+  expect(result).toEqual({ id: 5, ...data });
+});
+
+test('addPurchaseOrderItem inserts item', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 7 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { addPurchaseOrderItem } = await import('../services/purchaseOrdersService.js');
+  const data = { purchase_order_id: 5, part_id: 6, qty: 2, unit_price: 3 };
+  const result = await addPurchaseOrderItem(data);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/INSERT INTO purchase_order_items/), [5, 6, 2, 3]);
+  expect(result).toEqual({ id: 7, ...data });
+});

--- a/__tests__/quote-items-api.test.js
+++ b/__tests__/quote-items-api.test.js
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('quote-items GET returns items', async () => {
+  const rows = [{ id: 1 }];
+  const getMock = jest.fn().mockResolvedValue(rows);
+  jest.unstable_mockModule('../services/quoteItemsService.js', () => ({
+    getQuoteItems: getMock,
+    createQuoteItem: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quote-items/index.js');
+  const req = { method: 'GET', query: { quote_id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(getMock).toHaveBeenCalledWith('1');
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(rows);
+});
+
+test('quote-items POST creates item', async () => {
+  const item = { id: 2 };
+  const createMock = jest.fn().mockResolvedValue(item);
+  jest.unstable_mockModule('../services/quoteItemsService.js', () => ({
+    getQuoteItems: jest.fn(),
+    createQuoteItem: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/quote-items/index.js');
+  const req = { method: 'POST', body: { quote_id: 1 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(item);
+});

--- a/__tests__/suppliers-api.test.js
+++ b/__tests__/suppliers-api.test.js
@@ -1,0 +1,85 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('suppliers index returns list', async () => {
+  const suppliers = [{ id: 1 }];
+  const getAllMock = jest.fn().mockResolvedValue(suppliers);
+  jest.unstable_mockModule('../services/suppliersService.js', () => ({
+    getAllSuppliers: getAllMock,
+    createSupplier: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/suppliers/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(suppliers);
+});
+
+test('suppliers index creates supplier', async () => {
+  const supplier = { id: 2 };
+  const createMock = jest.fn().mockResolvedValue(supplier);
+  jest.unstable_mockModule('../services/suppliersService.js', () => ({
+    getAllSuppliers: jest.fn(),
+    createSupplier: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/suppliers/index.js');
+  const req = { method: 'POST', body: { name: 'A' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(supplier);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+});
+
+test('suppliers detail returns supplier', async () => {
+  const supplier = { id: 1 };
+  const getMock = jest.fn().mockResolvedValue(supplier);
+  jest.unstable_mockModule('../services/suppliersService.js', () => ({
+    getSupplierById: getMock,
+    updateSupplier: jest.fn(),
+    deleteSupplier: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/suppliers/[id].js');
+  const req = { method: 'GET', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(supplier);
+});
+
+test('suppliers detail updates supplier', async () => {
+  const updateMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/suppliersService.js', () => ({
+    getSupplierById: jest.fn(),
+    updateSupplier: updateMock,
+    deleteSupplier: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/suppliers/[id].js');
+  const req = { method: 'PUT', query: { id: '2' }, body: { name: 'B' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ ok: true });
+  expect(updateMock).toHaveBeenCalledWith('2', req.body);
+});
+
+test('suppliers detail deletes supplier', async () => {
+  const deleteMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/suppliersService.js', () => ({
+    getSupplierById: jest.fn(),
+    updateSupplier: jest.fn(),
+    deleteSupplier: deleteMock,
+  }));
+  const { default: handler } = await import('../pages/api/suppliers/[id].js');
+  const req = { method: 'DELETE', query: { id: '3' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(204);
+  expect(res.end).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalledWith('3');
+});

--- a/__tests__/suppliersService.test.js
+++ b/__tests__/suppliersService.test.js
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('getAllSuppliers fetches rows', async () => {
+  const rows = [{ id: 1 }];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { getAllSuppliers } = await import('../services/suppliersService.js');
+  const result = await getAllSuppliers();
+  expect(queryMock.mock.calls[0][0]).toMatch(/FROM suppliers/);
+  expect(result).toEqual(rows);
+});
+
+test('createSupplier inserts row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 2 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { createSupplier } = await import('../services/suppliersService.js');
+  const data = { name: 'A' };
+  const result = await createSupplier(data);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/INSERT INTO suppliers/), [
+    'A', null, null, null, null, null,
+  ]);
+  expect(result).toEqual({ id: 2, ...data, address: undefined, contact_number: undefined, email_address: undefined, payment_terms: undefined, credit_limit: undefined });
+});
+
+test('updateSupplier updates row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { updateSupplier } = await import('../services/suppliersService.js');
+  const result = await updateSupplier(1, { name: 'B' });
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/UPDATE suppliers/), ['B', null, null, null, null, null, 1]);
+  expect(result).toEqual({ ok: true });
+});
+
+test('deleteSupplier removes row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deleteSupplier } = await import('../services/suppliersService.js');
+  const result = await deleteSupplier(3);
+  expect(queryMock).toHaveBeenCalledWith('DELETE FROM suppliers WHERE id=?', [3]);
+  expect(result).toEqual({ ok: true });
+});

--- a/docs/docs/db_schema.md
+++ b/docs/docs/db_schema.md
@@ -528,3 +528,43 @@
 | `fk_job_requests_fleet` | FOREIGN KEY (`fleet_id`) REFERENCES `fleets` (`id`) |
 | `fk_job_requests_client` | FOREIGN KEY (`client_id`) REFERENCES `clients` (`id`) |
 | `fk_job_requests_vehicle` | FOREIGN KEY (`vehicle_id`) REFERENCES `vehicles` (`id`) |
+
+## Table: `suppliers`
+
+| Column | Definition |
+|--------|------------|
+| `id` | int(11) NOT NULL AUTO_INCREMENT |
+| `name` | varchar(255) NOT NULL |
+| `address` | text DEFAULT NULL |
+| `contact_number` | varchar(50) DEFAULT NULL |
+| `email_address` | varchar(255) DEFAULT NULL |
+| `payment_terms` | varchar(100) DEFAULT NULL |
+| `credit_limit` | decimal(10,2) DEFAULT NULL |
+
+## Table: `purchase_orders`
+
+| Column | Definition |
+|--------|------------|
+| `id` | int(11) NOT NULL AUTO_INCREMENT |
+| `job_id` | int(11) DEFAULT NULL |
+| `supplier_id` | int(11) NOT NULL |
+| `status` | varchar(50) DEFAULT NULL |
+| `created_at` | datetime DEFAULT current_timestamp() |
+| `fk_po_job` | (`job_id`) |
+| `fk_po_supplier` | (`supplier_id`) |
+| `fk_po_job` | FOREIGN KEY (`job_id`) REFERENCES `jobs` (`id`) |
+| `fk_po_supplier` | FOREIGN KEY (`supplier_id`) REFERENCES `suppliers` (`id`) |
+
+## Table: `purchase_order_items`
+
+| Column | Definition |
+|--------|------------|
+| `id` | int(11) NOT NULL AUTO_INCREMENT |
+| `purchase_order_id` | int(11) NOT NULL |
+| `part_id` | int(11) NOT NULL |
+| `qty` | int(11) DEFAULT NULL |
+| `unit_price` | decimal(10,2) DEFAULT NULL |
+| `fk_poi_po` | (`purchase_order_id`) |
+| `fk_poi_part` | (`part_id`) |
+| `fk_poi_po` | FOREIGN KEY (`purchase_order_id`) REFERENCES `purchase_orders` (`id`) |
+| `fk_poi_part` | FOREIGN KEY (`part_id`) REFERENCES `parts` (`id`) |

--- a/migrations/20251207_create_suppliers.sql
+++ b/migrations/20251207_create_suppliers.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS suppliers (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(255) NOT NULL,
+  address TEXT,
+  contact_number VARCHAR(50),
+  email_address VARCHAR(255),
+  payment_terms VARCHAR(100),
+  credit_limit DECIMAL(10,2)
+);

--- a/migrations/20251208_create_purchase_orders.sql
+++ b/migrations/20251208_create_purchase_orders.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS purchase_orders (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  job_id INT,
+  supplier_id INT NOT NULL,
+  status VARCHAR(50),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_po_job FOREIGN KEY (job_id) REFERENCES jobs(id),
+  CONSTRAINT fk_po_supplier FOREIGN KEY (supplier_id) REFERENCES suppliers(id)
+);

--- a/migrations/20251209_create_purchase_order_items.sql
+++ b/migrations/20251209_create_purchase_order_items.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS purchase_order_items (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  purchase_order_id INT NOT NULL,
+  part_id INT NOT NULL,
+  qty INT,
+  unit_price DECIMAL(10,2),
+  CONSTRAINT fk_poi_po FOREIGN KEY (purchase_order_id) REFERENCES purchase_orders(id),
+  CONSTRAINT fk_poi_part FOREIGN KEY (part_id) REFERENCES parts(id)
+);

--- a/migrations/20251210_add_parts_supplier_id.sql
+++ b/migrations/20251210_add_parts_supplier_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE parts ADD COLUMN supplier_id INT;
+ALTER TABLE parts ADD CONSTRAINT fk_parts_supplier FOREIGN KEY (supplier_id) REFERENCES suppliers(id);

--- a/migrations/20251211_add_quote_items_part_id.sql
+++ b/migrations/20251211_add_quote_items_part_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE quote_items ADD COLUMN part_id INT;
+ALTER TABLE quote_items ADD CONSTRAINT fk_quote_item_part FOREIGN KEY (part_id) REFERENCES parts(id);

--- a/pages/api/purchase-orders/index.js
+++ b/pages/api/purchase-orders/index.js
@@ -1,0 +1,21 @@
+import { createPurchaseOrder, addPurchaseOrderItem } from '../../../services/purchaseOrdersService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'POST') {
+      const { order, items } = req.body || {};
+      const po = await createPurchaseOrder(order);
+      if (items && Array.isArray(items)) {
+        for (const it of items) {
+          await addPurchaseOrderItem({ purchase_order_id: po.id, ...it });
+        }
+      }
+      return res.status(201).json(po);
+    }
+    res.setHeader('Allow', ['POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/quote-items/index.js
+++ b/pages/api/quote-items/index.js
@@ -1,0 +1,19 @@
+import { createQuoteItem, getQuoteItems } from '../../../services/quoteItemsService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const items = await getQuoteItems(req.query.quote_id);
+      return res.status(200).json(items);
+    }
+    if (req.method === 'POST') {
+      const item = await createQuoteItem(req.body);
+      return res.status(201).json(item);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/suppliers/[id].js
+++ b/pages/api/suppliers/[id].js
@@ -1,0 +1,24 @@
+import { getSupplierById, updateSupplier, deleteSupplier } from '../../../services/suppliersService.js';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const supplier = await getSupplierById(id);
+      return res.status(200).json(supplier);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateSupplier(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await deleteSupplier(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/suppliers/index.js
+++ b/pages/api/suppliers/index.js
@@ -1,0 +1,19 @@
+import { getAllSuppliers, createSupplier } from '../../../services/suppliersService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const rows = await getAllSuppliers();
+      return res.status(200).json(rows);
+    }
+    if (req.method === 'POST') {
+      const created = await createSupplier(req.body);
+      return res.status(201).json(created);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/office/index.js
+++ b/pages/office/index.js
@@ -290,6 +290,7 @@ export default function OfficeHome() {
           <DashboardCard href="/office/job-requests" title="Job Requests" Icon={JobManagementIcon} />
           <DashboardCard href="/office/live-screen" title="Live Screen" Icon={LiveScreenIcon} />
           <DashboardCard href="/office/parts" title="Parts" Icon={PartsIcon} />
+          <DashboardCard href="/office/suppliers" title="Suppliers" Icon={PartsIcon} />
           <DashboardCard href="/office/quotations" title="Quotations" Icon={QuotationsIcon} />
           <DashboardCard href="/office/reporting" title="Reporting" Icon={ReportingIcon} />
           <DashboardCard href="/office/scheduling" title="Scheduling" Icon={SchedulingIcon} />

--- a/pages/office/quotations/index.js
+++ b/pages/office/quotations/index.js
@@ -28,11 +28,55 @@ const QuotationsPage = () => {
   }, []);
 
   const approve = async id => {
+    const itemsRes = await fetch(`/api/quote-items?quote_id=${id}`);
+    const items = itemsRes.ok ? await itemsRes.json() : [];
+    const bySupplier = {};
+    items.forEach(it => {
+      if (!it.supplier_id) return;
+      bySupplier[it.supplier_id] ||= [];
+      bySupplier[it.supplier_id].push(it);
+    });
+    for (const [supplier_id, group] of Object.entries(bySupplier)) {
+      await fetch('/api/purchase-orders', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          order: { job_id: null, supplier_id, status: 'new' },
+          items: group.map(g => ({
+            part_id: g.part_id,
+            qty: g.qty,
+            unit_price: g.unit_price,
+          })),
+        }),
+      });
+    }
     await updateQuote(id, { status: 'approved' });
     load();
   };
 
   const convert = async id => {
+    const itemsRes = await fetch(`/api/quote-items?quote_id=${id}`);
+    const items = itemsRes.ok ? await itemsRes.json() : [];
+    const bySupplier = {};
+    items.forEach(it => {
+      if (!it.supplier_id) return;
+      bySupplier[it.supplier_id] ||= [];
+      bySupplier[it.supplier_id].push(it);
+    });
+    for (const [supplier_id, group] of Object.entries(bySupplier)) {
+      await fetch('/api/purchase-orders', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          order: { job_id: null, supplier_id, status: 'new' },
+          items: group.map(g => ({
+            part_id: g.part_id,
+            qty: g.qty,
+            unit_price: g.unit_price,
+          })),
+        }),
+      });
+    }
     await updateQuote(id, { status: 'job-card' });
     load();
   };

--- a/pages/office/suppliers/[id].js
+++ b/pages/office/suppliers/[id].js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Layout } from '../../../components/Layout';
+
+export default function EditSupplierPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [form, setForm] = useState({
+    name: '',
+    address: '',
+    contact_number: '',
+    email_address: '',
+    payment_terms: '',
+    credit_limit: '',
+  });
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/suppliers/${id}`)
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setForm)
+      .catch(() => setError('Failed to load supplier'));
+  }, [id]);
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      await fetch(`/api/suppliers/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      router.push('/office/suppliers');
+    } catch {
+      setError('Failed to update supplier');
+    }
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Edit Supplier</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        {['name','address','contact_number','email_address','payment_terms','credit_limit'].map(field => (
+          <div key={field}>
+            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
+            <input
+              name={field}
+              value={form[field] || ''}
+              onChange={change}
+              className="input w-full"
+            />
+          </div>
+        ))}
+        <button type="submit" className="button">Save</button>
+      </form>
+    </Layout>
+  );
+}

--- a/pages/office/suppliers/index.js
+++ b/pages/office/suppliers/index.js
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Layout } from '../../../components/Layout';
+
+export default function SuppliersPage() {
+  const [suppliers, setSuppliers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const load = () => {
+    setLoading(true);
+    fetch('/api/suppliers')
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setSuppliers)
+      .catch(() => setError('Failed to load suppliers'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const filtered = suppliers.filter(s =>
+    (s.name || '').toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  return (
+    <Layout>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-semibold">Suppliers</h1>
+        <Link href="/office/suppliers/new" className="button">
+          + New Supplier
+        </Link>
+      </div>
+      <Link href="/office" className="button inline-block mb-4">Return to Office</Link>
+      {error && <p className="text-red-500">{error}</p>}
+      {loading ? (
+        <p>Loading…</p>
+      ) : (
+        <>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            placeholder="Search…"
+            className="input mb-4 w-full"
+          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            {filtered.map(s => (
+              <div key={s.id} className="item-card">
+                <h2 className="font-semibold mb-1">{s.name}</h2>
+                <p className="text-sm">{s.email_address}</p>
+                <p className="text-sm">{s.contact_number}</p>
+                <Link href={`/office/suppliers/${s.id}`} className="button mt-2 px-4 text-sm">
+                  Edit
+                </Link>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </Layout>
+  );
+}

--- a/pages/office/suppliers/new.js
+++ b/pages/office/suppliers/new.js
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Layout } from '../../../components/Layout';
+
+export default function NewSupplierPage() {
+  const [form, setForm] = useState({
+    name: '',
+    address: '',
+    contact_number: '',
+    email_address: '',
+    payment_terms: '',
+    credit_limit: '',
+  });
+  const [error, setError] = useState(null);
+  const router = useRouter();
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/suppliers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error();
+      await res.json();
+      router.push('/office/suppliers');
+    } catch {
+      setError('Failed to create supplier');
+    }
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">New Supplier</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        {['name','address','contact_number','email_address','payment_terms','credit_limit'].map(field => (
+          <div key={field}>
+            <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
+            <input
+              name={field}
+              value={form[field]}
+              onChange={change}
+              className="input w-full"
+            />
+          </div>
+        ))}
+        <button type="submit" className="button">Save</button>
+      </form>
+    </Layout>
+  );
+}

--- a/services/purchaseOrdersService.js
+++ b/services/purchaseOrdersService.js
@@ -1,0 +1,19 @@
+import pool from '../lib/db.js';
+
+export async function createPurchaseOrder({ job_id, supplier_id, status }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO purchase_orders (job_id, supplier_id, status)
+     VALUES (?,?,?)`,
+    [job_id || null, supplier_id, status || null]
+  );
+  return { id: insertId, job_id, supplier_id, status };
+}
+
+export async function addPurchaseOrderItem({ purchase_order_id, part_id, qty, unit_price }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO purchase_order_items (purchase_order_id, part_id, qty, unit_price)
+     VALUES (?,?,?,?)`,
+    [purchase_order_id, part_id, qty || null, unit_price || null]
+  );
+  return { id: insertId, purchase_order_id, part_id, qty, unit_price };
+}

--- a/services/quoteItemsService.js
+++ b/services/quoteItemsService.js
@@ -2,9 +2,22 @@ import pool from '../lib/db.js';
 
 export async function getQuoteItems(quote_id) {
   const [rows] = await pool.query(
-    `SELECT id, quote_id, description, qty, unit_price
-       FROM quote_items WHERE quote_id=? ORDER BY id`,
+    `SELECT qi.id, qi.quote_id, qi.part_id, qi.description, qi.qty, qi.unit_price,
+            p.supplier_id
+       FROM quote_items qi
+  LEFT JOIN parts p ON qi.part_id=p.id
+      WHERE qi.quote_id=?
+   ORDER BY qi.id`,
     [quote_id]
   );
   return rows;
+}
+
+export async function createQuoteItem({ quote_id, part_id, description, qty, unit_price }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO quote_items (quote_id, part_id, description, qty, unit_price)
+     VALUES (?,?,?,?,?)`,
+    [quote_id, part_id || null, description || null, qty || null, unit_price || null]
+  );
+  return { id: insertId, quote_id, part_id, description, qty, unit_price };
 }

--- a/services/suppliersService.js
+++ b/services/suppliersService.js
@@ -1,0 +1,47 @@
+import pool from '../lib/db.js';
+
+export async function getAllSuppliers() {
+  const [rows] = await pool.query(
+    `SELECT id, name, address, contact_number, email_address, payment_terms, credit_limit
+       FROM suppliers ORDER BY id`
+  );
+  return rows;
+}
+
+export async function getSupplierById(id) {
+  const [[row]] = await pool.query(
+    `SELECT id, name, address, contact_number, email_address, payment_terms, credit_limit
+       FROM suppliers WHERE id=?`,
+    [id]
+  );
+  return row || null;
+}
+
+export async function createSupplier({ name, address, contact_number, email_address, payment_terms, credit_limit }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO suppliers (name, address, contact_number, email_address, payment_terms, credit_limit)
+     VALUES (?,?,?,?,?,?)`,
+    [name, address || null, contact_number || null, email_address || null, payment_terms || null, credit_limit || null]
+  );
+  return { id: insertId, name, address, contact_number, email_address, payment_terms, credit_limit };
+}
+
+export async function updateSupplier(id, { name, address, contact_number, email_address, payment_terms, credit_limit }) {
+  await pool.query(
+    `UPDATE suppliers SET
+       name=?,
+       address=?,
+       contact_number=?,
+       email_address=?,
+       payment_terms=?,
+       credit_limit=?
+     WHERE id=?`,
+    [name, address || null, contact_number || null, email_address || null, payment_terms || null, credit_limit || null, id]
+  );
+  return { ok: true };
+}
+
+export async function deleteSupplier(id) {
+  await pool.query('DELETE FROM suppliers WHERE id=?', [id]);
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- create migrations for suppliers, purchase orders and items
- extend quote items to track selected part and supplier
- implement suppliers and purchase orders services
- add related API routes
- build office pages for managing suppliers
- generate purchase orders when approving quotes or creating job cards
- document new tables and endpoints
- test new services and APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863216c48e8832aba9a2579bc68e2f2