### PR TITLE
Implement parts management

### DIFF
--- a/__tests__/parts-api.test.js
+++ b/__tests__/parts-api.test.js
@@ -25,3 +25,52 @@ test('parts index creates part', async () => {
     supplier_id: 2,
   });
 });
+
+test('parts detail returns part', async () => {
+  const part = { id: 1 };
+  const getMock = jest.fn().mockResolvedValue(part);
+  jest.unstable_mockModule('../services/partsService.js', () => ({
+    getPartById: getMock,
+    updatePart: jest.fn(),
+    deletePart: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/parts/[id].js');
+  const req = { method: 'GET', query: { id: '1' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(part);
+  expect(getMock).toHaveBeenCalledWith('1');
+});
+
+test('parts detail updates part', async () => {
+  const updateMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/partsService.js', () => ({
+    getPartById: jest.fn(),
+    updatePart: updateMock,
+    deletePart: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/parts/[id].js');
+  const req = { method: 'PUT', query: { id: '2' }, body: { part_number: 'X' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ ok: true });
+  expect(updateMock).toHaveBeenCalledWith('2', req.body);
+});
+
+test('parts detail deletes part', async () => {
+  const deleteMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/partsService.js', () => ({
+    getPartById: jest.fn(),
+    updatePart: jest.fn(),
+    deletePart: deleteMock,
+  }));
+  const { default: handler } = await import('../pages/api/parts/[id].js');
+  const req = { method: 'DELETE', query: { id: '3' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(204);
+  expect(res.end).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalledWith('3');
+});

--- a/__tests__/partsService.test.js
+++ b/__tests__/partsService.test.js
@@ -17,3 +17,24 @@ test('createPart inserts row', async () => {
   );
   expect(result).toEqual({ id: 3, ...data });
 });
+
+test('updatePart updates row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { updatePart } = await import('../services/partsService.js');
+  const result = await updatePart(1, { part_number: 'X', supplier_id: 5 });
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/UPDATE parts/),
+    ['X', null, null, 5, 1]
+  );
+  expect(result).toEqual({ ok: true });
+});
+
+test('deletePart removes row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deletePart } = await import('../services/partsService.js');
+  const result = await deletePart(2);
+  expect(queryMock).toHaveBeenCalledWith('DELETE FROM parts WHERE id=?', [2]);
+  expect(result).toEqual({ ok: true });
+});

