### PR TITLE
Improve pdf conversion error handling

### DIFF
--- a/generate_invoice.py
+++ b/generate_invoice.py
@@ -58,6 +58,8 @@ def convert_to_pdf(docx_path: str) -> str:
             subprocess.run(['unoconv', '-f', 'pdf', '-o', pdf_path, docx_path], check=True)
         except FileNotFoundError:
             raise RuntimeError('Neither docx2pdf nor unoconv is available for PDF conversion.')
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f'PDF conversion failed: {e}')
     return pdf_path
 
 

--- a/generate_quote.py
+++ b/generate_quote.py
@@ -57,6 +57,8 @@ def convert_to_pdf(docx_path: str) -> str:
             subprocess.run(['unoconv', '-f', 'pdf', '-o', pdf_path, docx_path], check=True)
         except FileNotFoundError:
             raise RuntimeError('Neither docx2pdf nor unoconv is available for PDF conversion.')
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f'PDF conversion failed: {e}')
     return pdf_path
 
 


### PR DESCRIPTION
## Summary
- catch `subprocess.CalledProcessError` when invoking `unoconv`
- raise a clear `RuntimeError` if PDF conversion fails

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68697e130e48833395e7071564b620e6