### PR TITLE
Fix job statuses migration

### DIFF
--- a/migrations/20251214_create_job_statuses.sql
+++ b/migrations/20251214_create_job_statuses.sql
@@ -12,4 +12,4 @@ INSERT INTO job_statuses (name)
     ('awaiting return'),
     ('completed');
 
-ALTER TABLE jobs DROP CHECK chk_jobs_status;
+ALTER TABLE jobs DROP CONSTRAINT chk_jobs_status;


### PR DESCRIPTION
## Summary
- fix drop constraint syntax in migrations
- verified `npm run migrate` works with local MariaDB after applying earlier migrations

## Testing
- `npm run migrate`

------
https://chatgpt.com/codex/tasks/task_e_6863ebb09fc8832aa06c0da41f3527d8