### PR TITLE
Fix dev portal root

### DIFF
--- a/pages/dev/index.js
+++ b/pages/dev/index.js
@@ -1,0 +1,10 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function DevIndex() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/dev/dashboard');
+  }, [router]);
+  return null;
+}


### PR DESCRIPTION
## Summary
- redirect `/dev` to `/dev/dashboard`

## Testing
- `npm test`
- `npm run lint`
- `npm run dev` *(fails: manual check via `curl`)*

------
https://chatgpt.com/codex/tasks/task_e_6863dce47b3c832a971b46c0d7c21565