### PR TITLE
Implement email system with SMTP settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,12 @@ AWS_SECRET_ACCESS_KEY="your-secret-key"
 NEXT_PUBLIC_S3_BUCKET="your-bucket-name"
 NEXT_PUBLIC_AWS_REGION="us-east-1"
 
+
+# SMTP configuration
+SMTP_HOST="smtp.example.com"
+SMTP_PORT="587"
+SMTP_USER="user@example.com"
+SMTP_PASS="password"
+SMTP_SECURE="false"
+SMTP_FROM_NAME="Garage"
+SMTP_FROM_EMAIL="noreply@example.com"

--- a/__tests__/company-email-api.test.js
+++ b/__tests__/company-email-api.test.js
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('smtp settings GET returns settings', async () => {
+  const settings = { id: 1 };
+  const getMock = jest.fn().mockResolvedValue(settings);
+  jest.unstable_mockModule('../services/smtpSettingsService.js', () => ({
+    getSmtpSettings: getMock,
+    upsertSmtpSettings: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/company/smtp-settings.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(getMock).toHaveBeenCalled();
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(settings);
+});
+
+test('smtp settings PUT updates settings', async () => {
+  const updated = { id: 1 };
+  const upsertMock = jest.fn().mockResolvedValue(updated);
+  jest.unstable_mockModule('../services/smtpSettingsService.js', () => ({
+    getSmtpSettings: jest.fn(),
+    upsertSmtpSettings: upsertMock,
+  }));
+  const { default: handler } = await import('../pages/api/company/smtp-settings.js');
+  const req = { method: 'PUT', body: { host: 'smtp' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(upsertMock).toHaveBeenCalledWith(req.body);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(updated);
+});

--- a/__tests__/email-service.test.js
+++ b/__tests__/email-service.test.js
@@ -1,0 +1,37 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('sendQuoteEmail sends mail', async () => {
+  const sendMock = jest.fn().mockResolvedValue();
+  jest.unstable_mockModule('nodemailer', () => ({
+    default: { createTransport: () => ({ sendMail: sendMock }) },
+    createTransport: () => ({ sendMail: sendMock }),
+  }));
+  process.env.DATABASE_URL = 'mysql://u:p@localhost/db';
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn().mockResolvedValue([[]]) },
+  }));
+  jest.unstable_mockModule('../services/smtpSettingsService.js', () => ({
+    getSmtpSettings: () => ({ host: 'h', port: 1, from_email: 'f' }),
+  }));
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getQuoteById: () => ({ id: 1 })
+  }));
+  jest.unstable_mockModule('../services/companySettingsService.js', () => ({
+    getSettings: () => ({})
+  }));
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getClientById: () => ({ email: 'c' })
+  }));
+  jest.unstable_mockModule('../services/quoteItemsService.js', () => ({
+    getQuoteItems: () => []
+  }));
+  const { sendQuoteEmail } = await import('../services/emailService.js');
+  await sendQuoteEmail(1);
+  expect(sendMock).toHaveBeenCalled();
+});
+

