### PR TITLE
Add invoice PDF API route

### DIFF
--- a/__tests__/invoicePdfApi.test.js
+++ b/__tests__/invoicePdfApi.test.js
@@ -1,0 +1,33 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('invoice pdf endpoint returns PDF', async () => {
+  const invoice = { id: 1, customer_id: 2, amount: 10 };
+  const buildMock = jest.fn().mockResolvedValue(Buffer.from('PDF'));
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getInvoiceById: jest.fn().mockResolvedValue(invoice),
+  }));
+  jest.unstable_mockModule('../services/companySettingsService.js', () => ({
+    getSettings: jest.fn().mockResolvedValue({})
+  }));
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getClientById: jest.fn().mockResolvedValue({})
+  }));
+  jest.unstable_mockModule('../services/invoiceItemsService.js', () => ({
+    getInvoiceItems: jest.fn().mockResolvedValue([])
+  }));
+  jest.unstable_mockModule('../lib/pdf.js', () => ({
+    buildInvoicePdf: buildMock
+  }));
+  const { default: handler } = await import('../pages/api/invoices/[id]/pdf.js');
+  const req = { method: 'GET', query: { id: '1' }, headers: {} };
+  const res = { setHeader: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn(), json: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(buildMock).toHaveBeenCalled();
+  expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+  expect(res.send).toHaveBeenCalledWith(Buffer.from('PDF'));
+});

--- a/pages/api/invoices/[id]/pdf.js
+++ b/pages/api/invoices/[id]/pdf.js
@@ -1,0 +1,35 @@
+import { getSettings } from '../../../../services/companySettingsService.js';
+import { getInvoiceById } from '../../../../services/invoicesService.js';
+import { getClientById } from '../../../../services/clientsService.js';
+import { getInvoiceItems } from '../../../../services/invoiceItemsService.js';
+import { buildInvoicePdf } from '../../../../lib/pdf.js';
+import apiHandler from '../../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  const { id } = req.query;
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+  try {
+    const invoice = await getInvoiceById(id);
+    if (!invoice) return res.status(404).json({ error: 'Not Found' });
+    const company = await getSettings();
+    const client = invoice.customer_id ? await getClientById(invoice.customer_id) : null;
+    const items = await getInvoiceItems(id);
+    const pdf = await buildInvoicePdf({
+      company,
+      invoice,
+      client,
+      items
+    });
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename=invoice-${id}.pdf`);
+    res.send(pdf);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+export default apiHandler(handler);


### PR DESCRIPTION
## Summary
- create API route to generate invoice PDFs
- add unit test for the new API

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697a8f2c988333b2f68a44ec3c6db2