### PR TITLE
Support vehicle association on quotes

### DIFF
--- a/__tests__/quotes-api.test.js
+++ b/__tests__/quotes-api.test.js
@@ -36,7 +36,7 @@ test('quotes index creates quote', async () => {
   await handler(req, res);
   expect(res.status).toHaveBeenCalledWith(201);
   expect(res.json).toHaveBeenCalledWith(newQuote);
-  expect(createMock).toHaveBeenCalledWith(req.body);
+  expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ job_id: 1 }));
 });
 
 test('quotes index rejects unsupported method', async () => {

--- a/__tests__/quotesService.test.js
+++ b/__tests__/quotesService.test.js
@@ -40,13 +40,14 @@ test('createQuote inserts quote', async () => {
     customer_id: 1,
     fleet_id: 2,
     job_id: 3,
+    vehicle_id: 4,
     total_amount: 50,
     status: 'new',
   };
   const result = await createQuote(data);
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/INSERT INTO quotes/),
-    [1, 2, 3, 50, 'new']
+    [1, 2, 3, 4, 50, 'new']
   );
   expect(result).toEqual({ id: 3, ...data });
 });
@@ -61,13 +62,14 @@ test('updateQuote updates row', async () => {
     customer_id: 4,
     fleet_id: 5,
     job_id: 6,
-    total_amount: 7,
+    vehicle_id: 7,
+    total_amount: 8,
     status: 'sent',
   };
-  const result = await updateQuote(8, data);
+  const result = await updateQuote(9, data);
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/UPDATE quotes/),
-    [4, 5, 6, 7, 'sent', 8]
+    [4, 5, 6, 7, 8, 'sent', 9]
   );
   expect(result).toEqual({ ok: true });
 });

--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -44,6 +44,12 @@ export function PortalDashboard({
       );
     });
 
+  const visibleIds = new Set(filteredVehicles.map(v => v.id));
+
+  const quotesFiltered = quotes.filter(q =>
+    !q.vehicle_id || visibleIds.has(q.vehicle_id)
+  );
+
   const brandOptions = [
     'All',
     ...Array.from(new Set(vehicles.filter(vehicleFilter).map(v => v.make))),
@@ -114,16 +120,20 @@ export function PortalDashboard({
       <section>
         <h2 className="text-xl font-semibold mb-2">Quotes</h2>
         <ul className="list-disc ml-6">
-          {quotes.map(q => (
-            <li key={q.id} className="mb-1">
-              Quote #{q.id} - {q.status}
-              {q.status !== 'accepted' && (
-                <button onClick={() => acceptQuote(q.id)} className="ml-2 underline">
-                  Accept
-                </button>
-              )}
-            </li>
-          ))}
+          {quotesFiltered.map(q => {
+            const veh = vehicles.find(v => v.id === q.vehicle_id);
+            return (
+              <li key={q.id} className="mb-1">
+                Quote #{q.id}
+                {veh ? ` - ${veh.licence_plate}` : ''} - {q.status}
+                {q.status !== 'accepted' && (
+                  <button onClick={() => acceptQuote(q.id)} className="ml-2 underline">
+                    Accept
+                  </button>
+                )}
+              </li>
+            );
+          })}
         </ul>
       </section>
       <section>

--- a/migrations/20251221_add_quotes_vehicle_id.sql
+++ b/migrations/20251221_add_quotes_vehicle_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE quotes
+  ADD COLUMN vehicle_id INT NULL AFTER job_id,
+  ADD CONSTRAINT fk_quotes_vehicle FOREIGN KEY (vehicle_id) REFERENCES vehicles(id);

--- a/pages/api/quotes/index.js
+++ b/pages/api/quotes/index.js
@@ -16,7 +16,15 @@ async function handler(req, res) {
       return res.status(200).json(quotes);
     }
     if (req.method === 'POST') {
-      const newQuote = await service.createQuote(req.body);
+      const data = {
+        customer_id: req.body.customer_id,
+        fleet_id: req.body.fleet_id,
+        job_id: req.body.job_id,
+        vehicle_id: req.body.vehicle_id,
+        total_amount: req.body.total_amount,
+        status: req.body.status,
+      };
+      const newQuote = await service.createQuote(data);
       try {
         const { sendQuoteEmail } = await import('../../../services/emailService.js');
         await sendQuoteEmail(newQuote.id);

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -79,6 +79,7 @@ export default function NewQuotationPage() {
         customer_id: mode === 'client' ? form.customer_id : null,
         fleet_id: mode === 'fleet' ? form.fleet_id : null,
         job_id: null,
+        vehicle_id: form.vehicle_id || null,
         customer_reference: form.customer_ref || null,
         po_number: form.po_number || null,
         total_amount: total,

--- a/services/quotesService.js
+++ b/services/quotesService.js
@@ -2,7 +2,7 @@ import pool from '../lib/db.js';
 
 export async function getAllQuotes() {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, created_ts
        FROM quotes ORDER BY id`
   );
   return rows;
@@ -10,7 +10,7 @@ export async function getAllQuotes() {
 
 export async function getQuotesByFleet(fleet_id) {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, created_ts
        FROM quotes WHERE fleet_id=? ORDER BY id`,
     [fleet_id]
   );
@@ -19,7 +19,7 @@ export async function getQuotesByFleet(fleet_id) {
 
 export async function getQuotesByCustomer(customer_id) {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, created_ts
        FROM quotes WHERE customer_id=? ORDER BY id`,
     [customer_id]
   );
@@ -28,38 +28,40 @@ export async function getQuotesByCustomer(customer_id) {
 
 export async function getQuoteById(id) {
   const [[row]] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, created_ts
        FROM quotes WHERE id=?`,
     [id]
   );
   return row || null;
 }
 
-export async function createQuote({ customer_id, fleet_id, job_id, total_amount, status }) {
+export async function createQuote({ customer_id, fleet_id, job_id, vehicle_id, total_amount, status }) {
   const [{ insertId }] = await pool.query(
     `INSERT INTO quotes
-      (customer_id, fleet_id, job_id, total_amount, status)
-     VALUES (?,?,?,?,?)`,
+      (customer_id, fleet_id, job_id, vehicle_id, total_amount, status)
+     VALUES (?,?,?,?,?,?)`,
     [
       customer_id || null,
       fleet_id || null,
       job_id || null,
+      vehicle_id || null,
       total_amount || null,
       status || null,
     ]
   );
-  return { id: insertId, customer_id, fleet_id, job_id, total_amount, status };
+  return { id: insertId, customer_id, fleet_id, job_id, vehicle_id, total_amount, status };
 }
 
 export async function updateQuote(
   id,
-  { customer_id, fleet_id, job_id, total_amount, status }
+  { customer_id, fleet_id, job_id, vehicle_id, total_amount, status }
 ) {
   await pool.query(
     `UPDATE quotes SET
        customer_id=?,
        fleet_id=?,
        job_id=?,
+       vehicle_id=?,
        total_amount=?,
        status=?
      WHERE id=?`,
@@ -67,6 +69,7 @@ export async function updateQuote(
       customer_id || null,
       fleet_id || null,
       job_id || null,
+      vehicle_id || null,
       total_amount || null,
       status || null,
       id,


### PR DESCRIPTION
## Summary
- add migration to store `vehicle_id` on quotes
- pass `vehicle_id` through API and service layers
- show vehicle plate when listing quotes in the portal dashboard
- allow quote creation page to send selected vehicle
- update tests

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68696ae27a5083338a809bffc94b1968