### PR TITLE
Move OfficeDashboard into components folder

### DIFF
--- a/components/OfficeDashboard.jsx
+++ b/components/OfficeDashboard.jsx
@@ -1,11 +1,11 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { fetchQuotes } from '../../lib/quotes';
-import { fetchJobs } from '../../lib/jobs';
-import { fetchInvoices } from '../../lib/invoices';
-import { JOB_STATUSES } from '../../lib/jobStatuses';
-import logout from '../../lib/logout.js';
+import { fetchQuotes } from '../lib/quotes';
+import { fetchJobs } from '../lib/jobs';
+import { fetchInvoices } from '../lib/invoices';
+import { JOB_STATUSES } from '../lib/jobStatuses';
+import logout from '../lib/logout.js';
 
 export default function OfficeDashboard() {
   const router = useRouter();

--- a/pages/office/index.js
+++ b/pages/office/index.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { useCurrentUser } from '../../components/useCurrentUser.js';
-import OfficeDashboard from '../../src/components/OfficeDashboard.jsx';
+import OfficeDashboard from '../../components/OfficeDashboard.jsx';
 
 export default function OfficePage() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- relocate `OfficeDashboard.jsx` from `src/components` to the main `components` directory
- update relative imports inside `OfficeDashboard.jsx`
- adjust office index page to import the moved component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686331b0d22c832a95394304b0010793