### PR TITLE
Add quote edit page

### DIFF
--- a/__tests__/quote-items-api.test.js
+++ b/__tests__/quote-items-api.test.js
@@ -24,6 +24,8 @@ test('quote-items POST creates item', async () => {
   jest.unstable_mockModule('../services/quoteItemsService.js', () => ({
     getQuoteItems: jest.fn(),
     createQuoteItem: createMock,
+    getQuoteItemById: jest.fn(),
+    updateQuoteItem: jest.fn(),
   }));
   const { default: handler } = await import('../pages/api/quote-items/index.js');
   const req = { method: 'POST', body: { quote_id: 1 }, headers: {} };
@@ -32,4 +34,35 @@ test('quote-items POST creates item', async () => {
   expect(createMock).toHaveBeenCalledWith(req.body);
   expect(res.status).toHaveBeenCalledWith(201);
   expect(res.json).toHaveBeenCalledWith(item);
+});
+
+test('quote-item detail returns item', async () => {
+  const item = { id: 3 };
+  const getMock = jest.fn().mockResolvedValue(item);
+  jest.unstable_mockModule('../services/quoteItemsService.js', () => ({
+    getQuoteItemById: getMock,
+    updateQuoteItem: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quote-items/[id].js');
+  const req = { method: 'GET', query: { id: '3' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(getMock).toHaveBeenCalledWith('3');
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(item);
+});
+
+test('quote-item detail updates item', async () => {
+  const updateMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/quoteItemsService.js', () => ({
+    getQuoteItemById: jest.fn(),
+    updateQuoteItem: updateMock,
+  }));
+  const { default: handler } = await import('../pages/api/quote-items/[id].js');
+  const req = { method: 'PUT', query: { id: '4' }, body: { qty: 2 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(updateMock).toHaveBeenCalledWith('4', req.body);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ ok: true });
 });

--- a/__tests__/quoteItemsService.test.js
+++ b/__tests__/quoteItemsService.test.js
@@ -16,3 +16,15 @@ test('getQuoteItems fetches items', async () => {
   expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/FROM quote_items/), [2]);
   expect(result).toEqual(rows);
 });
+
+test('updateQuoteItem updates row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { updateQuoteItem } = await import('../services/quoteItemsService.js');
+  const result = await updateQuoteItem(5, { description: 'x', qty: 2, unit_price: 3 });
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/UPDATE quote_items/),
+    ['x', 2, 3, 5]
+  );
+  expect(result).toEqual({ ok: true });
+});