--- a/__tests__/reminders-api.test.js
+++ b/__tests__/reminders-api.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('reminders GET lists reminders', async () => {
+  const rows = [{ id: 1 }];
+  jest.unstable_mockModule('../services/followUpRemindersService.js', () => ({
+    listReminders: jest.fn().mockResolvedValue(rows),
+    createReminder: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/reminders/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(rows);
+});
+
+test('reminders POST creates reminder', async () => {
+  const created = { id: 2 };
+  const createMock = jest.fn().mockResolvedValue(created);
+  jest.unstable_mockModule('../services/followUpRemindersService.js', () => ({
+    listReminders: jest.fn(),
+    createReminder: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/reminders/index.js');
+  const req = { method: 'POST', body: { quote_id: 1 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(created);
+});

--- a/docs/feature_spec_email_system.md
+++ b/docs/feature_spec_email_system.md
@@ -1,0 +1,68 @@
+# Garage App Email Feature Spec
+
+This document describes the email system used by Garage App for delivering quotes and invoices.
+
+## Database Tables
+
+### smtp_settings
+Holds SMTP credentials used when sending mail.
+
+- `id` INT primary key
+- `host` VARCHAR
+- `port` INT
+- `username` VARCHAR
+- `password` VARCHAR
+- `secure` TINYINT
+- `from_name` VARCHAR
+- `from_email` VARCHAR
+
+### email_templates
+Stores reusable templates for various mail types.
+
+- `id` INT primary key
+- `name` VARCHAR
+- `subject` VARCHAR
+- `body` TEXT
+- `type` VARCHAR (e.g. `quote` or `invoice`)
+
+### follow_up_reminders
+Automatically created reminders for staff to follow up on sent quotes or invoices.
+
+- `id` INT primary key
+- `quote_id` INT FK quotes.id
+- `invoice_id` INT FK invoices.id
+- `reminder_ts` DATETIME when reminder should trigger
+- `sent_ts` DATETIME when reminder email was sent
+- `status` VARCHAR
+
+## API Endpoints
+
+### /api/company/smtp-settings
+- `GET` – fetch current SMTP settings
+- `PUT` – create or update settings
+
+### /api/company/email-templates
+- `GET` – list templates
+- `POST` – create template
+
+### /api/company/email-templates/[id]
+- `GET` – fetch single template
+- `PUT` – update template
+- `DELETE` – remove template
+
+### /api/reminders
+- `GET` – list follow-up reminders
+- `POST` – create reminder manually
+
+### /api/reminders/[id]
+- `GET` – fetch reminder
+- `PUT` – update reminder
+- `DELETE` – delete reminder
+
+## Email Sending
+
+When a quote or invoice is created the system generates a PDF attachment and sends it to the client using Nodemailer and the configured SMTP credentials.
+
+## Follow‑Up Scheduler
+
+A scheduled job runs daily to populate new `follow_up_reminders` for quotes older than seven days that have not yet received a reminder.

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -30,3 +30,32 @@ export async function buildQuotePdf({ company = {}, quote, client = {}, vehicle 
     doc.end();
   });
 }
+
+export async function buildInvoicePdf({ company = {}, invoice, client = {}, items = [] }) {
+  return new Promise(resolve => {
+    const doc = new PDFDocument();
+    const chunks = [];
+    doc.on('data', c => chunks.push(c));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+
+    doc.fontSize(18).text(company.company_name || 'Invoice', { align: 'center' });
+    doc.moveDown();
+
+    doc.fontSize(12);
+    if (client.first_name || client.last_name) {
+      doc.text(`${client.first_name || ''} ${client.last_name || ''}`);
+    }
+    doc.moveDown();
+
+    doc.text('Items:');
+    items.forEach(it => {
+      const line = `${it.description} x${it.qty} @ ${it.unit_price} = ${(it.qty * it.unit_price).toFixed(2)}`;
+      doc.text(line);
+    });
+    doc.moveDown();
+    doc.text(`Total: ${invoice.amount}`);
+
+    doc.end();
+  });
+}
+

--- a/migrations/20251217_create_smtp_settings.sql
+++ b/migrations/20251217_create_smtp_settings.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS smtp_settings (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  host VARCHAR(255),
+  port INT,
+  username VARCHAR(255),
+  password VARCHAR(255),
+  secure TINYINT(1),
+  from_name VARCHAR(255),
+  from_email VARCHAR(255)
+);

--- a/migrations/20251218_create_email_templates.sql
+++ b/migrations/20251218_create_email_templates.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS email_templates (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(100),
+  subject VARCHAR(255),
+  body TEXT,
+  type VARCHAR(50)
+);

--- a/migrations/20251219_create_follow_up_reminders.sql
+++ b/migrations/20251219_create_follow_up_reminders.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS follow_up_reminders (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  quote_id INT,
+  invoice_id INT,
+  reminder_ts DATETIME,
+  sent_ts DATETIME,
+  status VARCHAR(50),
+  CONSTRAINT fk_follow_up_quote FOREIGN KEY (quote_id) REFERENCES quotes(id),
+  CONSTRAINT fk_follow_up_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id)
+);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "pdfkit": "^0.13.0",
     "react": "18.x",
     "react-dom": "18.x",
-    "socket.io": "^4.7.5"
+    "socket.io": "^4.7.5",
+    "nodemailer": "^6.9.8",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/pages/api/company/email-templates/[id].js
+++ b/pages/api/company/email-templates/[id].js
@@ -1,0 +1,24 @@
+import { getTemplateById, updateTemplate, deleteTemplate } from '../../../../services/emailTemplatesService.js';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const tpl = await getTemplateById(id);
+      return res.status(200).json(tpl);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateTemplate(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await deleteTemplate(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/company/email-templates/index.js
+++ b/pages/api/company/email-templates/index.js
@@ -1,0 +1,19 @@
+import { listTemplates, createTemplate } from '../../../../services/emailTemplatesService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const rows = await listTemplates();
+      return res.status(200).json(rows);
+    }
+    if (req.method === 'POST') {
+      const created = await createTemplate(req.body);
+      return res.status(201).json(created);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/company/smtp-settings.js
+++ b/pages/api/company/smtp-settings.js
@@ -1,0 +1,19 @@
+import { getSmtpSettings, upsertSmtpSettings } from '../../../services/smtpSettingsService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const settings = await getSmtpSettings();
+      return res.status(200).json(settings);
+    }
+    if (req.method === 'PUT') {
+      const updated = await upsertSmtpSettings(req.body);
+      return res.status(200).json(updated);
+    }
+    res.setHeader('Allow', ['GET','PUT']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/invoices/index.js
+++ b/pages/api/invoices/index.js
@@ -17,6 +17,12 @@ export default async function handler(req, res) {
     }
     if (req.method === 'POST') {
       const newInvoice = await service.createInvoice(req.body);
+      try {
+        const { sendInvoiceEmail } = await import('../../../services/emailService.js');
+        await sendInvoiceEmail(newInvoice.id);
+      } catch (e) {
+        console.error('INVOICE_EMAIL_ERROR:', e);
+      }
       return res.status(201).json(newInvoice);
     }
     res.setHeader('Allow', ['GET','POST']);

--- a/pages/api/quotes/index.js
+++ b/pages/api/quotes/index.js
@@ -17,6 +17,12 @@ export default async function handler(req, res) {
     }
     if (req.method === 'POST') {
       const newQuote = await service.createQuote(req.body);
+      try {
+        const { sendQuoteEmail } = await import('../../../services/emailService.js');
+        await sendQuoteEmail(newQuote.id);
+      } catch (e) {
+        console.error('QUOTE_EMAIL_ERROR:', e);
+      }
       return res.status(201).json(newQuote);
     }
     res.setHeader('Allow', ['GET','POST']);

--- a/pages/api/reminders/[id].js
+++ b/pages/api/reminders/[id].js
@@ -1,0 +1,24 @@
+import { getReminder, updateReminder, deleteReminder } from '../../../services/followUpRemindersService.js';
+
+export default async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const row = await getReminder(id);
+      return res.status(200).json(row);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateReminder(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await deleteReminder(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/pages/api/reminders/index.js
+++ b/pages/api/reminders/index.js
@@ -1,0 +1,19 @@
+import { listReminders, createReminder } from '../../../services/followUpRemindersService.js';
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const rows = await listReminders();
+      return res.status(200).json(rows);
+    }
+    if (req.method === 'POST') {
+      const created = await createReminder(req.body);
+      return res.status(201).json(created);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}

--- a/scripts/run_reminders.js
+++ b/scripts/run_reminders.js
@@ -1,0 +1,6 @@
+import { startReminderScheduler } from '../services/reminderScheduler.js';
+
+startReminderScheduler();
+
+// keep process running
+setInterval(() => {}, 1 << 30);

--- a/services/emailService.js
+++ b/services/emailService.js
@@ -1,0 +1,58 @@
+import nodemailer from 'nodemailer';
+import { getSmtpSettings } from './smtpSettingsService.js';
+import { getQuoteById } from './quotesService.js';
+import { getClientById } from './clientsService.js';
+import { getQuoteItems } from './quoteItemsService.js';
+import { getSettings } from './companySettingsService.js';
+import { buildQuotePdf, buildInvoicePdf } from '../lib/pdf.js';
+import { getInvoiceById } from './invoicesService.js';
+import { getInvoiceItems } from './invoiceItemsService.js';
+
+function createTransport(opts) {
+  return nodemailer.createTransport({
+    host: opts.host,
+    port: opts.port,
+    secure: !!opts.secure,
+    auth: opts.username ? { user: opts.username, pass: opts.password } : undefined,
+  });
+}
+
+export async function sendQuoteEmail(quoteId, to) {
+  const settings = await getSmtpSettings();
+  if (!settings) throw new Error('SMTP settings not configured');
+  const transporter = createTransport(settings);
+  const quote = await getQuoteById(quoteId);
+  const company = await getSettings();
+  const client = quote.customer_id ? await getClientById(quote.customer_id) : {};
+  const items = await getQuoteItems(quoteId);
+  const pdf = await buildQuotePdf({ company, quote, client, items });
+  const recipient = to || client.email || client.email_1 || client.email_2;
+  await transporter.sendMail({
+    from: settings.from_email,
+    to: recipient,
+    subject: 'Quote',
+    text: 'Please find attached your quote.',
+    attachments: [{ filename: `quote-${quoteId}.pdf`, content: pdf }],
+  });
+}
+
+export async function sendInvoiceEmail(invoiceId, to) {
+  const settings = await getSmtpSettings();
+  if (!settings) throw new Error('SMTP settings not configured');
+  const transporter = createTransport(settings);
+  const invoice = await getInvoiceById(invoiceId);
+  const company = await getSettings();
+  const client = invoice.customer_id ? await getClientById(invoice.customer_id) : {};
+  const items = await getInvoiceItems(invoiceId);
+  const pdf = await buildInvoicePdf({ company, invoice, client, items });
+  const recipient = to || client.email || client.email_1 || client.email_2;
+  await transporter.sendMail({
+    from: settings.from_email,
+    to: recipient,
+    subject: 'Invoice',
+    text: 'Please find attached your invoice.',
+    attachments: [{ filename: `invoice-${invoiceId}.pdf`, content: pdf }],
+  });
+}
+
+

--- a/services/emailTemplatesService.js
+++ b/services/emailTemplatesService.js
@@ -1,0 +1,32 @@
+import pool from '../lib/db.js';
+
+export async function listTemplates() {
+  const [rows] = await pool.query('SELECT id, name, subject, body, type FROM email_templates ORDER BY id');
+  return rows;
+}
+
+export async function getTemplateById(id) {
+  const [[row]] = await pool.query('SELECT id, name, subject, body, type FROM email_templates WHERE id=?', [id]);
+  return row || null;
+}
+
+export async function createTemplate({ name, subject, body, type }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO email_templates (name, subject, body, type) VALUES (?,?,?,?)`,
+    [name || null, subject || null, body || null, type || null]
+  );
+  return { id: insertId, name, subject, body, type };
+}
+
+export async function updateTemplate(id, { name, subject, body, type }) {
+  await pool.query(
+    `UPDATE email_templates SET name=?, subject=?, body=?, type=? WHERE id=?`,
+    [name || null, subject || null, body || null, type || null, id]
+  );
+  return { ok: true };
+}
+
+export async function deleteTemplate(id) {
+  await pool.query('DELETE FROM email_templates WHERE id=?', [id]);
+  return { ok: true };
+}

--- a/services/followUpRemindersService.js
+++ b/services/followUpRemindersService.js
@@ -1,0 +1,48 @@
+import pool from '../lib/db.js';
+
+export async function listReminders() {
+  const [rows] = await pool.query(
+    'SELECT id, quote_id, invoice_id, reminder_ts, sent_ts, status FROM follow_up_reminders ORDER BY reminder_ts DESC'
+  );
+  return rows;
+}
+
+export async function getReminder(id) {
+  const [[row]] = await pool.query(
+    'SELECT id, quote_id, invoice_id, reminder_ts, sent_ts, status FROM follow_up_reminders WHERE id=?',
+    [id]
+  );
+  return row || null;
+}
+
+export async function createReminder({ quote_id, invoice_id, reminder_ts, status }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO follow_up_reminders (quote_id, invoice_id, reminder_ts, status) VALUES (?,?,?,?)`,
+    [quote_id || null, invoice_id || null, reminder_ts || null, status || null]
+  );
+  return { id: insertId, quote_id, invoice_id, reminder_ts, status };
+}
+
+export async function updateReminder(id, { quote_id, invoice_id, reminder_ts, sent_ts, status }) {
+  await pool.query(
+    `UPDATE follow_up_reminders SET quote_id=?, invoice_id=?, reminder_ts=?, sent_ts=?, status=? WHERE id=?`,
+    [quote_id || null, invoice_id || null, reminder_ts || null, sent_ts || null, status || null, id]
+  );
+  return { ok: true };
+}
+
+export async function deleteReminder(id) {
+  await pool.query('DELETE FROM follow_up_reminders WHERE id=?', [id]);
+  return { ok: true };
+}
+
+export async function scheduleDueReminders() {
+  // create reminders for quotes older than 7 days without existing reminder
+  await pool.query(
+    `INSERT INTO follow_up_reminders (quote_id, reminder_ts, status)
+     SELECT q.id, DATE_ADD(q.created_ts, INTERVAL 7 DAY), 'pending'
+       FROM quotes q
+       LEFT JOIN follow_up_reminders r ON r.quote_id = q.id
+      WHERE q.created_ts <= DATE_SUB(NOW(), INTERVAL 7 DAY) AND r.id IS NULL`
+  );
+}

--- a/services/invoiceItemsService.js
+++ b/services/invoiceItemsService.js
@@ -1,0 +1,9 @@
+import pool from '../lib/db.js';
+
+export async function getInvoiceItems(invoice_id) {
+  const [rows] = await pool.query(
+    'SELECT id, invoice_id, description, qty, unit_price FROM invoice_items WHERE invoice_id=?',
+    [invoice_id]
+  );
+  return rows;
+}

--- a/services/reminderScheduler.js
+++ b/services/reminderScheduler.js
@@ -1,0 +1,13 @@
+import cron from 'node-cron';
+import { scheduleDueReminders } from './followUpRemindersService.js';
+
+export function startReminderScheduler() {
+  cron.schedule('0 3 * * *', async () => {
+    try {
+      await scheduleDueReminders();
+    } catch (err) {
+      console.error('REMINDER_JOB_ERROR:', err);
+    }
+  });
+}
+

--- a/services/smtpSettingsService.js
+++ b/services/smtpSettingsService.js
@@ -1,0 +1,24 @@
+import pool from '../lib/db.js';
+
+export async function getSmtpSettings() {
+  const [[row]] = await pool.query(
+    'SELECT id, host, port, username, password, secure, from_name, from_email FROM smtp_settings ORDER BY id LIMIT 1'
+  );
+  return row || null;
+}
+
+export async function upsertSmtpSettings({ host, port, username, password, secure, from_name, from_email }) {
+  const current = await getSmtpSettings();
+  if (current) {
+    await pool.query(
+      `UPDATE smtp_settings SET host=?, port=?, username=?, password=?, secure=?, from_name=?, from_email=? WHERE id=?`,
+      [host || null, port || null, username || null, password || null, secure ? 1 : 0, from_name || null, from_email || null, current.id]
+    );
+    return { id: current.id, host, port, username, password, secure: !!secure, from_name, from_email };
+  }
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO smtp_settings (host, port, username, password, secure, from_name, from_email) VALUES (?,?,?,?,?,?,?)`,
+    [host || null, port || null, username || null, password || null, secure ? 1 : 0, from_name || null, from_email || null]
+  );
+  return { id: insertId, host, port, username, password, secure: !!secure, from_name, from_email };
+}


### PR DESCRIPTION
## Summary
- document Garage App email feature spec
- add SMTP/email template/follow-up reminder migrations
- add nodemailer-based email service
- create API routes for company email settings and reminders
- trigger email sending on quote/invoice creation
- schedule follow-up reminders
- expose SMTP env vars
- test new routes and service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686474d84418832a8597c15d1aa89e8e