### PR TITLE
Add document templates preview

### DIFF
--- a/pages/office/company-settings.js
+++ b/pages/office/company-settings.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Layout } from '../../components/Layout';
 
 const S3_BASE_URL = `https://${process.env.NEXT_PUBLIC_S3_BUCKET}.s3.${process.env.NEXT_PUBLIC_AWS_REGION}.amazonaws.com`;
@@ -84,7 +85,10 @@ export default function CompanySettingsPage() {
 
   return (
     <Layout>
-      <h1 className="text-2xl font-semibold mb-4">Company Settings</h1>
+      <h1 className="text-2xl font-semibold mb-2">Company Settings</h1>
+      <Link href="/office/document-templates" className="text-blue-600 underline mb-4 inline-block">
+        View Document Templates
+      </Link>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
         <div>

--- a/pages/office/document-templates.js
+++ b/pages/office/document-templates.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { Layout } from '../../components/Layout';
+
+function TemplateBox({ title, company }) {
+  return (
+    <div className="mb-8">
+      <h2 className="text-xl font-semibold mb-2">{title} Template</h2>
+      <div className="border rounded p-4 bg-white text-black space-y-2">
+        {company.logo_url && (
+          <img src={company.logo_url} alt="Logo" className="h-16" />
+        )}
+        {company.company_name && (
+          <p className="font-bold">{company.company_name}</p>
+        )}
+        {company.address && <p className="text-sm">{company.address}</p>}
+        <p className="text-sm italic mt-4">
+          This preview uses your company settings.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function DocumentTemplatesPage() {
+  const [settings, setSettings] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/company-settings')
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => setSettings(data || {}))
+      .catch(() => setSettings({}))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return (
+    <Layout>
+      <p>Loading…</p>
+    </Layout>
+  );
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Document Templates</h1>
+      <TemplateBox title="Invoice" company={settings} />
+      <TemplateBox title="Quotation" company={settings} />
+      <TemplateBox title="Job Card" company={settings} />
+      <TemplateBox title="Purchase Order" company={settings} />
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- create a Document Templates page to preview invoice, quotation, job card, and purchase order layouts using company settings
- add link from Company Settings to the new document templates page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686333bf6dfc832ab268241e6bb3f58e