### PR TITLE
Add fleet portal list views

### DIFF
--- a/pages/fleet/invoices/index.js
+++ b/pages/fleet/invoices/index.js
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import logout from '../../../lib/logout.js';
+import { fetchInvoices } from '../../../lib/invoices';
 
 export default function FleetInvoices() {
   const router = useRouter();
   const [fleet, setFleet] = useState(null);
+  const [invoices, setInvoices] = useState([]);
 
   async function handleLogout() {
     try {
@@ -21,13 +23,15 @@ export default function FleetInvoices() {
       if (!res.ok) return router.replace('/fleet/login');
       const f = await res.json();
       setFleet(f);
+      const all = await fetchInvoices();
+      setInvoices(all.filter(inv => inv.fleet_id === f.id));
     })();
   }, [router]);
 
   if (!fleet) return <p className="p-8">Loading…</p>;
 
   return (
-    <div className="p-8">
+    <div className="min-h-screen p-8 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Invoices</h1>
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
@@ -35,7 +39,13 @@ export default function FleetInvoices() {
       <Link href="/fleet/home" className="button inline-block mb-4">
         Return to Home
       </Link>
-      <p>Coming soon.</p>
+      <ul className="list-disc ml-6 space-y-1">
+        {invoices.map(inv => (
+          <li key={inv.id}>
+            Invoice #{inv.id} - {inv.status}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/pages/fleet/jobs/index.js
+++ b/pages/fleet/jobs/index.js
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import logout from '../../../lib/logout.js';
+import { fetchJobs } from '../../../lib/jobs';
 
 export default function FleetJobs() {
   const router = useRouter();
   const [fleet, setFleet] = useState(null);
+  const [jobs, setJobs] = useState([]);
 
   async function handleLogout() {
     try {
@@ -21,13 +23,15 @@ export default function FleetJobs() {
       if (!res.ok) return router.replace('/fleet/login');
       const f = await res.json();
       setFleet(f);
+      const j = await fetchJobs({ fleet_id: f.id });
+      setJobs(j);
     })();
   }, [router]);
 
   if (!fleet) return <p className="p-8">Loading…</p>;
 
   return (
-    <div className="p-8">
+    <div className="min-h-screen p-8 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Jobs</h1>
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
@@ -35,7 +39,11 @@ export default function FleetJobs() {
       <Link href="/fleet/home" className="button inline-block mb-4">
         Return to Home
       </Link>
-      <p>Coming soon.</p>
+      <ul className="list-disc ml-6 space-y-1">
+        {jobs.map(j => (
+          <li key={j.id}>Job #{j.id} - {j.status}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/pages/fleet/quotes/index.js
+++ b/pages/fleet/quotes/index.js
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import logout from '../../../lib/logout.js';
+import { fetchQuotes } from '../../../lib/quotes';
 
 export default function FleetQuotes() {
   const router = useRouter();
   const [fleet, setFleet] = useState(null);
+  const [quotes, setQuotes] = useState([]);
 
   async function handleLogout() {
     try {
@@ -21,13 +23,15 @@ export default function FleetQuotes() {
       if (!res.ok) return router.replace('/fleet/login');
       const f = await res.json();
       setFleet(f);
+      const all = await fetchQuotes();
+      setQuotes(all.filter(q => q.fleet_id === f.id));
     })();
   }, [router]);
 
   if (!fleet) return <p className="p-8">Loading…</p>;
 
   return (
-    <div className="p-8">
+    <div className="min-h-screen p-8 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Quotes</h1>
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
@@ -35,7 +39,13 @@ export default function FleetQuotes() {
       <Link href="/fleet/home" className="button inline-block mb-4">
         Return to Home
       </Link>
-      <p>Coming soon.</p>
+      <ul className="list-disc ml-6 space-y-1">
+        {quotes.map(q => (
+          <li key={q.id}>
+            Quote #{q.id} - {q.status}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/pages/fleet/request-quotation.js
+++ b/pages/fleet/request-quotation.js
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import logout from '../../lib/logout.js';
+import { fetchVehicles } from '../../lib/vehicles';
 
 export default function FleetRequestQuotation() {
   const router = useRouter();
   const [fleet, setFleet] = useState(null);
+  const [vehicles, setVehicles] = useState([]);
 
   async function handleLogout() {
     try {
@@ -21,13 +23,15 @@ export default function FleetRequestQuotation() {
       if (!res.ok) return router.replace('/fleet/login');
       const f = await res.json();
       setFleet(f);
+      const veh = await fetchVehicles(null, f.id);
+      setVehicles(veh);
     })();
   }, [router]);
 
   if (!fleet) return <p className="p-8">Loading…</p>;
 
   return (
-    <div className="p-8">
+    <div className="min-h-screen p-8 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Request Quotation</h1>
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
@@ -35,7 +39,12 @@ export default function FleetRequestQuotation() {
       <Link href="/fleet/home" className="button inline-block mb-4">
         Return to Home
       </Link>
-      <p>Coming soon.</p>
+      <p className="mb-2">Select a vehicle to request a quote:</p>
+      <ul className="list-disc ml-6 space-y-1">
+        {vehicles.map(v => (
+          <li key={v.id}>{v.licence_plate} - {v.make} {v.model}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/pages/fleet/vehicles/index.js
+++ b/pages/fleet/vehicles/index.js
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import logout from '../../../lib/logout.js';
+import { fetchVehicles } from '../../../lib/vehicles';
 
 export default function FleetVehicles() {
   const router = useRouter();
   const [fleet, setFleet] = useState(null);
+  const [vehicles, setVehicles] = useState([]);
 
   async function handleLogout() {
     try {
@@ -21,13 +23,15 @@ export default function FleetVehicles() {
       if (!res.ok) return router.replace('/fleet/login');
       const f = await res.json();
       setFleet(f);
+      const veh = await fetchVehicles(null, f.id);
+      setVehicles(veh);
     })();
   }, [router]);
 
   if (!fleet) return <p className="p-8">Loading…</p>;
 
   return (
-    <div className="p-8">
+    <div className="min-h-screen p-8 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
       <div className="flex justify-between mb-4">
         <h1 className="text-2xl font-bold">Vehicles</h1>
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
@@ -35,7 +39,13 @@ export default function FleetVehicles() {
       <Link href="/fleet/home" className="button inline-block mb-4">
         Return to Home
       </Link>
-      <p>Coming soon.</p>
+      <ul className="list-disc ml-6 space-y-1">
+        {vehicles.map(v => (
+          <li key={v.id}>
+            {v.licence_plate} - {v.make} {v.model}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- fetch vehicles, quotes, invoices and jobs on fleet pages
- show data in simple lists
- give fleet pages matching blue gradient background

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm test` *(fails: cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_6869703030e883338396ea5d70c117bc