### PR TITLE
Add home links to Fleet pages

### DIFF
--- a/pages/fleet/index.js
+++ b/pages/fleet/index.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import logout from '../../lib/logout.js';
 import { fetchVehicles } from '../../lib/vehicles';
 import { fetchInvoices } from '../../lib/invoices';
@@ -49,6 +50,9 @@ export default function FleetDashboard() {
       <div className="p-4 text-right">
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
       </div>
+      <Link href="/fleet/home" className="button inline-block mb-4">
+        Return to Home
+      </Link>
       <PortalDashboard
         title={`${fleet.company_name} Dashboard`}
         requestJobPath="/fleet/request-job"

--- a/pages/fleet/request-job.js
+++ b/pages/fleet/request-job.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import { fetchVehicles } from '../../lib/vehicles';
 import logout from '../../lib/logout.js';
 
@@ -52,6 +53,9 @@ export default function FleetRequestJob() {
         <h1 className="text-2xl font-bold">New Job Request</h1>
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
       </div>
+      <Link href="/fleet/home" className="button inline-block mb-4">
+        Return to Home
+      </Link>
       {message && <p className="text-green-600 mb-2">{message}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-sm">
         <select value={vehicleId} onChange={e => setVehicleId(e.target.value)} className="input w-full" required>


### PR DESCRIPTION
## Summary
- add a home `<Link>` in `pages/fleet/index.js`
- add the same home link in `pages/fleet/request-job.js`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6863e28cef48832a8202169989e1ef00