### PR TITLE
Add suppliers link on office dashboard

### DIFF
--- a/components/OfficeDashboard.jsx
+++ b/components/OfficeDashboard.jsx
@@ -179,6 +179,12 @@ export default function OfficeDashboard() {
                   Vehicles
                 </Link>
               </li>
+              <li>
+                <Link href="/office/suppliers" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Suppliers
+                </Link>
+              </li>
             </ul>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- show Suppliers link under Assets on the Office dashboard

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68641fdee94c832abcc25f23360199ff