### PR TITLE
Fix description input width in quote forms

### DIFF
--- a/pages/office/quotations/[id]/edit.js
+++ b/pages/office/quotations/[id]/edit.js
@@ -289,7 +289,7 @@ export default function EditQuotationPage() {
                 }}
               />
               <input
-                className="input"
+                className="input w-full"
                 placeholder="Description"
                 value={it.description}
                 onChange={e => changeItem(i, 'description', e.target.value)}

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -218,7 +218,7 @@ export default function NewQuotationPage() {
                 }}
               />
               <input
-                className="input"
+                className="input w-full"
                 placeholder="Description"
                 value={it.description}
                 onChange={e => changeItem(i, 'description', e.target.value)}


### PR DESCRIPTION
## Summary
- match the description field width with other inputs on the new quote page
- apply same width fix to the edit quote page

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6869715ef4f08333ac6f6b463a63cabf