### PR TITLE
Add transactional purchase order creation

### DIFF
--- a/__tests__/purchase-orders-api.test.js
+++ b/__tests__/purchase-orders-api.test.js
@@ -4,17 +4,14 @@ afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
 
 test('purchase orders index creates order', async () => {
   const createMock = jest.fn().mockResolvedValue({ id: 1 });
-  const addItemMock = jest.fn();
   jest.unstable_mockModule('../services/purchaseOrdersService.js', () => ({
     createPurchaseOrder: createMock,
-    addPurchaseOrderItem: addItemMock,
   }));
   const { default: handler } = await import('../pages/api/purchase-orders/index.js');
   const req = { method: 'POST', body: { order: { supplier_id: 1 }, items: [{ part_id: 2 }] }, headers: {} };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
   await handler(req, res);
-  expect(createMock).toHaveBeenCalledWith(req.body.order);
-  expect(addItemMock).toHaveBeenCalledWith({ purchase_order_id: 1, part_id: 2 });
+  expect(createMock).toHaveBeenCalledWith({ ...req.body.order, items: req.body.items });
   expect(res.status).toHaveBeenCalledWith(201);
   expect(res.json).toHaveBeenCalledWith({ id: 1 });
 });

--- a/__tests__/purchaseOrdersService.test.js
+++ b/__tests__/purchaseOrdersService.test.js
@@ -5,7 +5,7 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-test('createPurchaseOrder inserts order', async () => {
+test('createPurchaseOrder inserts order without items', async () => {
   const queryMock = jest.fn().mockResolvedValue([{ insertId: 5 }]);
   jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
   const { createPurchaseOrder } = await import('../services/purchaseOrdersService.js');
@@ -13,6 +13,42 @@ test('createPurchaseOrder inserts order', async () => {
   const result = await createPurchaseOrder(data);
   expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/INSERT INTO purchase_orders/), [1, 2, 'new']);
   expect(result).toEqual({ id: 5, ...data });
+});
+
+test('createPurchaseOrder inserts order with items in a transaction', async () => {
+  const conn = {
+    beginTransaction: jest.fn(),
+    query: jest
+      .fn()
+      .mockResolvedValueOnce([{ insertId: 5 }])
+      .mockResolvedValueOnce([{ insertId: 7 }]),
+    commit: jest.fn(),
+    rollback: jest.fn(),
+    release: jest.fn(),
+  };
+  const getConnection = jest.fn().mockResolvedValue(conn);
+  const queryMock = jest.fn();
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { getConnection, query: queryMock },
+  }));
+  const { createPurchaseOrder } = await import('../services/purchaseOrdersService.js');
+  const data = { job_id: 1, supplier_id: 2, status: 'new', items: [{ part_id: 6, qty: 2, unit_price: 3 }] };
+  const result = await createPurchaseOrder(data);
+  expect(getConnection).toHaveBeenCalled();
+  expect(conn.beginTransaction).toHaveBeenCalled();
+  expect(conn.query).toHaveBeenNthCalledWith(
+    1,
+    expect.stringMatching(/INSERT INTO purchase_orders/),
+    [1, 2, 'new']
+  );
+  expect(conn.query).toHaveBeenNthCalledWith(
+    2,
+    expect.stringMatching(/INSERT INTO purchase_order_items/),
+    [5, 6, 2, 3]
+  );
+  expect(conn.commit).toHaveBeenCalled();
+  expect(conn.release).toHaveBeenCalled();
+  expect(result).toEqual({ id: 5, job_id: 1, supplier_id: 2, status: 'new' });
 });
 
 test('addPurchaseOrderItem inserts item', async () => {

--- a/pages/api/purchase-orders/index.js
+++ b/pages/api/purchase-orders/index.js
@@ -1,15 +1,10 @@
-import { createPurchaseOrder, addPurchaseOrderItem } from '../../../services/purchaseOrdersService.js';
+import { createPurchaseOrder } from '../../../services/purchaseOrdersService.js';
 
 export default async function handler(req, res) {
   try {
     if (req.method === 'POST') {
       const { order, items } = req.body || {};
-      const po = await createPurchaseOrder(order);
-      if (items && Array.isArray(items)) {
-        for (const it of items) {
-          await addPurchaseOrderItem({ purchase_order_id: po.id, ...it });
-        }
-      }
+      const po = await createPurchaseOrder({ ...order, items });
       return res.status(201).json(po);
     }
     res.setHeader('Allow', ['POST']);

--- a/services/purchaseOrdersService.js
+++ b/services/purchaseOrdersService.js
@@ -1,6 +1,32 @@
 import pool from '../lib/db.js';
 
-export async function createPurchaseOrder({ job_id, supplier_id, status }) {
+export async function createPurchaseOrder({ job_id, supplier_id, status, items }) {
+  if (Array.isArray(items) && items.length > 0) {
+    const conn = await pool.getConnection();
+    try {
+      await conn.beginTransaction();
+      const [{ insertId }] = await conn.query(
+        `INSERT INTO purchase_orders (job_id, supplier_id, status)
+         VALUES (?,?,?)`,
+        [job_id || null, supplier_id, status || null]
+      );
+      for (const it of items) {
+        const { part_id, qty, unit_price } = it;
+        await conn.query(
+          `INSERT INTO purchase_order_items (purchase_order_id, part_id, qty, unit_price)
+           VALUES (?,?,?,?)`,
+          [insertId, part_id, qty || null, unit_price || null]
+        );
+      }
+      await conn.commit();
+      return { id: insertId, job_id, supplier_id, status };
+    } catch (err) {
+      await conn.rollback();
+      throw err;
+    } finally {
+      conn.release();
+    }
+  }
   const [{ insertId }] = await pool.query(
     `INSERT INTO purchase_orders (job_id, supplier_id, status)
      VALUES (?,?,?)`,


### PR DESCRIPTION
## Summary
- support inserting purchase order items in a single transaction
- update API handler to pass item array directly to service
- extend tests for purchase order service and API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686327500700832a9f4e06f153bd0c56