### PR TITLE
Fix pdf generation when vehicle missing

### DIFF
--- a/pages/api/quotes/[id]/pdf.js
+++ b/pages/api/quotes/[id]/pdf.js
@@ -23,7 +23,13 @@ async function handler(req, res) {
     const company = await getSettings();
     const client = quote.customer_id ? await getClientById(quote.customer_id) : null;
     const items = await getQuoteItems(id);
-    const pdf = await buildQuotePdf({ company, quote, client, vehicle, items });
+    const pdf = await buildQuotePdf({
+      company,
+      quote,
+      client,
+      vehicle: vehicle || {},
+      items
+    });
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `attachment; filename=quote-${id}.pdf`);
     res.send(pdf);


### PR DESCRIPTION
## Summary
- ensure `buildQuotePdf` gets an empty object when no vehicle exists

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68695e8971a48333a956607d4d4a8bd2