### PR TITLE
Add custom terms support for quotes/invoices

### DIFF
--- a/__tests__/invoicesService.test.js
+++ b/__tests__/invoicesService.test.js
@@ -38,7 +38,10 @@ test('createInvoice inserts invoice', async () => {
   const { createInvoice } = await import('../services/invoicesService.js');
   const data = { job_id: 1, customer_id: 2, amount: 99, due_date: '2024-06-01', status: 'open' };
   const result = await createInvoice(data);
-  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/INSERT INTO invoices/), [1, 2, 99, '2024-06-01', 'open']);
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/INSERT INTO invoices/),
+    [1, 2, 99, '2024-06-01', 'open', null]
+  );
   expect(result).toEqual({ id: 3, ...data });
 });
 
@@ -50,7 +53,10 @@ test('updateInvoice updates row', async () => {
   const { updateInvoice } = await import('../services/invoicesService.js');
   const data = { job_id: 4, customer_id: 5, amount: 8, due_date: '2024-07-01', status: 'paid' };
   const result = await updateInvoice(6, data);
-  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/UPDATE invoices/), [4, 5, 8, '2024-07-01', 'paid', 6]);
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/UPDATE invoices/),
+    [4, 5, 8, '2024-07-01', 'paid', null, 6]
+  );
   expect(result).toEqual({ ok: true });
 });
 

--- a/__tests__/quotesService.test.js
+++ b/__tests__/quotesService.test.js
@@ -47,7 +47,7 @@ test('createQuote inserts quote', async () => {
   const result = await createQuote(data);
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/INSERT INTO quotes/),
-    [1, 2, 3, 4, 50, 'new']
+    [1, 2, 3, 4, 50, 'new', null]
   );
   expect(result).toEqual({ id: 3, ...data });
 });
@@ -69,7 +69,7 @@ test('updateQuote updates row', async () => {
   const result = await updateQuote(9, data);
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/UPDATE quotes/),
-    [4, 5, 6, 7, 8, 'sent', 9]
+    [4, 5, 6, 7, 8, 'sent', null, 9]
   );
   expect(result).toEqual({ ok: true });
 });

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -27,6 +27,12 @@ function renderFooter(doc, label, total) {
   doc.text(`${label}: ${total}`);
 }
 
