### PR TITLE
Add invoice generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ results so it can be run repeatedly without errors.
 - `/api/suppliers/[id]` - view, update and delete a supplier.
 - `/api/purchase-orders` - create purchase orders with items.
 - `/api/quote-items` - create or fetch quote items.
+
+## Invoice Generation
+
+An invoice template lives in `templates/invoice_template.docx`. Use the helper
+script `generate_invoice.py` to render this template with data in JSON format
+and produce a PDF invoice. Example usage:
+
+```bash
+pip install docxtpl python-docx2pdf
+python generate_invoice.py invoice_data.json
+```
+
+The resulting files are written to the `output/` directory as
+`invoice_<invoice_number>.docx` and `invoice_<invoice_number>.pdf`.

--- a/generate_invoice.py
+++ b/generate_invoice.py
@@ -1,0 +1,83 @@
+import json
+import os
+import sys
+from typing import Any
+
+try:
+    from docxtpl import DocxTemplate
+except ImportError as e:
+    sys.stderr.write("Missing dependency: docxtpl. Install with 'pip install docxtpl'.\n")
+    sys.exit(1)
+
+try:
+    from docx2pdf import convert as docx2pdf_convert
+    DOCX2PDF_AVAILABLE = True
+except ImportError:
+    DOCX2PDF_AVAILABLE = False
+
+
+def load_data(path: str) -> Any:
+    if path == '-':
+        return json.load(sys.stdin)
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def validate_data(data: dict) -> None:
+    required_top = [
+        'invoice_number', 'garage', 'client', 'vehicle',
+        'defect', 'items', 'totals', 'terms'
+    ]
+    for key in required_top:
+        if key not in data:
+            raise KeyError(f"Missing top-level key: {key}")
+
+
+def render_docx(data: dict) -> str:
+    template_path = os.path.join('templates', 'invoice_template.docx')
+    if not os.path.exists(template_path):
+        raise FileNotFoundError(f"Template not found: {template_path}")
+
+    doc = DocxTemplate(template_path)
+    doc.render(data)
+
+    os.makedirs('output', exist_ok=True)
+    out_docx = os.path.join('output', f"invoice_{data['invoice_number']}.docx")
+    doc.save(out_docx)
+    return out_docx
+
+
+def convert_to_pdf(docx_path: str) -> str:
+    pdf_path = docx_path.replace('.docx', '.pdf')
+    if DOCX2PDF_AVAILABLE:
+        docx2pdf_convert(docx_path, pdf_path)
+    else:
+        # Fallback to unoconv if installed
+        import subprocess
+        try:
+            subprocess.run(['unoconv', '-f', 'pdf', '-o', pdf_path, docx_path], check=True)
+        except FileNotFoundError:
+            raise RuntimeError('Neither docx2pdf nor unoconv is available for PDF conversion.')
+    return pdf_path
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write('Usage: python generate_invoice.py <data.json>|-\n')
+        return 1
+
+    data_path = sys.argv[1]
+    try:
+        data = load_data(data_path)
+        validate_data(data)
+        docx_path = render_docx(data)
+        pdf_path = convert_to_pdf(docx_path)
+        print(f"Generated: {pdf_path}")
+        return 0
+    except Exception as e:
+        sys.stderr.write(f"Error: {e}\n")
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- introduce a Python script to render invoice templates
- document invoice generation in README

## Testing
- `python -m py_compile generate_invoice.py`


------
https://chatgpt.com/codex/tasks/task_e_686440f61544832a9904445c960f098b