### PR TITLE
Add apiHandler wrapper and refactor APIs

### DIFF
--- a/__tests__/apiHandler.test.js
+++ b/__tests__/apiHandler.test.js
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+import apiHandler from '../lib/apiHandler.js';
+
+test('passes through successful handler', async () => {
+  const fn = jest.fn(async (req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  const wrapped = apiHandler(fn);
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), headersSent: false };
+  await wrapped({}, res);
+  expect(fn).toHaveBeenCalled();
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ ok: true });
+});
+
+test('catches errors and responds with 500', async () => {
+  const err = new Error('fail');
+  const fn = jest.fn(() => { throw err; });
+  const wrapped = apiHandler(fn);
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), headersSent: false };
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  await wrapped({}, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});

--- a/lib/apiHandler.js
+++ b/lib/apiHandler.js
@@ -1,0 +1,12 @@
+export default function apiHandler(fn) {
+  return async function handler(req, res) {
+    try {
+      await fn(req, res);
+    } catch (err) {
+      console.error(err);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Internal Server Error' });
+      }
+    }
+  };
+}

--- a/pages/api/admin/users/[id].js
+++ b/pages/api/admin/users/[id].js
@@ -1,8 +1,9 @@
+import apiHandler from '../../../../lib/apiHandler.js';
 // File: pages/api/admin/users/[id].js
 import pool from '../../../../lib/db';
 import { getTokenFromReq } from '../../../../lib/auth';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
 
   const t = getTokenFromReq(req);
@@ -34,3 +35,5 @@ export default async function handler(req, res) {
   res.setHeader('Allow', ['DELETE']);
   return res.status(405).end(`Method ${req.method} Not Allowed`);
 }
+
+export default apiHandler(handler);

