### PR TITLE
Add conditional column check for quote items

### DIFF
--- a/migrations/20251211_add_quote_items_part_id.sql
+++ b/migrations/20251211_add_quote_items_part_id.sql
@@ -1,2 +1,27 @@
-ALTER TABLE quote_items ADD COLUMN part_id INT;
-ALTER TABLE quote_items ADD CONSTRAINT fk_quote_item_part FOREIGN KEY (part_id) REFERENCES parts(id);
+-- Only add the column and foreign key if it doesn't already exist
+SET @col_count := (
+  SELECT COUNT(*)
+  FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'quote_items'
+    AND COLUMN_NAME = 'part_id'
+);
+
+SET @sql := IF(
+  @col_count = 0,
+  'ALTER TABLE quote_items ADD COLUMN part_id INT',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+  @col_count = 0,
+  'ALTER TABLE quote_items ADD CONSTRAINT fk_quote_item_part FOREIGN KEY (part_id) REFERENCES parts(id)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+


### PR DESCRIPTION
## Summary
- make the `quote_items` migration idempotent by checking if `part_id` already exists before adding the column and foreign key

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68632521e404832a8ae2d7df06547551