### PR TITLE
Create job on quote approval

### DIFF
--- a/pages/api/jobs/index.js
+++ b/pages/api/jobs/index.js
@@ -15,7 +15,11 @@ export default async function handler(req, res) {
       const jobs = await service.getAllJobs(status);
       return res.status(200).json(jobs);
     }
-    res.setHeader('Allow', ['GET']);
+    if (req.method === 'POST') {
+      const job = await service.createJob(req.body);
+      return res.status(201).json(job);
+    }
+    res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
   } catch (err) {
     console.error(err);

--- a/pages/office/quotations/[id]/purchase-orders.js
+++ b/pages/office/quotations/[id]/purchase-orders.js
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { Layout } from '../../../../components/Layout';
+
+export default function QuotePurchaseOrdersPage() {
+  const router = useRouter();
+  const { id, job_id } = router.query;
+  const [groups, setGroups] = useState({});
+  const [suppliers, setSuppliers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    async function load() {
+      setLoading(true);
+      try {
+        const [itemsRes, suppRes] = await Promise.all([
+          fetch(`/api/quote-items?quote_id=${id}`),
+          fetch('/api/suppliers'),
+        ]);
+        const items = itemsRes.ok ? await itemsRes.json() : [];
+        const sups = suppRes.ok ? await suppRes.json() : [];
+        const map = {};
+        items.forEach(it => {
+          if (!it.supplier_id) return;
+          map[it.supplier_id] ||= [];
+          map[it.supplier_id].push(it);
+        });
+        setGroups(map);
+        setSuppliers(sups);
+      } catch {
+        setError('Failed to load');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id]);
+
+  const supplierName = sid => suppliers.find(s => s.id === Number(sid))?.name || 'Supplier';
+
+  const createPO = async sid => {
+    const list = groups[sid] || [];
+    await fetch('/api/purchase-orders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        order: { job_id: job_id || null, supplier_id: sid, status: 'new' },
+        items: list.map(i => ({ part_id: i.part_id, qty: i.qty, unit_price: i.unit_price })),
+      }),
+    });
+    router.push('/office/quotations');
+  };
+
+  if (loading) return <Layout><p>Loading…</p></Layout>;
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Quote #{id} Parts</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      {Object.keys(groups).length === 0 ? (
+        <p>No supplier parts found.</p>
+      ) : (
+        Object.entries(groups).map(([sid, items]) => (
+          <div key={sid} className="mb-6">
+            <h2 className="font-semibold mb-2">{supplierName(sid)}</h2>
+            <ul className="mb-2">
+              {items.map(it => (
+                <li key={it.id} className="text-sm">
+                  {(it.description || it.part_id) + ' – qty ' + it.qty + ' @ €' + it.unit_price}
+                </li>
+              ))}
+            </ul>
+            <button onClick={() => createPO(sid)} className="button px-4 text-sm">
+              Generate Purchase Order
+            </button>
+          </div>
+        ))
+      )}
+      <Link href="/office/quotations" className="button mt-4 inline-block">
+        Back to Quotes
+      </Link>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- allow creating jobs via POST /api/jobs
- add job creation step when approving quotes and store job_id
- route to a quote purchase order generation page after approval
- remove automatic PO creation from job card conversion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68632ad68490832aa32c884b04a13365