--- a/pages/api/admin/users/index.js
+++ b/pages/api/admin/users/index.js
@@ -1,8 +1,9 @@
+import apiHandler from '../../../../lib/apiHandler.js';
 // File: pages/api/admin/users/index.js
 import pool from '../../../../lib/db';
 import { hashPassword, getTokenFromReq } from '../../../../lib/auth';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const [[roleRow]] = await pool.query(
@@ -57,3 +58,5 @@ export default async function handler(req, res) {
   res.setHeader('Allow', ['GET', 'POST']);
   return res.status(405).end(`Method ${req.method} Not Allowed`);
 }
+
+export default apiHandler(handler);

--- a/pages/api/auth/login.js
+++ b/pages/api/auth/login.js
@@ -1,7 +1,8 @@
 import pool from '../../../lib/db';
 import { verifyPassword, signToken } from '../../../lib/auth';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { identifier, email, username, password } = req.body;
   const ident = identifier || email || username;
   const [rows] = await pool.query(
@@ -19,3 +20,5 @@ export default async function handler(req, res) {
   );
   res.status(200).json({ ok: true });
 }
+
+export default apiHandler(handler);

--- a/pages/api/auth/logout.js
+++ b/pages/api/auth/logout.js
@@ -1,5 +1,8 @@
-export default function handler(req, res) {
+import apiHandler from '../../../lib/apiHandler.js';
+function handler(req, res) {
   const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
   res.setHeader('Set-Cookie', `auth_token=; HttpOnly; Path=/; Max-Age=0${secure}`);
   res.status(200).json({ ok:true });
 }
+
+export default apiHandler(handler);

--- a/pages/api/auth/me.js
+++ b/pages/api/auth/me.js
@@ -1,7 +1,8 @@
 import pool from '../../../lib/db';
 import { getTokenFromReq } from '../../../lib/auth';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const [rows] = await pool.query(
@@ -14,3 +15,5 @@ export default async function handler(req, res) {
   );
   res.status(200).json(rows[0]);
 }
+
+export default apiHandler(handler);

--- a/pages/api/chat/history.js
+++ b/pages/api/chat/history.js
@@ -1,11 +1,12 @@
 import pool from "../../../lib/db";
+import apiHandler from '../../../lib/apiHandler.js';
 
 const extractMentions = (body) =>
   Array.from(
     new Set((body.match(/@([\w.-]+)/g) || []).map((m) => m.slice(1))),
   );
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const limit = parseInt(req.query.limit || "50", 10);
   const room = parseInt(req.query.room_id || "1", 10);
   try {
@@ -29,3 +30,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: "Internal server error" });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/chat/topics.js
+++ b/pages/api/chat/topics.js
@@ -1,6 +1,7 @@
 import pool from "../../../lib/db";
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (req.method === "GET") {
     const [rows] = await pool.query(
       "SELECT id, name FROM chat_rooms ORDER BY name"
@@ -29,3 +30,5 @@ export default async function handler(req, res) {
   res.setHeader("Allow", ["GET", "POST"]);
   res.status(405).end();
 }
+
+export default apiHandler(handler);

--- a/pages/api/chat/upload.js
+++ b/pages/api/chat/upload.js
@@ -1,6 +1,7 @@
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import crypto from 'crypto';
+import apiHandler from '../../../lib/apiHandler.js';
 
 const client = new S3Client({
   region: process.env.AWS_REGION,
@@ -10,7 +11,7 @@ const client = new S3Client({
   },
 });
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).end();
@@ -35,3 +36,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Failed to generate URL' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/clients/[id].js
+++ b/pages/api/clients/[id].js
@@ -1,7 +1,8 @@
+import apiHandler from '../../../lib/apiHandler.js';
 // pages/api/clients/[id].js
 import { getClientById, updateClient, deleteClient } from '../../../services/clientsService';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -23,3 +24,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/clients/index.js
+++ b/pages/api/clients/index.js
@@ -1,8 +1,8 @@
+import apiHandler from '../../../lib/apiHandler.js';
 // pages/api/clients/index.js
 import { getAllClients, createClient } from '../../../services/clientsService';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const clients = await getAllClients();
       return res.status(200).json(clients);
@@ -13,8 +13,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/company-settings/index.js
+++ b/pages/api/company-settings/index.js
@@ -1,7 +1,7 @@
 import { getSettings, updateSettings } from '../../../services/companySettingsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const settings = await getSettings();
       return res.status(200).json(settings);
@@ -12,8 +12,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','PUT']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/company/email-templates/[id].js
+++ b/pages/api/company/email-templates/[id].js
@@ -1,6 +1,7 @@
 import { getTemplateById, updateTemplate, deleteTemplate } from '../../../../services/emailTemplatesService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -22,3 +23,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/company/email-templates/index.js
+++ b/pages/api/company/email-templates/index.js
@@ -1,7 +1,7 @@
 import { listTemplates, createTemplate } from '../../../../services/emailTemplatesService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const rows = await listTemplates();
       return res.status(200).json(rows);
@@ -12,8 +12,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/company/smtp-settings.js
+++ b/pages/api/company/smtp-settings.js
@@ -1,7 +1,7 @@
 import { getSmtpSettings, upsertSmtpSettings } from '../../../services/smtpSettingsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const settings = await getSmtpSettings();
       return res.status(200).json(settings);
@@ -12,8 +12,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','PUT']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/dev/dashboard.js
+++ b/pages/api/dev/dashboard.js
@@ -1,7 +1,8 @@
 import pool from '../../../lib/db';
 import { getTokenFromReq } from '../../../lib/auth';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const userId = t.sub;
@@ -52,3 +53,5 @@ export default async function handler(req, res) {
 
   res.json({ projects, announcements });
 }
+
+export default apiHandler(handler);

--- a/pages/api/dev/files/index.js
+++ b/pages/api/dev/files/index.js
@@ -1,7 +1,8 @@
 import pool from '../../../../lib/db';
 import { getTokenFromReq } from '../../../../lib/auth';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const userId = t.sub;
@@ -42,3 +43,5 @@ export default async function handler(req, res) {
   res.setHeader('Allow', ['GET','POST']);
   res.status(405).end();
 }
+
+export default apiHandler(handler);

--- a/pages/api/dev/projects/[id].js
+++ b/pages/api/dev/projects/[id].js
@@ -1,7 +1,8 @@
 import pool from '../../../../lib/db';
 import { getTokenFromReq } from '../../../../lib/auth';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const { id } = req.query;
@@ -36,3 +37,5 @@ export default async function handler(req, res) {
   res.setHeader('Allow',['GET','PUT','DELETE']);
   res.status(405).end();
 }
+
+export default apiHandler(handler);

--- a/pages/api/dev/projects/index.js
+++ b/pages/api/dev/projects/index.js
@@ -1,7 +1,8 @@
 import pool from '../../../../lib/db';
 import { getTokenFromReq } from '../../../../lib/auth';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const userId = t.sub;
@@ -39,3 +40,5 @@ export default async function handler(req, res) {
   res.setHeader('Allow', ['GET','POST']);
   res.status(405).end();
 }
+
+export default apiHandler(handler);

--- a/pages/api/dev/tasks/[id].js
+++ b/pages/api/dev/tasks/[id].js
@@ -1,7 +1,8 @@
 import pool from '../../../../lib/db';
 import { getTokenFromReq } from '../../../../lib/auth';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const { id } = req.query;
@@ -36,3 +37,5 @@ export default async function handler(req, res) {
   res.setHeader('Allow',['GET','PUT','DELETE']);
   res.status(405).end();
 }
+
+export default apiHandler(handler);

--- a/pages/api/dev/tasks/index.js
+++ b/pages/api/dev/tasks/index.js
@@ -1,7 +1,8 @@
 import pool from '../../../../lib/db';
 import { getTokenFromReq } from '../../../../lib/auth';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const userId = t.sub;
@@ -48,3 +49,5 @@ export default async function handler(req, res) {
   res.setHeader('Allow',['GET','POST']);
   res.status(405).end();
 }
+
+export default apiHandler(handler);

--- a/pages/api/documents/index.js
+++ b/pages/api/documents/index.js
@@ -1,6 +1,7 @@
 import { getDocuments, createDocument } from '../../../services/documentsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const entity_type = req.query.entity_type || req.body.entity_type;
   const entity_id = req.query.entity_id || req.body.entity_id;
 
@@ -34,3 +35,5 @@ export default async function handler(req, res) {
   res.setHeader('Allow', ['GET', 'POST']);
   res.status(405).end(`Method ${req.method} Not Allowed`);
 }
+
+export default apiHandler(handler);

--- a/pages/api/engineer/holiday-requests/index.js
+++ b/pages/api/engineer/holiday-requests/index.js
@@ -1,8 +1,9 @@
 import pool from '../../../../lib/db';
 import { getTokenFromReq } from '../../../../lib/auth';
 import { listRequests, submitRequest } from '../../../../services/holidayRequestsService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const [[roleRow]] = await pool.query(
@@ -37,3 +38,5 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/engineer/jobs/index.js
+++ b/pages/api/engineer/jobs/index.js
@@ -1,8 +1,9 @@
 import pool from '../../../../lib/db';
 import { getTokenFromReq } from '../../../../lib/auth';
 import { listActiveJobsForEngineer } from '../../../../services/jobsService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const [[roleRow]] = await pool.query(
@@ -27,3 +28,5 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/engineer/time-entries/index.js
+++ b/pages/api/engineer/time-entries/index.js
@@ -1,8 +1,9 @@
 import pool from '../../../../lib/db';
 import { getTokenFromReq } from '../../../../lib/auth';
 import { clockIn, clockOut } from '../../../../services/timeEntriesService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
   const [[roleRow]] = await pool.query(
@@ -41,3 +42,5 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/engineers/[id].js
+++ b/pages/api/engineers/[id].js
@@ -1,6 +1,7 @@
 import { getEngineerById, updateEngineer, deleteEngineer } from '../../../services/engineersService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -22,3 +23,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/engineers/index.js
+++ b/pages/api/engineers/index.js
@@ -1,7 +1,7 @@
 import { getAllEngineers, createEngineer } from '../../../services/engineersService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const engineers = await getAllEngineers();
       return res.status(200).json(engineers);
@@ -12,8 +12,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/fleets/[id].js
+++ b/pages/api/fleets/[id].js
@@ -1,6 +1,7 @@
 import { getFleetById } from '../../../services/fleetsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -25,4 +26,4 @@ export default async function handler(req, res) {
   }
 }
 
-
+export default apiHandler(handler);

--- a/pages/api/fleets/index.js
+++ b/pages/api/fleets/index.js
@@ -1,7 +1,7 @@
 import { getAllFleets } from '../../../services/fleetsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const fleets = await getAllFleets();
       return res.status(200).json(fleets);
@@ -13,10 +13,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
 
-
+export default apiHandler(handler);

--- a/pages/api/invoices/[id].js
+++ b/pages/api/invoices/[id].js
@@ -1,6 +1,7 @@
 import { getInvoiceById, updateInvoice, deleteInvoice } from '../../../services/invoicesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -22,3 +23,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/invoices/index.js
+++ b/pages/api/invoices/index.js
@@ -1,7 +1,7 @@
 import * as service from '../../../services/invoicesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const { customer_id, fleet_id, status } = req.query || {};
       if (fleet_id) {
@@ -27,8 +27,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/job-requests/index.js
+++ b/pages/api/job-requests/index.js
@@ -1,9 +1,9 @@
 import { createJobRequest, getAllJobRequests } from '../../../services/jobRequestsService.js';
 import { verifyToken, getTokenFromReq } from '../../../lib/auth.js';
 import { parse } from 'cookie';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const t = getTokenFromReq(req);
       if (!t) return res.status(401).json({ error: 'Unauthorized' });
@@ -32,8 +32,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/job-statuses/[id].js
+++ b/pages/api/job-statuses/[id].js
@@ -1,6 +1,7 @@
 import { deleteJobStatus } from '../../../services/jobStatusesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'DELETE') {
@@ -14,3 +15,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/job-statuses/index.js
+++ b/pages/api/job-statuses/index.js
@@ -1,7 +1,7 @@
 import * as service from '../../../services/jobStatusesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const statuses = await service.getJobStatuses();
       return res.status(200).json(statuses);
@@ -12,8 +12,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/jobs/index.js
+++ b/pages/api/jobs/index.js
@@ -1,7 +1,7 @@
 import * as service from '../../../services/jobsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const { fleet_id, customer_id, status } = req.query || {};
       if (fleet_id) {
@@ -21,8 +21,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/parts/[id].js
+++ b/pages/api/parts/[id].js
@@ -1,6 +1,7 @@
 import { getPartById, updatePart, deletePart } from '../../../services/partsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -22,3 +23,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/parts/index.js
+++ b/pages/api/parts/index.js
@@ -1,7 +1,7 @@
 import { searchParts, createPart } from '../../../services/partsService';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const { q } = req.query || {};
       const parts = await searchParts(q || '');
@@ -19,8 +19,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET', 'POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/portal/fleet/login.js
+++ b/pages/api/portal/fleet/login.js
@@ -1,7 +1,8 @@
 import pool from '../../../../lib/db';
 import { verifyPassword, signToken } from '../../../../lib/auth';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { garage_name, pin } = req.body || {};
   const [rows] = await pool.query('SELECT id, pin_hash FROM fleets WHERE garage_name=?', [garage_name]);
   if (!rows.length || !(await verifyPassword(pin, rows[0].pin_hash))) {
@@ -12,3 +13,5 @@ export default async function handler(req, res) {
   res.setHeader('Set-Cookie', `fleet_token=${token}; HttpOnly; Path=/; Max-Age=3600; SameSite=Strict${secure}`);
   res.status(200).json({ ok: true });
 }
+
+export default apiHandler(handler);

--- a/pages/api/portal/fleet/logout.js
+++ b/pages/api/portal/fleet/logout.js
@@ -1,5 +1,8 @@
-export default function handler(req, res) {
+import apiHandler from '../../../../lib/apiHandler.js';
+function handler(req, res) {
   const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
   res.setHeader('Set-Cookie', `fleet_token=; HttpOnly; Path=/; Max-Age=0${secure}`);
   res.status(200).json({ ok: true });
 }
+
+export default apiHandler(handler);

--- a/pages/api/portal/fleet/me.js
+++ b/pages/api/portal/fleet/me.js
@@ -1,8 +1,9 @@
 import pool from '../../../../lib/db';
 import { verifyToken } from '../../../../lib/auth';
 import { parse } from 'cookie';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const cookies = parse(req.headers.cookie || '');
   if (!cookies.fleet_token) return res.status(401).json({ error: 'Unauthorized' });
   let payload;
@@ -15,3 +16,5 @@ export default async function handler(req, res) {
   if (!row) return res.status(404).json({ error: 'Not found' });
   res.status(200).json(row);
 }
+
+export default apiHandler(handler);

--- a/pages/api/portal/local/login.js
+++ b/pages/api/portal/local/login.js
@@ -1,7 +1,8 @@
 import pool from '../../../../lib/db';
 import { verifyPassword, signToken } from '../../../../lib/auth';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { garage_name, vehicle_reg, password } = req.body || {};
   const [rows] = await pool.query(
     'SELECT id, password_hash FROM clients WHERE garage_name=? AND vehicle_reg=?',
@@ -15,3 +16,5 @@ export default async function handler(req, res) {
   res.setHeader('Set-Cookie', `local_token=${token}; HttpOnly; Path=/; Max-Age=3600; SameSite=Strict${secure}`);
   res.status(200).json({ ok: true });
 }
+
+export default apiHandler(handler);

--- a/pages/api/portal/local/logout.js
+++ b/pages/api/portal/local/logout.js
@@ -1,5 +1,8 @@
-export default function handler(req, res) {
+import apiHandler from '../../../../lib/apiHandler.js';
+function handler(req, res) {
   const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
   res.setHeader('Set-Cookie', `local_token=; HttpOnly; Path=/; Max-Age=0${secure}`);
   res.status(200).json({ ok: true });
 }
+
+export default apiHandler(handler);

--- a/pages/api/portal/local/me.js
+++ b/pages/api/portal/local/me.js
@@ -1,8 +1,9 @@
 import pool from '../../../../lib/db';
 import { verifyToken } from '../../../../lib/auth';
 import { parse } from 'cookie';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const cookies = parse(req.headers.cookie || '');
   if (!cookies.local_token) return res.status(401).json({ error: 'Unauthorized' });
   let payload;
@@ -18,3 +19,5 @@ export default async function handler(req, res) {
   if (!row) return res.status(404).json({ error: 'Not found' });
   res.status(200).json(row);
 }
+
+export default apiHandler(handler);

--- a/pages/api/purchase-orders/index.js
+++ b/pages/api/purchase-orders/index.js
@@ -1,7 +1,7 @@
 import { createPurchaseOrder } from '../../../services/purchaseOrdersService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'POST') {
       const { order, items } = req.body || {};
       const po = await createPurchaseOrder({ ...order, items });
@@ -9,8 +9,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/quote-items/index.js
+++ b/pages/api/quote-items/index.js
@@ -1,7 +1,7 @@
 import { createQuoteItem, getQuoteItems } from '../../../services/quoteItemsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const items = await getQuoteItems(req.query.quote_id);
       return res.status(200).json(items);
@@ -12,8 +12,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/quotes/[id].js
+++ b/pages/api/quotes/[id].js
@@ -1,6 +1,7 @@
 import { getQuoteById, updateQuote, deleteQuote } from '../../../services/quotesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -22,3 +23,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/quotes/[id]/pdf.js
+++ b/pages/api/quotes/[id]/pdf.js
@@ -5,8 +5,9 @@ import { getVehicleById } from '../../../../services/vehiclesService.js';
 import { getQuoteItems } from '../../../../services/quoteItemsService.js';
 import pool from '../../../../lib/db.js';
 import { buildQuotePdf } from '../../../../lib/pdf.js';
+import apiHandler from '../../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   if (req.method !== 'GET') {
     res.setHeader('Allow', ['GET']);
@@ -31,3 +32,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/quotes/index.js
+++ b/pages/api/quotes/index.js
@@ -1,7 +1,7 @@
 import * as service from '../../../services/quotesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const { fleet_id, customer_id } = req.query || {};
       if (fleet_id) {
@@ -27,8 +27,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/reminders/[id].js
+++ b/pages/api/reminders/[id].js
@@ -1,6 +1,7 @@
 import { getReminder, updateReminder, deleteReminder } from '../../../services/followUpRemindersService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -22,3 +23,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/reminders/index.js
+++ b/pages/api/reminders/index.js
@@ -1,7 +1,7 @@
 import { listReminders, createReminder } from '../../../services/followUpRemindersService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const rows = await listReminders();
       return res.status(200).json(rows);
@@ -12,8 +12,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/reporting/business-performance.js
+++ b/pages/api/reporting/business-performance.js
@@ -1,7 +1,7 @@
 import { getBusinessPerformanceReport } from '../../../services/reportingService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method !== 'GET') {
       res.setHeader('Allow', ['GET']);
       return res.status(405).end(`Method ${req.method} Not Allowed`);
@@ -9,8 +9,6 @@ export default async function handler(req, res) {
     const { start, end } = req.query;
     const report = await getBusinessPerformanceReport(start, end);
     return res.status(200).json(report);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/reporting/engineer-performance.js
+++ b/pages/api/reporting/engineer-performance.js
@@ -1,7 +1,7 @@
 import { getEngineerPerformanceReport } from '../../../services/reportingService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method !== 'GET') {
       res.setHeader('Allow', ['GET']);
       return res.status(405).end(`Method ${req.method} Not Allowed`);
@@ -9,8 +9,6 @@ export default async function handler(req, res) {
     const { start, end } = req.query;
     const report = await getEngineerPerformanceReport(start, end);
     return res.status(200).json(report);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/reporting/finance.js
+++ b/pages/api/reporting/finance.js
@@ -1,7 +1,7 @@
 import { getFinanceReport } from '../../../services/reportingService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method !== 'GET') {
       res.setHeader('Allow', ['GET']);
       return res.status(405).end(`Method ${req.method} Not Allowed`);
@@ -9,8 +9,6 @@ export default async function handler(req, res) {
     const { start, end } = req.query;
     const report = await getFinanceReport(start, end);
     return res.status(200).json(report);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/socket-io.js
+++ b/pages/api/socket-io.js
@@ -1,12 +1,13 @@
 import { Server } from "socket.io";
 import pool from "../../lib/db";
+import apiHandler from '../../lib/apiHandler.js';
 
 const extractMentions = (body) =>
   Array.from(
     new Set((body.match(/@([\w.-]+)/g) || []).map((m) => m.slice(1))),
   );
 
-export default function handler(req, res) {
+function handler(req, res) {
   if (!res.socket.server.io) {
     const io = new Server(res.socket.server, { path: "/api/socket-io" });
     io.on("connection", (socket) => {
@@ -45,3 +46,5 @@ export default function handler(req, res) {
   }
   res.end();
 }
+
+export default apiHandler(handler);

--- a/pages/api/suppliers/[id].js
+++ b/pages/api/suppliers/[id].js
@@ -1,6 +1,7 @@
 import { getSupplierById, updateSupplier, deleteSupplier } from '../../../services/suppliersService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -22,3 +23,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/suppliers/index.js
+++ b/pages/api/suppliers/index.js
@@ -1,7 +1,7 @@
 import { getAllSuppliers, createSupplier } from '../../../services/suppliersService.js';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const rows = await getAllSuppliers();
       return res.status(200).json(rows);
@@ -12,8 +12,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -1,7 +1,8 @@
 import pool from '../../../lib/db';
 import { getTokenFromReq } from '../../../lib/auth';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const t = getTokenFromReq(req);
   if (!t) return res.status(401).json({ error: 'Unauthorized' });
 
@@ -14,3 +15,4 @@ export default async function handler(req, res) {
   res.status(200).json(users);
 }
 
+export default apiHandler(handler);

--- a/pages/api/vehicles/[id].js
+++ b/pages/api/vehicles/[id].js
@@ -1,6 +1,7 @@
 import { getVehicleById, updateVehicle, deleteVehicle } from '../../../services/vehiclesService';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { id } = req.query;
   try {
     if (req.method === 'GET') {
@@ -22,3 +23,5 @@ export default async function handler(req, res) {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 }
+
+export default apiHandler(handler);

--- a/pages/api/vehicles/index.js
+++ b/pages/api/vehicles/index.js
@@ -1,7 +1,7 @@
 import { getAllVehicles, createVehicle } from '../../../services/vehiclesService';
+import apiHandler from '../../../lib/apiHandler.js';
 
-export default async function handler(req, res) {
-  try {
+async function handler(req, res) {
     if (req.method === 'GET') {
       const { customer_id, fleet_id } = req.query || {};
       const vehicles = await getAllVehicles(customer_id, fleet_id);
@@ -13,8 +13,6 @@ export default async function handler(req, res) {
     }
     res.setHeader('Allow', ['GET','POST']);
     res.status(405).end(`Method ${req.method} Not Allowed`);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
 }
+
+export default apiHandler(handler);

--- a/scripts/updateApiHandler.mjs
+++ b/scripts/updateApiHandler.mjs
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+
+for (const file of process.argv.slice(2)) {
+  let code = fs.readFileSync(file, 'utf8');
+  const rel = path.posix.relative(path.posix.dirname(file), 'lib/apiHandler.js');
+
+  // insert import after existing imports
+  const lines = code.split('\n');
+  let idx = 0;
+  while (idx < lines.length && lines[idx].startsWith('import')) idx++;
+  lines.splice(idx, 0, `import apiHandler from '${rel}';`);
+  code = lines.join('\n');
+
+  // replace export default line
+  code = code.replace(/export default (async )?function handler\(/, '$1function handler(');
+
+  // remove outer try/catch if present
+  const outerTry = /(function handler\(req, res\) {\n)(\s*)try \{\n/;
+  if (outerTry.test(code)) {
+    code = code.replace(outerTry, '$1');
+    code = code.replace(/\n\s*}\s*catch\s*\(err\)\s*{\n\s*console.error\(err\);\n\s*res.status\(500\).json\({ error: 'Internal Server Error' }\);\n\s*}\n/, '\n');
+  }
+
+  // append export default line
+  code = code.replace(/\n}\s*$/, '\n}\n\nexport default apiHandler(handler);\n');
+  fs.writeFileSync(file, code);
+}


### PR DESCRIPTION
## Summary
- add `lib/apiHandler.js` helper for consistent API error handling
- refactor all API routes to use the wrapper
- add unit tests for the new handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68647c5e0a90832aa0335e3b3a448547