### PR TITLE
Add placeholder fleet pages

### DIFF
--- a/pages/fleet/invoices/index.js
+++ b/pages/fleet/invoices/index.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import logout from '../../../lib/logout.js';
+
+export default function FleetInvoices() {
+  const router = useRouter();
+  const [fleet, setFleet] = useState(null);
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } finally {
+      router.push('/fleet/login');
+    }
+  }
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/fleet/me');
+      if (!res.ok) return router.replace('/fleet/login');
+      const f = await res.json();
+      setFleet(f);
+    })();
+  }, [router]);
+
+  if (!fleet) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Invoices</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      <Link href="/fleet/home" className="button inline-block mb-4">
+        Return to Home
+      </Link>
+      <p>Coming soon.</p>
+    </div>
+  );
+}

--- a/pages/fleet/jobs/index.js
+++ b/pages/fleet/jobs/index.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import logout from '../../../lib/logout.js';
+
+export default function FleetJobs() {
+  const router = useRouter();
+  const [fleet, setFleet] = useState(null);
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } finally {
+      router.push('/fleet/login');
+    }
+  }
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/fleet/me');
+      if (!res.ok) return router.replace('/fleet/login');
+      const f = await res.json();
+      setFleet(f);
+    })();
+  }, [router]);
+
+  if (!fleet) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Jobs</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      <Link href="/fleet/home" className="button inline-block mb-4">
+        Return to Home
+      </Link>
+      <p>Coming soon.</p>
+    </div>
+  );
+}

--- a/pages/fleet/quotes/index.js
+++ b/pages/fleet/quotes/index.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import logout from '../../../lib/logout.js';
+
+export default function FleetQuotes() {
+  const router = useRouter();
+  const [fleet, setFleet] = useState(null);
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } finally {
+      router.push('/fleet/login');
+    }
+  }
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/fleet/me');
+      if (!res.ok) return router.replace('/fleet/login');
+      const f = await res.json();
+      setFleet(f);
+    })();
+  }, [router]);
+
+  if (!fleet) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Quotes</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      <Link href="/fleet/home" className="button inline-block mb-4">
+        Return to Home
+      </Link>
+      <p>Coming soon.</p>
+    </div>
+  );
+}

--- a/pages/fleet/request-quotation.js
+++ b/pages/fleet/request-quotation.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import logout from '../../lib/logout.js';
+
+export default function FleetRequestQuotation() {
+  const router = useRouter();
+  const [fleet, setFleet] = useState(null);
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } finally {
+      router.push('/fleet/login');
+    }
+  }
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/fleet/me');
+      if (!res.ok) return router.replace('/fleet/login');
+      const f = await res.json();
+      setFleet(f);
+    })();
+  }, [router]);
+
+  if (!fleet) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Request Quotation</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      <Link href="/fleet/home" className="button inline-block mb-4">
+        Return to Home
+      </Link>
+      <p>Coming soon.</p>
+    </div>
+  );
+}

--- a/pages/fleet/vehicles/index.js
+++ b/pages/fleet/vehicles/index.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import logout from '../../../lib/logout.js';
+
+export default function FleetVehicles() {
+  const router = useRouter();
+  const [fleet, setFleet] = useState(null);
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } finally {
+      router.push('/fleet/login');
+    }
+  }
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/fleet/me');
+      if (!res.ok) return router.replace('/fleet/login');
+      const f = await res.json();
+      setFleet(f);
+    })();
+  }, [router]);
+
+  if (!fleet) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Vehicles</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      <Link href="/fleet/home" className="button inline-block mb-4">
+        Return to Home
+      </Link>
+      <p>Coming soon.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder pages for fleet portal sections so dashboard links work

## Testing
- `npm test --silent` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686960b5c63c8333992cf08213e812ca