### PR TITLE
Introduce OfficeLayout for office pages

### DIFF
--- a/components/OfficeDashboard.jsx
+++ b/components/OfficeDashboard.jsx
@@ -1,30 +1,14 @@
 import { useEffect, useState, useMemo } from 'react';
-import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { fetchQuotes } from '../lib/quotes';
 import { fetchJobs } from '../lib/jobs';
 import { fetchInvoices } from '../lib/invoices';
 import { fetchJobStatuses } from '../lib/jobStatuses';
-import logout from '../lib/logout.js';
-
-function ArrowIcon() {
-  return (
-    <svg
-      viewBox="0 0 20 20"
-      fill="currentColor"
-      className="w-4 h-4 mr-2 flex-shrink-0"
-    >
-      <path d="M9 5l7 5-7 5V5z" />
-    </svg>
-  );
-}
 
 export default function OfficeDashboard() {
-  const router = useRouter();
   const [quotes, setQuotes] = useState([]);
   const [jobs, setJobs] = useState([]);
   const [invoices, setInvoices] = useState([]);
-  const [searchQuery, setSearchQuery] = useState('');
   const [statuses, setStatuses] = useState([]);
 
   useEffect(() => {
@@ -59,187 +43,31 @@ export default function OfficeDashboard() {
     return counts;
   }, [jobs, statuses]);
 
-  async function handleLogout() {
-    try {
-      await logout();
-    } finally {
-      router.push('/login');
-    }
-  }
-
   return (
-    <div className="min-h-screen flex text-white bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700">
-      <aside className="w-64 bg-blue-900 p-6 space-y-6">
-        <nav className="space-y-4">
-          <div>
-            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Sales</h3>
-            <ul className="space-y-1">
-              <li>
-                <Link href="/office/quotations/new" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  New Quotation
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/invoices" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Invoices
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/invoices?status=unpaid" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Pay Invoice
-                </Link>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Operations</h3>
-            <ul className="space-y-1">
-              <li>
-                <Link href="/office/jobs/new" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  New Job
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/job-requests" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Job Requests
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/job-management" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Job Management
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/job-cards" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Job Cards
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/scheduling" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Scheduling
-                </Link>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">CRM</h3>
-            <ul className="space-y-1">
-              <li>
-                <Link href="/office/clients" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Clients
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/engineers" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Engineers
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/crm" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  CRM
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/reporting" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Reporting
-                </Link>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Assets</h3>
-            <ul className="space-y-1">
-              <li>
-                <Link href="/office/parts" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Parts
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/fleets" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Fleets
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/vehicles" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Vehicles
-                </Link>
-              </li>
-              <li>
-                <Link href="/office/suppliers" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Suppliers
-                </Link>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Settings</h3>
-            <ul className="space-y-1">
-              <li>
-                <Link href="/office/company-settings" className="flex items-center hover:underline">
-                  <ArrowIcon />
-                  Company Settings
-                </Link>
-              </li>
-              <li>
-                <button onClick={handleLogout} className="flex items-center w-full text-left hover:underline">
-                  <ArrowIcon />
-                  Logout
-                </button>
-              </li>
-            </ul>
-          </div>
-        </nav>
-      </aside>
-      <div className="flex-1 flex flex-col">
-        <header className="bg-blue-700 p-6 space-y-4">
-          <div className="flex items-center space-x-3">
-            <img src="/logo.png" alt="Garage Vision" className="w-10 h-10 rounded-full" />
-            <h1 className="text-2xl font-bold">Garage Vision</h1>
-          </div>
-          <input type="text" placeholder="Search…" value={searchQuery} onChange={e => setSearchQuery(e.target.value)} className="input w-full" />
-        </header>
-        <div className="p-6 space-y-6 flex-1 overflow-y-auto">
-          <div className="flex flex-wrap justify-center gap-4">
-            <Link href="/office/quotations/new" className="button px-8 text-lg">Create Quote</Link>
-            <Link href="/office/jobs/new" className="button px-8 text-lg">New Job</Link>
-            <Link href="/office/invoices?status=unpaid" className="button px-8 text-lg">Pay Invoice</Link>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="bg-white text-black rounded-2xl p-4 shadow">
-              <h2 className="text-lg font-semibold mb-2">Open Quotes</h2>
-              <p className="text-4xl font-bold text-blue-600">{openQuotes.length}</p>
-            </div>
-            <div className="bg-white text-black rounded-2xl p-4 shadow">
-              <h2 className="text-lg font-semibold mb-2">Jobs</h2>
-              <ul className="text-sm space-y-1">
-                {statuses.map(s => (
-                  <li key={s.id} className="capitalize">{s.name}: {jobStatusCounts[s.name] || 0}</li>
-                ))}
-              </ul>
-            </div>
-            <div className="bg-white text-black rounded-2xl p-4 shadow">
-              <h2 className="text-lg font-semibold mb-2">Unpaid Invoices</h2>
-              <p className="text-4xl font-bold text-blue-600">{unpaidInvoices.length}</p>
-            </div>
-          </div>
+    <>
+      <div className="flex flex-wrap justify-center gap-4">
+        <Link href="/office/quotations/new" className="button px-8 text-lg">Create Quote</Link>
+        <Link href="/office/jobs/new" className="button px-8 text-lg">New Job</Link>
+        <Link href="/office/invoices?status=unpaid" className="button px-8 text-lg">Pay Invoice</Link>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="bg-white text-black rounded-2xl p-4 shadow">
+          <h2 className="text-lg font-semibold mb-2">Open Quotes</h2>
+          <p className="text-4xl font-bold text-blue-600">{openQuotes.length}</p>
+        </div>
+        <div className="bg-white text-black rounded-2xl p-4 shadow">
+          <h2 className="text-lg font-semibold mb-2">Jobs</h2>
+          <ul className="text-sm space-y-1">
+            {statuses.map(s => (
+              <li key={s.id} className="capitalize">{s.name}: {jobStatusCounts[s.name] || 0}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="bg-white text-black rounded-2xl p-4 shadow">
+          <h2 className="text-lg font-semibold mb-2">Unpaid Invoices</h2>
+          <p className="text-4xl font-bold text-blue-600">{unpaidInvoices.length}</p>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/components/OfficeLayout.jsx
+++ b/components/OfficeLayout.jsx
@@ -1,0 +1,185 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import logout from '../lib/logout.js';
+
+function ArrowIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 mr-2 flex-shrink-0">
+      <path d="M9 5l7 5-7 5V5z" />
+    </svg>
+  );
+}
+
+export default function OfficeLayout({ children }) {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } finally {
+      router.push('/login');
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex text-white bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700">
+      <aside className="w-64 bg-blue-900 p-6 space-y-6">
+        <nav className="space-y-4">
+          <div>
+            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Sales</h3>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/office/quotations/new" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  New Quotation
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/invoices" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Invoices
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/invoices?status=unpaid" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Pay Invoice
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Operations</h3>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/office/jobs/new" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  New Job
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/job-requests" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Job Requests
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/job-management" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Job Management
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/job-cards" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Job Cards
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/scheduling" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Scheduling
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">CRM</h3>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/office/clients" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Clients
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/engineers" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Engineers
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/crm" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  CRM
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/reporting" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Reporting
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Assets</h3>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/office/parts" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Parts
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/fleets" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Fleets
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/vehicles" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Vehicles
+                </Link>
+              </li>
+              <li>
+                <Link href="/office/suppliers" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Suppliers
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Settings</h3>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/office/company-settings" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Company Settings
+                </Link>
+              </li>
+              <li>
+                <button onClick={handleLogout} className="flex items-center w-full text-left hover:underline">
+                  <ArrowIcon />
+                  Logout
+                </button>
+              </li>
+            </ul>
+          </div>
+        </nav>
+      </aside>
+      <div className="flex-1 flex flex-col">
+        <header className="bg-blue-700 p-6 space-y-4">
+          <div className="flex items-center space-x-3">
+            <img src="/logo.png" alt="Garage Vision" className="w-10 h-10 rounded-full" />
+            <h1 className="text-2xl font-bold">Garage Vision</h1>
+          </div>
+          <input
+            type="text"
+            placeholder="Search…"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            className="input w-full"
+          />
+        </header>
+        <div className="p-6 space-y-6 flex-1 overflow-y-auto">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/office/clients/[id].js
+++ b/pages/office/clients/[id].js
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchVehicles } from '../../../lib/vehicles';
 
 const EditClientPage = () => {
@@ -60,10 +60,10 @@ const EditClientPage = () => {
     fetchVehicles(id).then(setVehicles);
   };
 
-  if (loading) return <Layout><p>Loading…</p></Layout>;
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Edit Client</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -143,7 +143,7 @@ const EditClientPage = () => {
           </table>
         )}
       </div>
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/clients/index.js
+++ b/pages/office/clients/index.js
@@ -1,7 +1,7 @@
 // pages/office/clients/index.js
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchClients } from '../../../lib/clients';
 import { fetchVehicles } from '../../../lib/vehicles';
 import { fetchFleets } from '../../../lib/fleets';
@@ -53,14 +53,13 @@ const ClientsPage = () => {
   });
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-semibold">Clients</h1>
         <Link href="/office/clients/new" className="button">
           + New Client
         </Link>
       </div>
-      <Link href="/office" className="button inline-block mb-4">Return to Office</Link>
       {loading && <p>Loading…</p>}
       {error && <p className="text-red-500">{error}</p>}
       {!loading && !error && (
@@ -111,7 +110,7 @@ const ClientsPage = () => {
         </div>
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/clients/new.js
+++ b/pages/office/clients/new.js
@@ -1,7 +1,7 @@
 // pages/office/clients/new.js
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const NewClientPage = () => {
   const [form, setForm] = useState({
@@ -52,7 +52,7 @@ const NewClientPage = () => {
   const changeVehicle = e => setVehicle(v => ({ ...v, [e.target.name]: e.target.value }));
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">New Client</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -92,7 +92,7 @@ const NewClientPage = () => {
         ))}
           <button type="submit" className="button">Save</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/clients/view/[id].js
+++ b/pages/office/clients/view/[id].js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { Layout } from '../../../../components/Layout';
+import OfficeLayout from '../../../../components/OfficeLayout';
 import { Card } from '../../../../components/Card';
 import { fetchVehicles } from '../../../../lib/vehicles';
 import { fetchDocuments } from '../../../../lib/documents';
@@ -49,11 +49,11 @@ export default function ClientViewPage() {
     setVehicles(vs);
   };
 
-  if (loading) return <Layout><p>Loading…</p></Layout>;
-  if (error) return <Layout><p className="text-red-500">{error}</p></Layout>;
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
+  if (error) return <OfficeLayout><p className="text-red-500">{error}</p></OfficeLayout>;
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="mb-6 flex flex-wrap items-center gap-4">
         <Link href={`/office/clients/${id}`}><a className="button">Edit Client</a></Link>
         <button onClick={deleteClient} className="button bg-red-600 hover:bg-red-700">Delete Client</button>
@@ -111,6 +111,6 @@ export default function ClientViewPage() {
           )}
         </Card>
       </div>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/company-settings.js
+++ b/pages/office/company-settings.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Layout } from '../../components/Layout';
+import OfficeLayout from '../../components/OfficeLayout';
 
 const S3_BASE_URL = `https://${process.env.NEXT_PUBLIC_S3_BUCKET}.s3.${process.env.NEXT_PUBLIC_AWS_REGION}.amazonaws.com`;
 
@@ -103,15 +103,15 @@ export default function CompanySettingsPage() {
   }
 
   if (loading) return (
-    <Layout>
+    <OfficeLayout>
       <p>Loading…</p>
-    </Layout>
+    </OfficeLayout>
   );
 
   const fields = ['company_name', 'address', 'phone', 'website', 'social_links', 'terms'];
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-2">Company Settings</h1>
       <Link href="/office/document-templates" className="text-blue-600 underline mb-4 inline-block">
         View Document Templates
@@ -182,6 +182,6 @@ export default function CompanySettingsPage() {
           </ul>
       </div>
       </div>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/crm/index.js
+++ b/pages/office/crm/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const CrmPage = () => (
-  <Layout>
+  <OfficeLayout>
     <h1 className="text-xl font-semibold">CRM</h1>
     {/* TODO: CRM tools and client interactions */}
-  </Layout>
+  </OfficeLayout>
 );
 
 export default CrmPage;

--- a/pages/office/document-templates.js
+++ b/pages/office/document-templates.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Layout } from '../../components/Layout';
+import OfficeLayout from '../../components/OfficeLayout';
 
 function TemplateBox({ title, company }) {
   return (
@@ -34,18 +34,18 @@ export default function DocumentTemplatesPage() {
   }, []);
 
   if (loading) return (
-    <Layout>
+    <OfficeLayout>
       <p>Loading…</p>
-    </Layout>
+    </OfficeLayout>
   );
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Document Templates</h1>
       <TemplateBox title="Invoice" company={settings} />
       <TemplateBox title="Quotation" company={settings} />
       <TemplateBox title="Job Card" company={settings} />
       <TemplateBox title="Purchase Order" company={settings} />
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/engineers/[id].js
+++ b/pages/office/engineers/[id].js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const EditEngineerPage = () => {
   const { id } = useRouter().query;
@@ -35,10 +35,10 @@ const EditEngineerPage = () => {
 
   const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
 
-  if (loading) return <Layout><p>Loading…</p></Layout>;
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Edit Engineer</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -67,7 +67,7 @@ const EditEngineerPage = () => {
         </div>
         <button type="submit" className="button">Update</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/engineers/index.js
+++ b/pages/office/engineers/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchEngineers } from '../../../lib/engineers';
 
 const EngineersPage = () => {
@@ -34,16 +34,13 @@ const EngineersPage = () => {
   });
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-semibold">Engineers</h1>
         <Link href="/office/engineers/new" className="button">
           + New Engineer
         </Link>
       </div>
-      <Link href="/office" className="button inline-block mb-4">
-        Return to Office
-      </Link>
       {loading && <p>Loading…</p>}
       {error && <p className="text-red-500">{error}</p>}
       {!loading && !error && (
@@ -83,7 +80,7 @@ const EngineersPage = () => {
           </div>
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/engineers/new.js
+++ b/pages/office/engineers/new.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const NewEngineerPage = () => {
   const [form, setForm] = useState({ username: '', email: '', password: '' });
@@ -25,7 +25,7 @@ const NewEngineerPage = () => {
   const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">New Engineer</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -46,7 +46,7 @@ const NewEngineerPage = () => {
         ))}
         <button type="submit" className="button">Save</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/engineers/view/[id].js
+++ b/pages/office/engineers/view/[id].js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { Layout } from '../../../../components/Layout';
+import OfficeLayout from '../../../../components/OfficeLayout';
 import { Card } from '../../../../components/Card';
 
 export default function EngineerViewPage() {
@@ -34,11 +34,11 @@ export default function EngineerViewPage() {
     router.push('/office/engineers');
   };
 
-  if (loading) return <Layout><p>Loading…</p></Layout>;
-  if (error) return <Layout><p className="text-red-500">{error}</p></Layout>;
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
+  if (error) return <OfficeLayout><p className="text-red-500">{error}</p></OfficeLayout>;
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="mb-6 flex flex-wrap items-center gap-4">
         <Link href={`/office/engineers/${id}`} className="button">Edit Engineer</Link>
         <button onClick={deleteEngineer} className="button bg-red-600 hover:bg-red-700">Delete Engineer</button>
@@ -49,6 +49,6 @@ export default function EngineerViewPage() {
         <p><strong>Username:</strong> {engineer.username}</p>
         <p><strong>Email:</strong> {engineer.email || '—'}</p>
       </Card>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/fleets/[id].js
+++ b/pages/office/fleets/[id].js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const EditFleetPage = () => {
   const router = useRouter();
@@ -60,10 +60,10 @@ const EditFleetPage = () => {
     setVehicles(vs => vs.filter(v => v.id !== vid));
   };
 
-  if (loading) return <Layout><p>Loading…</p></Layout>;
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Edit Fleet</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -130,7 +130,7 @@ const EditFleetPage = () => {
           </table>
         )}
       </div>
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/fleets/index.js
+++ b/pages/office/fleets/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchFleets } from '../../../lib/fleets';
 
 const FleetsPage = () => {
@@ -34,16 +34,13 @@ const FleetsPage = () => {
   });
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-semibold">Fleets</h1>
         <Link href="/office/fleets/new" className="button">
           + New Fleet
         </Link>
       </div>
-      <Link href="/office" className="button inline-block mb-4">
-        Return to Office
-      </Link>
       {loading && <p>Loading…</p>}
       {error && <p className="text-red-500">{error}</p>}
       {!loading && !error && (
@@ -86,7 +83,7 @@ const FleetsPage = () => {
           </div>
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/fleets/new.js
+++ b/pages/office/fleets/new.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const NewFleetPage = () => {
   const router = useRouter();
@@ -38,7 +38,7 @@ const NewFleetPage = () => {
   const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">New Fleet</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -68,7 +68,7 @@ const NewFleetPage = () => {
         ))}
         <button type="submit" className="button">Save</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/fleets/view/[id].js
+++ b/pages/office/fleets/view/[id].js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { Layout } from '../../../../components/Layout';
+import OfficeLayout from '../../../../components/OfficeLayout';
 import { PortalDashboard } from '../../../../components/PortalDashboard';
 import { fetchVehicles } from '../../../../lib/vehicles';
 import { fetchJobs } from '../../../../lib/jobs';
@@ -50,18 +50,18 @@ export default function FleetViewPage() {
   };
 
   if (loading) return (
-    <Layout>
+    <OfficeLayout>
       <p>Loading…</p>
-    </Layout>
+    </OfficeLayout>
   );
   if (error) return (
-    <Layout>
+    <OfficeLayout>
       <p className="text-red-500">{error}</p>
-    </Layout>
+    </OfficeLayout>
   );
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="mb-6 flex flex-wrap items-center gap-4">
         <Link href={`/office/fleets/${id}`} className="button">Edit Fleet</Link>
         <button onClick={deleteFleet} className="button bg-red-600 hover:bg-red-700">Delete Fleet</button>
@@ -76,6 +76,6 @@ export default function FleetViewPage() {
         setQuotes={setQuotes}
         invoices={invoices}
       />
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/index.js
+++ b/pages/office/index.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { useCurrentUser } from '../../components/useCurrentUser.js';
 import OfficeDashboard from '../../components/OfficeDashboard.jsx';
+import OfficeLayout from '../../components/OfficeLayout.jsx';
 
 export default function OfficePage() {
   const router = useRouter();
@@ -27,7 +28,9 @@ export default function OfficePage() {
       <Head>
         <title>Garage Vision - Office</title>
       </Head>
-      <OfficeDashboard />
+      <OfficeLayout>
+        <OfficeDashboard />
+      </OfficeLayout>
     </>
   );
 }

--- a/pages/office/invoices/index.js
+++ b/pages/office/invoices/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchInvoices } from '../../../lib/invoices';
 import { fetchClients } from '../../../lib/clients';
 
@@ -44,7 +44,7 @@ const InvoicesPage = () => {
   }, []);
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Invoices</h1>
       {error && <p className="text-red-500">{error}</p>}
       {loading ? (
@@ -70,7 +70,7 @@ const InvoicesPage = () => {
           </div>
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/job-cards/index.js
+++ b/pages/office/job-cards/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchQuotes, updateQuote } from '../../../lib/quotes';
 import { createInvoice } from '../../../lib/invoices';
 import { fetchClients } from '../../../lib/clients';
@@ -66,7 +66,7 @@ const JobCardsPage = () => {
   });
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Job Cards</h1>
       {error && <p className="text-red-500">{error}</p>}
       {loading ? (
@@ -110,7 +110,7 @@ const JobCardsPage = () => {
           </div>
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const JobManagementPage = () => (
-  <Layout>
+  <OfficeLayout>
     <h1 className="text-xl font-semibold">Job Management</h1>
     {/* TODO: Kanban or board view */}
-  </Layout>
+  </OfficeLayout>
 );
 
 export default JobManagementPage;

--- a/pages/office/job-requests/index.js
+++ b/pages/office/job-requests/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 export default function JobRequestsPage() {
   const [requests, setRequests] = useState([]);
@@ -13,9 +13,8 @@ export default function JobRequestsPage() {
   }, []);
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Job Requests</h1>
-      <Link href="/office" className="button mb-4 inline-block">Return to Office</Link>
       <ul className="space-y-2">
         {requests.map(r => (
           <li key={r.id} className="p-2 rounded bg-gray-100 dark:bg-gray-800">
@@ -23,6 +22,6 @@ export default function JobRequestsPage() {
           </li>
         ))}
       </ul>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/jobs/new.js
+++ b/pages/office/jobs/new.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import PartAutocomplete from '../../../components/PartAutocomplete';
 
 export default function NewJobPage() {
   const { query } = useRouter();
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">New Job</h1>
       <p className="text-sm">Placeholder page for creating a job.</p>
       <div className="max-w-sm mt-4">
@@ -19,6 +19,6 @@ export default function NewJobPage() {
       {query.vehicle_id && (
         <p className="text-sm">Vehicle ID: {query.vehicle_id}</p>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/live-screen/index.js
+++ b/pages/office/live-screen/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchQuotes } from '../../../lib/quotes';
 import { fetchJobs } from '../../../lib/jobs';
 import { fetchInvoices } from '../../../lib/invoices';
@@ -51,7 +51,7 @@ const LiveScreenPage = () => {
   }, [jobs, statuses]);
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Live Screen</h1>
       {error && <p className="text-red-500">{error}</p>}
       {loading ? (
@@ -93,7 +93,7 @@ const LiveScreenPage = () => {
           </div>
         </div>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/parts/[id].js
+++ b/pages/office/parts/[id].js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 export default function EditPartPage() {
   const router = useRouter();
@@ -58,10 +58,10 @@ export default function EditPartPage() {
     }
   };
 
-  if (loading) return <Layout><p>Loading…</p></Layout>;
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Edit Part</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -88,6 +88,6 @@ export default function EditPartPage() {
         </div>
         <button type="submit" className="button">Save</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/parts/index.js
+++ b/pages/office/parts/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 export default function PartsPage() {
   const [parts, setParts] = useState([]);
@@ -39,12 +39,11 @@ export default function PartsPage() {
   const supplierName = id => suppliers.find(s => s.id === id)?.name || '';
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-semibold">Parts</h1>
         <Link href="/office/parts/new" className="button">+ New Part</Link>
       </div>
-      <Link href="/office" className="button inline-block mb-4">Return to Office</Link>
       {error && <p className="text-red-500">{error}</p>}
       {loading ? (
         <p>Loading…</p>
@@ -72,6 +71,6 @@ export default function PartsPage() {
           </div>
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/parts/new.js
+++ b/pages/office/parts/new.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 export default function NewPartPage() {
   const [form, setForm] = useState({
@@ -43,7 +43,7 @@ export default function NewPartPage() {
   };
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">New Part</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -70,6 +70,6 @@ export default function NewPartPage() {
         </div>
         <button type="submit" className="button">Save</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/quotations/[id]/purchase-orders.js
+++ b/pages/office/quotations/[id]/purchase-orders.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { Layout } from '../../../../components/Layout';
+import OfficeLayout from '../../../../components/OfficeLayout';
 
 export default function QuotePurchaseOrdersPage() {
   const router = useRouter();
@@ -54,10 +54,10 @@ export default function QuotePurchaseOrdersPage() {
     router.push('/office/quotations');
   };
 
-  if (loading) return <Layout><p>Loading…</p></Layout>;
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Quote #{id} Parts</h1>
       {error && <p className="text-red-500">{error}</p>}
       {Object.keys(groups).length === 0 ? (
@@ -82,6 +82,6 @@ export default function QuotePurchaseOrdersPage() {
       <Link href="/office/quotations" className="button mt-4 inline-block">
         Back to Quotes
       </Link>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/quotations/index.js
+++ b/pages/office/quotations/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchQuotes, updateQuote } from '../../../lib/quotes';
 import { fetchClients } from '../../../lib/clients';
 
@@ -71,7 +71,7 @@ const QuotationsPage = () => {
   });
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-semibold">Quotations</h1>
         <Link href="/office/quotations/new" className="button px-4 text-sm">
@@ -126,7 +126,7 @@ const QuotationsPage = () => {
           </div>
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchClients } from '../../../lib/clients';
 import { fetchFleets } from '../../../lib/fleets';
 import { fetchVehicles } from '../../../lib/vehicles';
@@ -108,7 +108,7 @@ export default function NewQuotationPage() {
   };
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">New Quote</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 mb-8 max-w-lg">
@@ -260,6 +260,6 @@ export default function NewQuotationPage() {
           Create Quote
         </button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/reporting/index.js
+++ b/pages/office/reporting/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchFinanceReport, fetchEngineerPerformance, fetchBusinessPerformance } from '../../../lib/reporting';
 
 function formatDate(d) {
@@ -65,7 +65,7 @@ const ReportingPage = () => {
   }, [range, customStart, customEnd]);
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-xl font-semibold mb-4">Reporting</h1>
       <div className="mb-6 space-x-2">
         <select value={range} onChange={e => setRange(e.target.value)} className="input inline-block w-auto">
@@ -142,7 +142,7 @@ const ReportingPage = () => {
           )}
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/scheduling/index.js
+++ b/pages/office/scheduling/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const SchedulingPage = () => (
-  <Layout>
+  <OfficeLayout>
     <h1 className="text-xl font-semibold">Scheduling</h1>
     {/* TODO: Calendar component */}
-  </Layout>
+  </OfficeLayout>
 );
 
 export default SchedulingPage;

--- a/pages/office/suppliers/[id].js
+++ b/pages/office/suppliers/[id].js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 export default function EditSupplierPage() {
   const router = useRouter();
@@ -40,7 +40,7 @@ export default function EditSupplierPage() {
   };
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Edit Supplier</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -57,6 +57,6 @@ export default function EditSupplierPage() {
         ))}
         <button type="submit" className="button">Save</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/suppliers/index.js
+++ b/pages/office/suppliers/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 export default function SuppliersPage() {
   const [suppliers, setSuppliers] = useState([]);
@@ -24,14 +24,13 @@ export default function SuppliersPage() {
   );
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-semibold">Suppliers</h1>
         <Link href="/office/suppliers/new" className="button">
           + New Supplier
         </Link>
       </div>
-      <Link href="/office" className="button inline-block mb-4">Return to Office</Link>
       {error && <p className="text-red-500">{error}</p>}
       {loading ? (
         <p>Loading…</p>
@@ -58,6 +57,6 @@ export default function SuppliersPage() {
           </div>
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/suppliers/new.js
+++ b/pages/office/suppliers/new.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 export default function NewSupplierPage() {
   const [form, setForm] = useState({
@@ -33,7 +33,7 @@ export default function NewSupplierPage() {
   };
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">New Supplier</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -50,6 +50,6 @@ export default function NewSupplierPage() {
         ))}
         <button type="submit" className="button">Save</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 }

--- a/pages/office/vehicles/[id].js
+++ b/pages/office/vehicles/[id].js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const EditVehiclePage = () => {
   const router = useRouter();
@@ -43,10 +43,10 @@ const EditVehiclePage = () => {
 
   const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
 
-  if (loading) return <Layout><p>Loading…</p></Layout>;
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Edit Vehicle</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -63,7 +63,7 @@ const EditVehiclePage = () => {
         ))}
           <button type="submit" className="button">Update</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/vehicles/index.js
+++ b/pages/office/vehicles/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchVehicles } from '../../../lib/vehicles';
 import { fetchFleets } from '../../../lib/fleets';
 
@@ -43,16 +43,13 @@ const VehiclesPage = () => {
   });
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-semibold">Vehicles</h1>
         <Link href="/office/vehicles/new" className="button">
           + New Vehicle
         </Link>
       </div>
-      <Link href="/office" className="button inline-block mb-4">
-        Return to Office
-      </Link>
       {loading && <p>Loading…</p>}
       {error && <p className="text-red-500">{error}</p>}
       {!loading && !error && (
@@ -106,7 +103,7 @@ const VehiclesPage = () => {
           </div>
         </>
       )}
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/vehicles/new.js
+++ b/pages/office/vehicles/new.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
-import { Layout } from '../../../components/Layout';
+import OfficeLayout from '../../../components/OfficeLayout';
 
 const NewVehiclePage = () => {
   const router = useRouter();
@@ -33,7 +33,7 @@ const NewVehiclePage = () => {
   const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
 
   return (
-    <Layout>
+    <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">New Vehicle</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
@@ -50,7 +50,7 @@ const NewVehiclePage = () => {
         ))}
           <button type="submit" className="button">Save</button>
       </form>
-    </Layout>
+    </OfficeLayout>
   );
 };
 

--- a/pages/office/vehicles/view/[id].js
+++ b/pages/office/vehicles/view/[id].js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { Layout } from '../../../../components/Layout';
+import OfficeLayout from '../../../../components/OfficeLayout';
 import { Card } from '../../../../components/Card';
 import { fetchDocuments } from '../../../../lib/documents';
 
@@ -50,11 +50,11 @@ export default function VehicleViewPage() {
     router.push('/office/vehicles');
   };
 
-  if (loading) return <Layout><p>Loading…</p></Layout>;
-  if (error) return <Layout><p className="text-red-500">{error}</p></Layout>;
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
+  if (error) return <OfficeLayout><p className="text-red-500">{error}</p></OfficeLayout>;
 
   return (
-    <Layout>
+    <OfficeLayout>
       <div className="mb-6 flex flex-wrap items-center gap-4">
         <Link href={`/office/vehicles/${id}`}><a className="button">Edit Vehicle</a></Link>
         {client && (
@@ -106,6 +106,6 @@ export default function VehicleViewPage() {
           )}
         </Card>
       </div>
-    </Layout>
+    </OfficeLayout>
   );
 }


### PR DESCRIPTION
## Summary
- extract layout from `OfficeDashboard` into new `OfficeLayout` component
- apply `OfficeLayout` in `/office` dashboard page
- switch all Office pages to use `OfficeLayout` instead of generic `Layout`
- remove obsolete "Return to Office" links

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686426b425b0832abd41063650ff5de0