--- a/pages/api/quote-items/[id].js
+++ b/pages/api/quote-items/[id].js
@@ -1,0 +1,23 @@
+import { getQuoteItemById, updateQuoteItem } from '../../../services/quoteItemsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const item = await getQuoteItemById(id);
+      return res.status(200).json(item);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateQuoteItem(id, req.body);
+      return res.status(200).json(updated);
+    }
+    res.setHeader('Allow', ['GET','PUT']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+export default apiHandler(handler);

--- a/pages/office/quotations/[id]/edit.js
+++ b/pages/office/quotations/[id]/edit.js
@@ -1,0 +1,331 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import OfficeLayout from '../../../../components/OfficeLayout';
+import { fetchFleets } from '../../../../lib/fleets';
+import { fetchVehicles } from '../../../../lib/vehicles';
+import { updateQuote } from '../../../../lib/quotes';
+
+const emptyItem = { id: null, part_number: '', part_id: '', description: '', qty: 1, price: 0 };
+import PartAutocomplete from '../../../../components/PartAutocomplete';
+import ClientAutocomplete from '../../../../components/ClientAutocomplete';
+
+export default function EditQuotationPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [loading, setLoading] = useState(true);
+  const [vehicles, setVehicles] = useState([]);
+  const [fleets, setFleets] = useState([]);
+  const [mode, setMode] = useState('client');
+  const [clientName, setClientName] = useState('');
+  const [form, setForm] = useState({
+    customer_id: '',
+    fleet_id: '',
+    vehicle_id: '',
+    customer_ref: '',
+    po_number: '',
+  });
+  const [items, setItems] = useState([emptyItem]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setForm(f => ({ ...f, customer_id: '', fleet_id: '', vehicle_id: '' }));
+    setClientName('');
+    setVehicles([]);
+  }, [mode]);
+
+  useEffect(() => {
+    fetchFleets()
+      .then(setFleets)
+      .catch(() => setError('Failed to load fleets'));
+  }, []);
+
+  useEffect(() => {
+    if (mode === 'client') {
+      if (!form.customer_id) return setVehicles([]);
+      fetchVehicles(form.customer_id, null)
+        .then(setVehicles)
+        .catch(() => setVehicles([]));
+    } else {
+      if (!form.fleet_id) return setVehicles([]);
+      fetchVehicles(null, form.fleet_id)
+        .then(setVehicles)
+        .catch(() => setVehicles([]));
+    }
+  }, [mode, form.customer_id, form.fleet_id]);
+
+  useEffect(() => {
+    if (!id) return;
+    async function load() {
+      setLoading(true);
+      try {
+        const [quoteRes, itemsRes] = await Promise.all([
+          fetch(`/api/quotes/${id}`),
+          fetch(`/api/quote-items?quote_id=${id}`),
+        ]);
+        const quote = quoteRes.ok ? await quoteRes.json() : null;
+        const its = itemsRes.ok ? await itemsRes.json() : [];
+        if (quote) {
+          setMode(quote.fleet_id ? 'fleet' : 'client');
+          setForm({
+            customer_id: quote.customer_id || '',
+            fleet_id: quote.fleet_id || '',
+            vehicle_id: quote.vehicle_id || '',
+            customer_ref: quote.customer_reference || '',
+            po_number: quote.po_number || '',
+          });
+          if (quote.customer_id) {
+            const cRes = await fetch(`/api/clients/${quote.customer_id}`);
+            if (cRes.ok) {
+              const c = await cRes.json();
+              setClientName(`${c.first_name || ''} ${c.last_name || ''}`.trim());
+            }
+          }
+        }
+        const detailed = await Promise.all(
+          its.map(async it => {
+            let part_number = '';
+            if (it.part_id) {
+              const pRes = await fetch(`/api/parts/${it.part_id}`);
+              if (pRes.ok) {
+                const p = await pRes.json();
+                part_number = p.part_number || '';
+              }
+            }
+            return {
+              id: it.id,
+              part_id: it.part_id || '',
+              part_number,
+              description: it.description || '',
+              qty: it.qty || 1,
+              price: it.unit_price || 0,
+            };
+          })
+        );
+        setItems(detailed.length ? detailed : [emptyItem]);
+      } catch {
+        setError('Failed to load quote');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id]);
+
+  const addItem = () => setItems(items => [...items, emptyItem]);
+
+  const changeItem = (i, field, value) => {
+    setItems(itms => {
+      const copy = [...itms];
+      copy[i] = { ...copy[i], [field]: value };
+      return copy;
+    });
+  };
+
+  const total = items.reduce(
+    (sum, it) => sum + Number(it.qty) * Number(it.price),
+    0
+  );
+
+  const formatEuro = n =>
+    new Intl.NumberFormat('en-IE', { style: 'currency', currency: 'EUR' }).format(
+      n || 0
+    );
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      await updateQuote(id, {
+        customer_id: mode === 'client' ? form.customer_id : null,
+        fleet_id: mode === 'fleet' ? form.fleet_id : null,
+        job_id: null,
+        vehicle_id: form.vehicle_id || null,
+        total_amount: total,
+        status: 'new',
+      });
+      for (const it of items) {
+        if (it.id) {
+          await fetch(`/api/quote-items/${it.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              description: it.description,
+              qty: it.qty,
+              unit_price: it.price,
+            }),
+          });
+        } else {
+          await fetch('/api/quote-items', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              quote_id: id,
+              part_id: it.part_id || null,
+              description: it.description,
+              qty: it.qty,
+              unit_price: it.price,
+            }),
+          });
+        }
+      }
+      router.push('/office/quotations');
+    } catch {
+      setError('Failed to update quote');
+    }
+  };
+
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Edit Quote</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 mb-8 max-w-lg">
+        <div className="mb-2 flex gap-2">
+          <button
+            type="button"
+            className={(mode === 'client' ? 'button' : 'button-secondary') + ' px-4'}
+            onClick={() => setMode('client')}
+          >
+            Client
+          </button>
+          <button
+            type="button"
+            className={(mode === 'fleet' ? 'button' : 'button-secondary') + ' px-4'}
+            onClick={() => setMode('fleet')}
+          >
+            Fleet
+          </button>
+        </div>
+        {mode === 'client' ? (
+          <div>
+            <label className="block mb-1">Client</label>
+            <ClientAutocomplete
+              value={clientName}
+              onChange={v => {
+                setClientName(v);
+                setForm(f => ({ ...f, customer_id: '' }));
+              }}
+              onSelect={c => {
+                setClientName(`${c.first_name || ''} ${c.last_name || ''}`.trim());
+                setForm(f => ({ ...f, customer_id: c.id, fleet_id: '' }));
+              }}
+            />
+          </div>
+        ) : (
+          <div>
+            <label className="block mb-1">Fleet</label>
+            <select
+              className="input w-full"
+              value={form.fleet_id}
+              onChange={e =>
+                setForm(f => ({ ...f, fleet_id: e.target.value, customer_id: '' }))
+              }
+            >
+              <option value="">Select fleet</option>
+              {fleets.map(f => (
+                <option key={f.id} value={f.id}>
+                  {f.company_name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+        <div>
+          <label className="block mb-1">Vehicle</label>
+          <select
+            className="input w-full"
+            value={form.vehicle_id}
+            onChange={e =>
+              setForm(f => ({ ...f, vehicle_id: e.target.value }))
+            }
+          >
+            <option value="">Select vehicle</option>
+            {vehicles.map(v => (
+              <option key={v.id} value={v.id}>
+                {v.licence_plate}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Customer Ref #</label>
+          <input
+            className="input w-full"
+            value={form.customer_ref}
+            onChange={e =>
+              setForm(f => ({ ...f, customer_ref: e.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <label className="block mb-1">PO Number</label>
+          <input
+            className="input w-full"
+            value={form.po_number}
+            onChange={e =>
+              setForm(f => ({ ...f, po_number: e.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Item Details</h2>
+          <div className="grid grid-cols-5 gap-2 mb-2 font-semibold text-sm">
+            <div>Part #</div>
+            <div>Description</div>
+            <div>Qty</div>
+            <div>Unit Cost</div>
+            <div>Line Cost</div>
+          </div>
+          {items.map((it, i) => (
+            <div key={i} className="grid grid-cols-5 gap-2 mb-2">
+              <PartAutocomplete
+                value={it.part_number}
+                onChange={v => changeItem(i, 'part_number', v)}
+                onSelect={p => {
+                  changeItem(i, 'part_number', p.part_number);
+                  changeItem(i, 'part_id', p.id);
+                  changeItem(i, 'description', p.description || '');
+                  changeItem(i, 'price', p.unit_cost || 0);
+                }}
+              />
+              <input
+                className="input"
+                placeholder="Description"
+                value={it.description}
+                onChange={e => changeItem(i, 'description', e.target.value)}
+              />
+              <input
+                type="number"
+                className="input"
+                placeholder="Qty"
+                value={it.qty}
+                onChange={e => changeItem(i, 'qty', e.target.value)}
+              />
+              <input
+                type="number"
+                className="input"
+                placeholder="Unit cost"
+                value={it.price}
+                onChange={e => changeItem(i, 'price', e.target.value)}
+              />
+              <div className="flex items-center px-2 border rounded bg-gray-50">
+                {formatEuro(Number(it.qty) * Number(it.price))}
+              </div>
+            </div>
+          ))}
+          <button type="button" onClick={addItem} className="button-secondary px-4">
+            Add Item
+          </button>
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Summary</h2>
+          <p className="font-semibold">Total: {formatEuro(total)}</p>
+        </div>
+        <button type="submit" className="button">
+          Update Quote
+        </button>
+      </form>
+    </OfficeLayout>
+  );
+}
+

--- a/pages/office/quotations/index.js
+++ b/pages/office/quotations/index.js
@@ -114,6 +114,12 @@ const QuotationsPage = () => {
                     Create Job Card
                   </button>
                 )}
+                <Link
+                  href={`/office/quotations/${q.id}/edit`}
+                  className="button px-4 text-sm"
+                >
+                  Edit
+                </Link>
                 <a
                   href={`/api/quotes/${q.id}/pdf`}
                   className="button-secondary px-4 text-sm"

--- a/services/quoteItemsService.js
+++ b/services/quoteItemsService.js
@@ -21,3 +21,19 @@ export async function createQuoteItem({ quote_id, part_id, description, qty, uni
   );
   return { id: insertId, quote_id, part_id, description, qty, unit_price };
 }
+
+export async function getQuoteItemById(id) {
+  const [[row]] = await pool.query(
+    `SELECT id, quote_id, part_id, description, qty, unit_price FROM quote_items WHERE id=?`,
+    [id]
+  );
+  return row || null;
+}
+
+export async function updateQuoteItem(id, { description, qty, unit_price }) {
+  await pool.query(
+    `UPDATE quote_items SET description=?, qty=?, unit_price=? WHERE id=?`,
+    [description || null, qty || null, unit_price || null, id]
+  );
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- add ability to update quote items through new API route
- support editing quote items in service layer
- create edit page for quotes with preloaded data
- link edit page from quotation list
- test quote item API & service

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696caff9c48333a9c71d1dc77700b1