### PR TITLE
Add client autocomplete for quotations

### DIFF
--- a/__tests__/clients-api.test.js
+++ b/__tests__/clients-api.test.js
@@ -13,6 +13,7 @@ test('clients index returns list of clients', async () => {
   jest.unstable_mockModule('../services/clientsService.js', () => ({
     getAllClients: getAllMock,
     createClient: jest.fn(),
+    searchClients: jest.fn(),
   }));
   const { default: handler } = await import('../pages/api/clients/index.js');
   const req = { method: 'GET', headers: {} };
@@ -30,6 +31,7 @@ test('clients index creates client', async () => {
   jest.unstable_mockModule('../services/clientsService.js', () => ({
     getAllClients: jest.fn(),
     createClient: createMock,
+    searchClients: jest.fn(),
   }));
   const { default: handler } = await import('../pages/api/clients/index.js');
   const req = {
@@ -49,6 +51,7 @@ test('clients index rejects unsupported method', async () => {
   jest.unstable_mockModule('../services/clientsService.js', () => ({
     getAllClients: jest.fn(),
     createClient: jest.fn(),
+    searchClients: jest.fn(),
   }));
   const { default: handler } = await import('../pages/api/clients/index.js');
   const req = { method: 'PUT', headers: {} };
@@ -67,6 +70,7 @@ test('clients index handles errors', async () => {
   jest.unstable_mockModule('../services/clientsService.js', () => ({
     getAllClients: getAllMock,
     createClient: jest.fn(),
+    searchClients: jest.fn(),
   }));
   const { default: handler } = await import('../pages/api/clients/index.js');
   const req = { method: 'GET', headers: {} };

--- a/components/ClientAutocomplete.js
+++ b/components/ClientAutocomplete.js
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react';
+
+export default function ClientAutocomplete({ value, onChange, onSelect }) {
+  const [term, setTerm] = useState(value || '');
+  const [results, setResults] = useState([]);
+
+  useEffect(() => {
+    if (value !== undefined) setTerm(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (!term) return setResults([]);
+    let cancel = false;
+    fetch(`/api/clients?q=${encodeURIComponent(term)}`)
+      .then(r => (r.ok ? r.json() : []))
+      .then(data => {
+        if (cancel) return;
+        setResults(data);
+      })
+      .catch(() => {
+        if (cancel) return;
+        setResults([]);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [term]);
+
+  return (
+    <div className="relative">
+      <input
+        className="input w-full"
+        value={term}
+        onChange={e => {
+          setTerm(e.target.value);
+          onChange && onChange(e.target.value);
+        }}
+        placeholder="Client name or email"
+      />
+      {term && results.length > 0 && (
+        <div className="absolute z-10 bg-white shadow rounded w-full text-black">
+          {results.map(c => (
+            <div
+              key={c.id}
+              className="px-2 py-1 cursor-pointer hover:bg-gray-200"
+              onClick={() => {
+                onSelect && onSelect(c);
+                const name = `${c.first_name || ''} ${c.last_name || ''}`.trim();
+                if (value === undefined) {
+                  setTerm('');
+                } else {
+                  setTerm(name);
+                  onChange && onChange(name);
+                }
+                setResults([]);
+              }}
+            >
+              {(c.first_name || '') + ' ' + (c.last_name || '')}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/api/clients/index.js
+++ b/pages/api/clients/index.js
@@ -1,10 +1,15 @@
 import apiHandler from '../../../lib/apiHandler.js';
 // pages/api/clients/index.js
-import { getAllClients, createClient } from '../../../services/clientsService';
+import {
+  getAllClients,
+  createClient,
+  searchClients,
+} from '../../../services/clientsService';
 
 async function handler(req, res) {
     if (req.method === 'GET') {
-      const clients = await getAllClients();
+      const { q } = req.query || {};
+      const clients = q ? await searchClients(q) : await getAllClients();
       return res.status(200).json(clients);
     }
     if (req.method === 'POST') {

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -1,20 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import OfficeLayout from '../../../components/OfficeLayout';
-import { fetchClients } from '../../../lib/clients';
 import { fetchFleets } from '../../../lib/fleets';
 import { fetchVehicles } from '../../../lib/vehicles';
 import { createQuote } from '../../../lib/quotes';
 
 const emptyItem = { part_number: '', part_id: '', description: '', qty: 1, price: 0 };
 import PartAutocomplete from '../../../components/PartAutocomplete';
+import ClientAutocomplete from '../../../components/ClientAutocomplete';
 
 export default function NewQuotationPage() {
   const router = useRouter();
-  const [clients, setClients] = useState([]);
   const [vehicles, setVehicles] = useState([]);
   const [fleets, setFleets] = useState([]);
   const [mode, setMode] = useState('client');
+  const [clientName, setClientName] = useState('');
   const [form, setForm] = useState({
     customer_id: '',
     fleet_id: '',
@@ -27,14 +27,10 @@ export default function NewQuotationPage() {
 
   useEffect(() => {
     setForm(f => ({ ...f, customer_id: '', fleet_id: '', vehicle_id: '' }));
+    setClientName('');
     setVehicles([]);
   }, [mode]);
 
-  useEffect(() => {
-    fetchClients()
-      .then(setClients)
-      .catch(() => setError('Failed to load clients'));
-  }, []);
 
   useEffect(() => {
     fetchFleets()
@@ -131,20 +127,17 @@ export default function NewQuotationPage() {
         {mode === 'client' ? (
           <div>
             <label className="block mb-1">Client</label>
-            <select
-              className="input w-full"
-              value={form.customer_id}
-              onChange={e =>
-                setForm(f => ({ ...f, customer_id: e.target.value, fleet_id: '' }))
-              }
-            >
-              <option value="">Select client</option>
-              {clients.map(c => (
-                <option key={c.id} value={c.id}>
-                  {(c.first_name || '') + ' ' + (c.last_name || '')}
-                </option>
-              ))}
-            </select>
+            <ClientAutocomplete
+              value={clientName}
+              onChange={v => {
+                setClientName(v);
+                setForm(f => ({ ...f, customer_id: '' }));
+              }}
+              onSelect={c => {
+                setClientName(`${c.first_name || ''} ${c.last_name || ''}`.trim());
+                setForm(f => ({ ...f, customer_id: c.id, fleet_id: '' }));
+              }}
+            />
           </div>
         ) : (
           <div>

--- a/services/clientsService.js
+++ b/services/clientsService.js
@@ -2,6 +2,30 @@ import pool from '../lib/db.js';
 import { hashPassword } from '../lib/auth.js';
 import { randomBytes } from 'crypto';
 
+export async function searchClients(query) {
+  const q = `%${query}%`;
+  const [rows] = query
+    ? await pool.query(
+        `SELECT id, first_name, last_name, email, mobile, landline, nie_number,
+                street_address, town, province, post_code,
+                garage_name, vehicle_reg
+           FROM clients
+          WHERE first_name LIKE ? OR last_name LIKE ? OR email LIKE ?
+          ORDER BY first_name, last_name
+          LIMIT 20`,
+        [q, q, q]
+      )
+    : await pool.query(
+        `SELECT id, first_name, last_name, email, mobile, landline, nie_number,
+                street_address, town, province, post_code,
+                garage_name, vehicle_reg
+           FROM clients
+          ORDER BY first_name, last_name
+          LIMIT 20`
+      );
+  return rows;
+}
+
 export async function getAllClients() {
   const [rows] = await pool.query(
     `SELECT id, first_name, last_name, email, mobile, landline, nie_number,


### PR DESCRIPTION
## Summary
- implement `searchClients` service query
- add `/api/clients` query support
- create `ClientAutocomplete` component
- replace client `<select>` with new autocomplete input
- adjust tests for new service export

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6869638f768083339a958e86654602ca