### PR TITLE
Add supplier_id support to parts

### DIFF
--- a/__tests__/parts-api.test.js
+++ b/__tests__/parts-api.test.js
@@ -1,0 +1,27 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('parts index creates part', async () => {
+  const part = { id: 1 };
+  const createMock = jest.fn().mockResolvedValue(part);
+  jest.unstable_mockModule('../services/partsService.js', () => ({
+    searchParts: jest.fn(),
+    createPart: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/parts/index.js');
+  const req = { method: 'POST', body: { part_number: 'P1', supplier_id: 2 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(part);
+  expect(createMock).toHaveBeenCalledWith({
+    part_number: 'P1',
+    description: undefined,
+    unit_cost: undefined,
+    supplier_id: 2,
+  });
+});

--- a/__tests__/partsService.test.js
+++ b/__tests__/partsService.test.js
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('createPart inserts row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 3 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { createPart } = await import('../services/partsService.js');
+  const data = { part_number: 'A', description: 'B', unit_cost: 1.2, supplier_id: 4 };
+  const result = await createPart(data);
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/INSERT INTO parts/),
+    ['A', 'B', 1.2, 4]
+  );
+  expect(result).toEqual({ id: 3, ...data });
+});

--- a/pages/api/parts/index.js
+++ b/pages/api/parts/index.js
@@ -8,7 +8,13 @@ export default async function handler(req, res) {
       return res.status(200).json(parts);
     }
     if (req.method === 'POST') {
-      const newPart = await createPart(req.body);
+      const { part_number, description, unit_cost, supplier_id } = req.body || {};
+      const newPart = await createPart({
+        part_number,
+        description,
+        unit_cost,
+        supplier_id,
+      });
       return res.status(201).json(newPart);
     }
     res.setHeader('Allow', ['GET', 'POST']);

--- a/services/partsService.js
+++ b/services/partsService.js
@@ -20,11 +20,16 @@ export async function searchParts(query) {
   return rows;
 }
 
-export async function createPart({ part_number, description, unit_cost }) {
+export async function createPart({
+  part_number,
+  description,
+  unit_cost,
+  supplier_id,
+}) {
   const [{ insertId }] = await pool.query(
-    `INSERT INTO parts (part_number, description, unit_cost)
-     VALUES (?,?,?)`,
-    [part_number, description || null, unit_cost || null]
+    `INSERT INTO parts (part_number, description, unit_cost, supplier_id)
+     VALUES (?,?,?,?)`,
+    [part_number, description || null, unit_cost || null, supplier_id || null]
   );
-  return { id: insertId, part_number, description, unit_cost };
+  return { id: insertId, part_number, description, unit_cost, supplier_id };
 }


### PR DESCRIPTION
## Summary
- accept optional `supplier_id` when creating parts
- handle the new field in API route
- test `createPart` and API handler with `supplier_id`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68632614fc68832a85bc5ceeb46a13f9