### PR TITLE
Enhance client creation password handling

### DIFF
--- a/__tests__/clients-service.test.js
+++ b/__tests__/clients-service.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('createClient uses provided password', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 1 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  let hashedArg;
+  const hashMock = jest.fn(async p => {
+    hashedArg = p;
+    return 'HASHED';
+  });
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    hashPassword: hashMock,
+  }));
+  const { createClient } = await import('../services/clientsService.js');
+  const res = await createClient({ first_name: 'A', password: 'secret' });
+  expect(hashMock).toHaveBeenCalledWith('secret');
+  expect(hashedArg).toBe('secret');
+  expect(queryMock).toHaveBeenCalled();
+  expect(res.password).toBe('secret');
+});
+
+test('createClient generates password when missing', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 2 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('crypto', () => ({
+    randomBytes: () => Buffer.from('ranpwd'),
+  }));
+  let hashedArg;
+  const hashMock = jest.fn(async p => {
+    hashedArg = p;
+    return 'HASHED2';
+  });
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    hashPassword: hashMock,
+  }));
+  const { createClient } = await import('../services/clientsService.js');
+  const res = await createClient({ first_name: 'B' });
+  expect(hashMock).toHaveBeenCalledWith(res.password);
+  expect(hashedArg).toBe(res.password);
+  expect(res.password).toBe('cmFucHdk');
+  expect(queryMock).toHaveBeenCalled();
+});
+

--- a/pages/local/login.js
+++ b/pages/local/login.js
@@ -5,7 +5,7 @@ export default function LocalLogin() {
   const router = useRouter();
   const [garage, setGarage] = useState('');
   const [vehicleReg, setVehicleReg] = useState('');
-  const [firstName, setFirstName] = useState('');
+  const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
   async function handleSubmit(e) {
@@ -18,7 +18,7 @@ export default function LocalLogin() {
         body: JSON.stringify({
           garage_name: garage,
           vehicle_reg: vehicleReg,
-          password: firstName,
+          password,
         }),
       });
       if (!res.ok) {
@@ -58,10 +58,10 @@ export default function LocalLogin() {
         />
         <input
           type="password"
-          placeholder="First Name"
+          placeholder="Password"
           className="input w-full"
-          value={firstName}
-          onChange={e => setFirstName(e.target.value)}
+          value={password}
+          onChange={e => setPassword(e.target.value)}
         />
         <button type="submit" className="button w-full">Login</button>
       </form>

--- a/pages/office/clients/[id].js
+++ b/pages/office/clients/[id].js
@@ -6,7 +6,8 @@ import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchVehicles } from '../../../lib/vehicles';
 
 const EditClientPage = () => {
-  const { id } = useRouter().query;
+  const router = useRouter();
+  const { id, pw } = router.query;
   const [form, setForm] = useState({
     first_name: '',
     last_name: '',
@@ -22,7 +23,6 @@ const EditClientPage = () => {
   const [vehicles, setVehicles] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const router = useRouter();
 
   useEffect(() => {
     if (!id) return;
@@ -65,6 +65,9 @@ const EditClientPage = () => {
   return (
     <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Edit Client</h1>
+      {pw && (
+        <p className="mb-4 font-semibold">Password: {pw}</p>
+      )}
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
         {[

--- a/pages/office/clients/new.js
+++ b/pages/office/clients/new.js
@@ -15,6 +15,7 @@ const NewClientPage = () => {
     town: '',
     province: '',
     post_code: '',
+    password: '',
   });
   const [vehicle, setVehicle] = useState({
     licence_plate: '',
@@ -42,7 +43,7 @@ const NewClientPage = () => {
           body: JSON.stringify({ ...vehicle, customer_id: created.id }),
         });
       }
-      router.push('/office/clients');
+      router.push(`/office/clients/${created.id}?pw=${created.password}`);
     } catch {
       setError('Failed to create client');
     }
@@ -65,8 +66,9 @@ const NewClientPage = () => {
           'nie_number',
           'street_address',
           'town',
-          'province',
+        'province',
         'post_code',
+        'password',
       ].map(field => (
         <div key={field}>
           <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g, c => c.toUpperCase())}</label>

--- a/services/clientsService.js
+++ b/services/clientsService.js
@@ -1,5 +1,6 @@
 import pool from '../lib/db.js';
 import { hashPassword } from '../lib/auth.js';
+import { randomBytes } from 'crypto';
 
 export async function getAllClients() {
   const [rows] = await pool.query(
@@ -35,8 +36,12 @@ export async function createClient({
   town,
   province,
   post_code,
+  password,
 }) {
-  const password_hash = await hashPassword(first_name);
+  if (!password) {
+    password = randomBytes(12).toString('base64url');
+  }
+  const password_hash = await hashPassword(password);
   const [{ insertId }] = await pool.query(
     `INSERT INTO clients
       (first_name, last_name, email, mobile, landline, nie_number,
@@ -73,6 +78,7 @@ export async function createClient({
     town,
     province,
     post_code,
+    password,
   };
 }
 


### PR DESCRIPTION
## Summary
- require password when creating clients
- show generated password in the office UI
- allow setting a custom password when adding a client
- update local login form to request password instead of first name
- add tests for password generation logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68647873d8e0832a98ec16fdb4272dad