### PR TITLE
Add fleet view dashboard

### DIFF
--- a/pages/office/fleets/index.js
+++ b/pages/office/fleets/index.js
@@ -68,6 +68,9 @@ const FleetsPage = () => {
                   {f.payment_terms || '—'}
                 </p>
                 <div className="mt-3 flex flex-wrap gap-2">
+                  <Link href={`/office/fleets/view/${f.id}`} className="button px-4 text-sm">
+                    View
+                  </Link>
                   <Link href={`/office/fleets/${f.id}`} className="button px-4 text-sm">
                     Edit
                   </Link>

--- a/pages/office/fleets/view/[id].js
+++ b/pages/office/fleets/view/[id].js
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { Layout } from '../../../../components/Layout';
+import { PortalDashboard } from '../../../../components/PortalDashboard';
+import { fetchVehicles } from '../../../../lib/vehicles';
+import { fetchJobs } from '../../../../lib/jobs';
+
+export default function FleetViewPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [fleet, setFleet] = useState(null);
+  const [vehicles, setVehicles] = useState([]);
+  const [jobs, setJobs] = useState([]);
+  const [quotes, setQuotes] = useState([]);
+  const [invoices, setInvoices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    (async () => {
+      try {
+        const res = await fetch(`/api/fleets/${id}`);
+        if (!res.ok) throw new Error();
+        const f = await res.json();
+        setFleet(f);
+        const [v, j, q, i] = await Promise.all([
+          fetchVehicles(null, id),
+          fetchJobs({ fleet_id: id, status: 'in progress' }),
+          fetch(`/api/quotes?fleet_id=${id}`).then(r => r.json()),
+          fetch(`/api/invoices?fleet_id=${id}`).then(r => r.json()),
+        ]);
+        setVehicles(v);
+        setJobs(j);
+        setQuotes(q);
+        setInvoices(i);
+      } catch (err) {
+        setError('Failed to load');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [id]);
+
+  const deleteFleet = async () => {
+    if (!confirm('Delete this fleet?')) return;
+    await fetch(`/api/fleets/${id}`, { method: 'DELETE' });
+    router.push('/office/fleets');
+  };
+
+  if (loading) return (
+    <Layout>
+      <p>Loading…</p>
+    </Layout>
+  );
+  if (error) return (
+    <Layout>
+      <p className="text-red-500">{error}</p>
+    </Layout>
+  );
+
+  return (
+    <Layout>
+      <div className="mb-6 flex flex-wrap items-center gap-4">
+        <Link href={`/office/fleets/${id}`} className="button">Edit Fleet</Link>
+        <button onClick={deleteFleet} className="button bg-red-600 hover:bg-red-700">Delete Fleet</button>
+        <Link href="/office/fleets" className="button">Back to Fleets</Link>
+      </div>
+      <PortalDashboard
+        title={`${fleet.company_name} Dashboard`}
+        requestJobPath={`/office/jobs/new?fleet_id=${id}`}
+        vehicles={vehicles}
+        jobs={jobs}
+        quotes={quotes}
+        setQuotes={setQuotes}
+        invoices={invoices}
+      />
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- link to fleet view page from fleets list
- add fleet view dashboard page using PortalDashboard widget

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6863e3a067e8832a9af980858b913a91