--- a/pages/api/parts/[id].js
+++ b/pages/api/parts/[id].js
@@ -1,0 +1,24 @@
+import { getPartById, updatePart, deletePart } from '../../../services/partsService.js';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const part = await getPartById(id);
+      return res.status(200).json(part);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updatePart(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await deletePart(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/office/parts/[id].js
+++ b/pages/office/parts/[id].js
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Layout } from '../../../components/Layout';
+
+export default function EditPartPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [form, setForm] = useState({
+    part_number: '',
+    description: '',
+    unit_cost: '',
+    supplier_id: '',
+  });
+  const [suppliers, setSuppliers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = () => {
+    if (!id) return;
+    setLoading(true);
+    Promise.all([
+      fetch(`/api/parts/${id}`).then(r => (r.ok ? r.json() : Promise.reject())),
+      fetch('/api/suppliers').then(r => (r.ok ? r.json() : Promise.reject())),
+    ])
+      .then(([p, s]) => {
+        setForm({
+          part_number: p.part_number || '',
+          description: p.description || '',
+          unit_cost: p.unit_cost || '',
+          supplier_id: p.supplier_id || '',
+        });
+        setSuppliers(s);
+      })
+      .catch(() => setError('Failed to load part'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, [id]);
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      await fetch(`/api/parts/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          part_number: form.part_number,
+          description: form.description,
+          unit_cost: form.unit_cost,
+          supplier_id: form.supplier_id || null,
+        }),
+      });
+      router.push('/office/parts');
+    } catch {
+      setError('Failed to update part');
+    }
+  };
+
+  if (loading) return <Layout><p>Loading…</p></Layout>;
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Edit Part</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block mb-1">Part Number</label>
+          <input name="part_number" value={form.part_number} onChange={change} className="input w-full" />
+        </div>
+        <div>
+          <label className="block mb-1">Description</label>
+          <input name="description" value={form.description} onChange={change} className="input w-full" />
+        </div>
+        <div>
+          <label className="block mb-1">Unit Cost</label>
+          <input name="unit_cost" value={form.unit_cost} onChange={change} className="input w-full" />
+        </div>
+        <div>
+          <label className="block mb-1">Supplier</label>
+          <select name="supplier_id" value={form.supplier_id} onChange={change} className="input w-full">
+            <option value="">-- None --</option>
+            {suppliers.map(s => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        </div>
+        <button type="submit" className="button">Save</button>
+      </form>
+    </Layout>
+  );
+}

--- a/pages/office/parts/index.js
+++ b/pages/office/parts/index.js
@@ -1,11 +1,77 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Layout } from '../../../components/Layout';
 
-const PartsPage = () => (
-  <Layout>
-    <h1 className="text-xl font-semibold">Parts Catalog</h1>
-    {/* TODO: Display parts inventory */}
-  </Layout>
-);
+export default function PartsPage() {
+  const [parts, setParts] = useState([]);
+  const [suppliers, setSuppliers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
 
-export default PartsPage;
+  const load = () => {
+    setLoading(true);
+    Promise.all([
+      fetch('/api/parts').then(r => (r.ok ? r.json() : Promise.reject())),
+      fetch('/api/suppliers').then(r => (r.ok ? r.json() : Promise.reject())),
+    ])
+      .then(([p, s]) => {
+        setParts(p);
+        setSuppliers(s);
+      })
+      .catch(() => setError('Failed to load parts'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const handleDelete = async id => {
+    if (!confirm('Delete this part?')) return;
+    await fetch(`/api/parts/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  const filtered = parts.filter(p =>
+    p.part_number.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    (p.description || '').toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const supplierName = id => suppliers.find(s => s.id === id)?.name || '';
+
+  return (
+    <Layout>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-semibold">Parts</h1>
+        <Link href="/office/parts/new" className="button">+ New Part</Link>
+      </div>
+      <Link href="/office" className="button inline-block mb-4">Return to Office</Link>
+      {error && <p className="text-red-500">{error}</p>}
+      {loading ? (
+        <p>Loading…</p>
+      ) : (
+        <>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            placeholder="Search…"
+            className="input mb-4 w-full"
+          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            {filtered.map(p => (
+              <div key={p.id} className="item-card">
+                <h2 className="font-semibold mb-1">{p.part_number}</h2>
+                <p className="text-sm">{p.description}</p>
+                <p className="text-sm">Supplier: {supplierName(p.supplier_id)}</p>
+                <div className="mt-2 flex gap-2">
+                  <Link href={`/office/parts/${p.id}`} className="button px-4 text-sm">Edit</Link>
+                  <button onClick={() => handleDelete(p.id)} className="button px-4 text-sm bg-red-600 hover:bg-red-700">Delete</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </Layout>
+  );
+}

--- a/pages/office/parts/new.js
+++ b/pages/office/parts/new.js
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { Layout } from '../../../components/Layout';
+
+export default function NewPartPage() {
+  const [form, setForm] = useState({
+    part_number: '',
+    description: '',
+    unit_cost: '',
+    supplier_id: '',
+  });
+  const [suppliers, setSuppliers] = useState([]);
+  const [error, setError] = useState(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch('/api/suppliers')
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setSuppliers)
+      .catch(() => setError('Failed to load suppliers'));
+  }, []);
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/parts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          part_number: form.part_number,
+          description: form.description,
+          unit_cost: form.unit_cost,
+          supplier_id: form.supplier_id || null,
+        }),
+      });
+      if (!res.ok) throw new Error();
+      router.push('/office/parts');
+    } catch {
+      setError('Failed to create part');
+    }
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">New Part</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block mb-1">Part Number</label>
+          <input name="part_number" value={form.part_number} onChange={change} className="input w-full" />
+        </div>
+        <div>
+          <label className="block mb-1">Description</label>
+          <input name="description" value={form.description} onChange={change} className="input w-full" />
+        </div>
+        <div>
+          <label className="block mb-1">Unit Cost</label>
+          <input name="unit_cost" value={form.unit_cost} onChange={change} className="input w-full" />
+        </div>
+        <div>
+          <label className="block mb-1">Supplier</label>
+          <select name="supplier_id" value={form.supplier_id} onChange={change} className="input w-full">
+            <option value="">-- None --</option>
+            {suppliers.map(s => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        </div>
+        <button type="submit" className="button">Save</button>
+      </form>
+    </Layout>
+  );
+}

--- a/services/partsService.js
+++ b/services/partsService.js
@@ -33,3 +33,24 @@ export async function createPart({
   );
   return { id: insertId, part_number, description, unit_cost, supplier_id };
 }
+
+export async function getPartById(id) {
+  const [[row]] = await pool.query(
+    `SELECT id, part_number, description, unit_cost, supplier_id FROM parts WHERE id=?`,
+    [id]
+  );
+  return row || null;
+}
+
+export async function updatePart(id, { part_number, description, unit_cost, supplier_id }) {
+  await pool.query(
+    `UPDATE parts SET part_number=?, description=?, unit_cost=?, supplier_id=? WHERE id=?`,
+    [part_number, description || null, unit_cost || null, supplier_id || null, id]
+  );
+  return { ok: true };
+}
+
+export async function deletePart(id) {
+  await pool.query('DELETE FROM parts WHERE id=?', [id]);
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- support updating and deleting parts in `partsService`
- expose `/api/parts/[id]` for retrieving, updating and deleting a part
- build UI pages for listing, creating and editing parts
- test new service functions and API endpoints

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68632882beec832ab61d514a7d68a59e