+function renderTerms(doc, terms) {
+  if (!terms) return;
+  doc.moveDown();
+  doc.fontSize(10).text(terms);
+}
+
 export async function buildQuotePdf({ company = {}, quote, client = {}, vehicle = {}, items = [] }) {
   return new Promise(resolve => {
     const doc = new PDFDocument();
@@ -37,6 +43,7 @@ export async function buildQuotePdf({ company = {}, quote, client = {}, vehicle 
     renderHeader(doc, company.company_name || 'Quote', { client, vehicle });
     renderItemsTable(doc, items);
     renderFooter(doc, 'Total', quote.total_amount);
+    renderTerms(doc, quote.terms || company.terms);
 
     doc.end();
   });
@@ -52,6 +59,7 @@ export async function buildInvoicePdf({ company = {}, invoice, client = {}, item
     renderHeader(doc, company.company_name || 'Invoice', { client });
     renderItemsTable(doc, items);
     renderFooter(doc, 'Total', invoice.amount);
+    renderTerms(doc, invoice.terms || company.terms);
 
     doc.end();
   });

--- a/migrations/20251222_add_terms_to_quotes_invoices.sql
+++ b/migrations/20251222_add_terms_to_quotes_invoices.sql
@@ -1,0 +1,5 @@
+ALTER TABLE quotes
+  ADD COLUMN terms TEXT NULL AFTER status;
+
+ALTER TABLE invoices
+  ADD COLUMN terms TEXT NULL AFTER status;

--- a/pages/api/quotes/index.js
+++ b/pages/api/quotes/index.js
@@ -23,6 +23,7 @@ async function handler(req, res) {
         vehicle_id: req.body.vehicle_id,
         total_amount: req.body.total_amount,
         status: req.body.status,
+        terms: req.body.terms,
       };
       const newQuote = await service.createQuote(data);
       try {

--- a/services/invoicesService.js
+++ b/services/invoicesService.js
@@ -2,14 +2,14 @@ import pool from '../lib/db.js';
 
 export async function getAllInvoices() {
   const [rows] = await pool.query(
-    `SELECT id, job_id, customer_id, amount, due_date, status, created_ts
+    `SELECT id, job_id, customer_id, amount, due_date, status, terms, created_ts
        FROM invoices ORDER BY id`
   );
   return rows;
 }
 
 export async function getInvoicesByCustomer(customer_id, status) {
-  const base = `SELECT id, job_id, customer_id, amount, due_date, status, created_ts FROM invoices WHERE customer_id=?`;
+  const base = `SELECT id, job_id, customer_id, amount, due_date, status, terms, created_ts FROM invoices WHERE customer_id=?`;
   const [rows] = status
     ? await pool.query(`${base} AND status=? ORDER BY id`, [customer_id, status])
     : await pool.query(`${base} ORDER BY id`, [customer_id]);
@@ -17,7 +17,7 @@ export async function getInvoicesByCustomer(customer_id, status) {
 }
 
 export async function getInvoicesByFleet(fleet_id, status) {
-  const base = `SELECT i.id, i.job_id, i.customer_id, i.amount, i.due_date, i.status, i.created_ts
+  const base = `SELECT i.id, i.job_id, i.customer_id, i.amount, i.due_date, i.status, i.terms, i.created_ts
        FROM invoices i
        JOIN jobs j ON i.job_id=j.id
        JOIN vehicles v ON j.vehicle_id=v.id
@@ -30,26 +30,26 @@ export async function getInvoicesByFleet(fleet_id, status) {
 
 export async function getInvoiceById(id) {
   const [[row]] = await pool.query(
-    `SELECT id, job_id, customer_id, amount, due_date, status, created_ts
+    `SELECT id, job_id, customer_id, amount, due_date, status, terms, created_ts
        FROM invoices WHERE id=?`,
     [id]
   );
   return row || null;
 }
 
-export async function createInvoice({ job_id, customer_id, amount, due_date, status }) {
+export async function createInvoice({ job_id, customer_id, amount, due_date, status, terms }) {
   const [{ insertId }] = await pool.query(
     `INSERT INTO invoices
-      (job_id, customer_id, amount, due_date, status)
-     VALUES (?,?,?,?,?)`,
-    [job_id || null, customer_id || null, amount || null, due_date || null, status || null]
+      (job_id, customer_id, amount, due_date, status, terms)
+     VALUES (?,?,?,?,?,?)`,
+    [job_id || null, customer_id || null, amount || null, due_date || null, status || null, terms || null]
   );
-  return { id: insertId, job_id, customer_id, amount, due_date, status };
+  return { id: insertId, job_id, customer_id, amount, due_date, status, terms };
 }
 
 export async function updateInvoice(
   id,
-  { job_id, customer_id, amount, due_date, status }
+  { job_id, customer_id, amount, due_date, status, terms }
 ) {
   await pool.query(
     `UPDATE invoices SET
@@ -57,9 +57,10 @@ export async function updateInvoice(
        customer_id=?,
        amount=?,
        due_date=?,
-       status=?
+       status=?,
+       terms=?
      WHERE id=?`,
-    [job_id || null, customer_id || null, amount || null, due_date || null, status || null, id]
+    [job_id || null, customer_id || null, amount || null, due_date || null, status || null, terms || null, id]
   );
   return { ok: true };
 }

--- a/services/quotesService.js
+++ b/services/quotesService.js
@@ -2,7 +2,7 @@ import pool from '../lib/db.js';
 
 export async function getAllQuotes() {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms, created_ts
        FROM quotes ORDER BY id`
   );
   return rows;
@@ -10,7 +10,7 @@ export async function getAllQuotes() {
 
 export async function getQuotesByFleet(fleet_id) {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms, created_ts
        FROM quotes WHERE fleet_id=? ORDER BY id`,
     [fleet_id]
   );
@@ -19,7 +19,7 @@ export async function getQuotesByFleet(fleet_id) {
 
 export async function getQuotesByCustomer(customer_id) {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms, created_ts
        FROM quotes WHERE customer_id=? ORDER BY id`,
     [customer_id]
   );
@@ -28,18 +28,18 @@ export async function getQuotesByCustomer(customer_id) {
 
 export async function getQuoteById(id) {
   const [[row]] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms, created_ts
        FROM quotes WHERE id=?`,
     [id]
   );
   return row || null;
 }
 
-export async function createQuote({ customer_id, fleet_id, job_id, vehicle_id, total_amount, status }) {
+export async function createQuote({ customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms }) {
   const [{ insertId }] = await pool.query(
     `INSERT INTO quotes
-      (customer_id, fleet_id, job_id, vehicle_id, total_amount, status)
-     VALUES (?,?,?,?,?,?)`,
+      (customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms)
+     VALUES (?,?,?,?,?,?,?)`,
     [
       customer_id || null,
       fleet_id || null,
@@ -47,14 +47,15 @@ export async function createQuote({ customer_id, fleet_id, job_id, vehicle_id, t
       vehicle_id || null,
       total_amount || null,
       status || null,
+      terms || null,
     ]
   );
-  return { id: insertId, customer_id, fleet_id, job_id, vehicle_id, total_amount, status };
+  return { id: insertId, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms };
 }
 
 export async function updateQuote(
   id,
-  { customer_id, fleet_id, job_id, vehicle_id, total_amount, status }
+  { customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms }
 ) {
   await pool.query(
     `UPDATE quotes SET
@@ -63,7 +64,8 @@ export async function updateQuote(
        job_id=?,
        vehicle_id=?,
        total_amount=?,
-       status=?
+       status=?,
+       terms=?
      WHERE id=?`,
     [
       customer_id || null,
@@ -72,6 +74,7 @@ export async function updateQuote(
       vehicle_id || null,
       total_amount || null,
       status || null,
+      terms || null,
       id,
     ]
   );


### PR DESCRIPTION
## Summary
- add migration to add optional `terms` column on quotes and invoices
- include `terms` in service layer create/update and queries
- accept `terms` when creating quotes via API
- render custom terms in PDFs with fallback to company default
- update unit tests for new SQL parameters

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68697bd6c5308333a3f23fd1b1e387d5