### PR TITLE
Fix migration duplication issue

### DIFF
--- a/migrations/20251214_create_job_statuses.sql
+++ b/migrations/20251214_create_job_statuses.sql
@@ -3,13 +3,12 @@ CREATE TABLE IF NOT EXISTS job_statuses (
   name VARCHAR(50) NOT NULL UNIQUE
 );
 
-INSERT INTO job_statuses (name)
-  VALUES
-    ('awaiting collection'),
-    ('awaiting assessment'),
-    ('awaiting parts'),
-    ('in progress'),
-    ('awaiting return'),
-    ('completed');
+INSERT IGNORE INTO job_statuses (name) VALUES
+  ('awaiting collection'),
+  ('awaiting assessment'),
+  ('awaiting parts'),
+  ('in progress'),
+  ('awaiting return'),
+  ('completed');
 
 ALTER TABLE jobs DROP CONSTRAINT chk_jobs_status;


### PR DESCRIPTION
## Summary
- guard against re-running the job status migration by ignoring duplicate records

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f0daa90c832a948c632601c8dac8