### PR TITLE
Enable navigation from dashboard counts

### DIFF
--- a/components/OfficeDashboard.jsx
+++ b/components/OfficeDashboard.jsx
@@ -53,19 +53,26 @@ export default function OfficeDashboard() {
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <div className="bg-white text-black rounded-2xl p-4 shadow">
           <h2 className="text-lg font-semibold mb-2">Open Quotes</h2>
-          <p className="text-4xl font-bold text-blue-600">{openQuotes.length}</p>
+          <p className="text-4xl font-bold text-blue-600">
+            <Link href="/office/quotations">{openQuotes.length}</Link>
+          </p>
         </div>
         <div className="bg-white text-black rounded-2xl p-4 shadow">
           <h2 className="text-lg font-semibold mb-2">Jobs</h2>
           <ul className="text-sm space-y-1">
             {statuses.map(s => (
-              <li key={s.id} className="capitalize">{s.name}: {jobStatusCounts[s.name] || 0}</li>
+              <li key={s.id} className="capitalize">
+                {s.name}:{' '}
+                <Link href={`/office/job-cards?status=${encodeURIComponent(s.name)}`}>{jobStatusCounts[s.name] || 0}</Link>
+              </li>
             ))}
           </ul>
         </div>
         <div className="bg-white text-black rounded-2xl p-4 shadow">
           <h2 className="text-lg font-semibold mb-2">Unpaid Invoices</h2>
-          <p className="text-4xl font-bold text-blue-600">{unpaidInvoices.length}</p>
+          <p className="text-4xl font-bold text-blue-600">
+            <Link href="/office/invoices?status=unpaid">{unpaidInvoices.length}</Link>
+          </p>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- wrap open quotes count in a link to `/office/quotations`
- wrap job status counts in links to `/office/job-cards?status=STATUS_NAME`
- wrap unpaid invoices count in a link to `/office/invoices?status=unpaid`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695f212df083338e94f820e9110f3f