### PR TITLE
Add dashboard link in OfficeLayout

### DIFF
--- a/components/OfficeLayout.jsx
+++ b/components/OfficeLayout.jsx
@@ -28,6 +28,23 @@ export default function OfficeLayout({ children }) {
       <aside className="w-64 bg-blue-900 p-6 space-y-6">
         <nav className="space-y-4">
           <div>
+            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Main</h3>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/dashboard" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Dashboard
+                </Link>
+              </li>
+              <li>
+                <Link href="/office" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Office Home
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
             <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Sales</h3>
             <ul className="space-y-1">
               <li>


### PR DESCRIPTION
## Summary
- provide navigation back to the dashboard from the Office pages

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68646800244c832aa25c00bc00125758