### PR TITLE
Refactor PDF helpers

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -1,5 +1,32 @@
 import PDFDocument from 'pdfkit';
 
+function renderHeader(doc, title, { client = {}, vehicle = {} } = {}) {
+  doc.fontSize(18).text(title, { align: 'center' });
+  doc.moveDown();
+
+  doc.fontSize(12);
+  if (client.first_name || client.last_name) {
+    doc.text(`${client.first_name || ''} ${client.last_name || ''}`);
+  }
+  if (vehicle.licence_plate) {
+    doc.text(`Vehicle: ${vehicle.make || ''} ${vehicle.model || ''} (${vehicle.licence_plate})`);
+  }
+  doc.moveDown();
+}
+
+function renderItemsTable(doc, items = []) {
+  doc.text('Items:');
+  items.forEach(it => {
+    const line = `${it.description} x${it.qty} @ ${it.unit_price} = ${(it.qty * it.unit_price).toFixed(2)}`;
+    doc.text(line);
+  });
+  doc.moveDown();
+}
+
+function renderFooter(doc, label, total) {
+  doc.text(`${label}: ${total}`);
+}
+
 export async function buildQuotePdf({ company = {}, quote, client = {}, vehicle = {}, items = [] }) {
   return new Promise(resolve => {
     const doc = new PDFDocument();
@@ -7,25 +34,9 @@ export async function buildQuotePdf({ company = {}, quote, client = {}, vehicle 
     doc.on('data', c => chunks.push(c));
     doc.on('end', () => resolve(Buffer.concat(chunks)));
 
-    doc.fontSize(18).text(company.company_name || 'Quote', { align: 'center' });
-    doc.moveDown();
-
-    doc.fontSize(12);
-    if (client.first_name || client.last_name) {
-      doc.text(`${client.first_name || ''} ${client.last_name || ''}`);
-    }
-    if (vehicle.licence_plate) {
-      doc.text(`Vehicle: ${vehicle.make || ''} ${vehicle.model || ''} (${vehicle.licence_plate})`);
-    }
-    doc.moveDown();
-
-    doc.text('Items:');
-    items.forEach(it => {
-      const line = `${it.description} x${it.qty} @ ${it.unit_price} = ${(it.qty * it.unit_price).toFixed(2)}`;
-      doc.text(line);
-    });
-    doc.moveDown();
-    doc.text(`Total: ${quote.total_amount}`);
+    renderHeader(doc, company.company_name || 'Quote', { client, vehicle });
+    renderItemsTable(doc, items);
+    renderFooter(doc, 'Total', quote.total_amount);
 
     doc.end();
   });
@@ -38,22 +49,9 @@ export async function buildInvoicePdf({ company = {}, invoice, client = {}, item
     doc.on('data', c => chunks.push(c));
     doc.on('end', () => resolve(Buffer.concat(chunks)));
 
-    doc.fontSize(18).text(company.company_name || 'Invoice', { align: 'center' });
-    doc.moveDown();
-
-    doc.fontSize(12);
-    if (client.first_name || client.last_name) {
-      doc.text(`${client.first_name || ''} ${client.last_name || ''}`);
-    }
-    doc.moveDown();
-
-    doc.text('Items:');
-    items.forEach(it => {
-      const line = `${it.description} x${it.qty} @ ${it.unit_price} = ${(it.qty * it.unit_price).toFixed(2)}`;
-      doc.text(line);
-    });
-    doc.moveDown();
-    doc.text(`Total: ${invoice.amount}`);
+    renderHeader(doc, company.company_name || 'Invoice', { client });
+    renderItemsTable(doc, items);
+    renderFooter(doc, 'Total', invoice.amount);
 
     doc.end();
   });


### PR DESCRIPTION
## Summary
- extract helper functions for rendering PDF sections
- keep entry points for quote/invoice generation that call helpers

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697b4b345c83339b28111051ab5f73