### PR TITLE
Add invoice pdf API test

### DIFF
--- a/__tests__/invoicePdfApi.test.js
+++ b/__tests__/invoicePdfApi.test.js
@@ -29,5 +29,6 @@ test('invoice pdf endpoint returns PDF', async () => {
   await handler(req, res);
   expect(buildMock).toHaveBeenCalled();
   expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+  expect(res.setHeader).toHaveBeenCalledWith('Content-Disposition', 'attachment; filename=invoice-1.pdf');
   expect(res.send).toHaveBeenCalledWith(Buffer.from('PDF'));
 });


### PR DESCRIPTION
## Summary
- verify invoice PDF endpoint returns buffer and proper headers

## Testing
- `npm test __tests__/invoicePdfApi.test.js` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68697d60e2d08333a39b4f1cb817f7fa