### PR TITLE
Add customer reference and PO number to quotes

### DIFF
--- a/__tests__/quotes-api.test.js
+++ b/__tests__/quotes-api.test.js
@@ -101,7 +101,7 @@ test('quote update returns updated data', async () => {
   await handler(req, res);
   expect(res.status).toHaveBeenCalledWith(200);
   expect(res.json).toHaveBeenCalledWith(updated);
-  expect(updateMock).toHaveBeenCalledWith('2', req.body);
+  expect(updateMock).toHaveBeenCalledWith('2', expect.objectContaining({ total_amount: 5 }));
 });
 
 test('quote delete succeeds', async () => {

--- a/__tests__/quotesService.test.js
+++ b/__tests__/quotesService.test.js
@@ -41,13 +41,15 @@ test('createQuote inserts quote', async () => {
     fleet_id: 2,
     job_id: 3,
     vehicle_id: 4,
+    customer_reference: 'ref',
+    po_number: 'PO123',
     total_amount: 50,
     status: 'new',
   };
   const result = await createQuote(data);
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/INSERT INTO quotes/),
-    [1, 2, 3, 4, 50, 'new', null]
+    [1, 2, 3, 4, 'ref', 'PO123', 50, 'new', null]
   );
   expect(result).toEqual({ id: 3, ...data });
 });
@@ -63,13 +65,15 @@ test('updateQuote updates row', async () => {
     fleet_id: 5,
     job_id: 6,
     vehicle_id: 7,
+    customer_reference: 'r',
+    po_number: 'PO',
     total_amount: 8,
     status: 'sent',
   };
   const result = await updateQuote(9, data);
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/UPDATE quotes/),
-    [4, 5, 6, 7, 8, 'sent', null, 9]
+    [4, 5, 6, 7, 'r', 'PO', 8, 'sent', null, 9]
   );
   expect(result).toEqual({ ok: true });
 });

--- a/migrations/20251223_add_customer_reference_po_to_quotes.sql
+++ b/migrations/20251223_add_customer_reference_po_to_quotes.sql
@@ -1,0 +1,3 @@
+ALTER TABLE quotes
+  ADD COLUMN customer_reference VARCHAR(255) NULL AFTER vehicle_id,
+  ADD COLUMN po_number VARCHAR(255) NULL AFTER customer_reference;

--- a/pages/api/quotes/[id].js
+++ b/pages/api/quotes/[id].js
@@ -9,7 +9,18 @@ async function handler(req, res) {
       return res.status(200).json(quote);
     }
     if (req.method === 'PUT') {
-      const updated = await updateQuote(id, req.body);
+      const data = {
+        customer_id: req.body.customer_id,
+        fleet_id: req.body.fleet_id,
+        job_id: req.body.job_id,
+        vehicle_id: req.body.vehicle_id,
+        customer_reference: req.body.customer_reference,
+        po_number: req.body.po_number,
+        total_amount: req.body.total_amount,
+        status: req.body.status,
+        terms: req.body.terms,
+      };
+      const updated = await updateQuote(id, data);
       return res.status(200).json(updated);
     }
     if (req.method === 'DELETE') {

--- a/pages/api/quotes/index.js
+++ b/pages/api/quotes/index.js
@@ -21,6 +21,8 @@ async function handler(req, res) {
         fleet_id: req.body.fleet_id,
         job_id: req.body.job_id,
         vehicle_id: req.body.vehicle_id,
+        customer_reference: req.body.customer_reference,
+        po_number: req.body.po_number,
         total_amount: req.body.total_amount,
         status: req.body.status,
         terms: req.body.terms,

--- a/services/quotesService.js
+++ b/services/quotesService.js
@@ -2,7 +2,7 @@ import pool from '../lib/db.js';
 
 export async function getAllQuotes() {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, customer_reference, po_number, total_amount, status, terms, created_ts
        FROM quotes ORDER BY id`
   );
   return rows;
@@ -10,7 +10,7 @@ export async function getAllQuotes() {
 
 export async function getQuotesByFleet(fleet_id) {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, customer_reference, po_number, total_amount, status, terms, created_ts
        FROM quotes WHERE fleet_id=? ORDER BY id`,
     [fleet_id]
   );
@@ -19,7 +19,7 @@ export async function getQuotesByFleet(fleet_id) {
 
 export async function getQuotesByCustomer(customer_id) {
   const [rows] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, customer_reference, po_number, total_amount, status, terms, created_ts
        FROM quotes WHERE customer_id=? ORDER BY id`,
     [customer_id]
   );
@@ -28,34 +28,67 @@ export async function getQuotesByCustomer(customer_id) {
 
 export async function getQuoteById(id) {
   const [[row]] = await pool.query(
-    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms, created_ts
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, customer_reference, po_number, total_amount, status, terms, created_ts
        FROM quotes WHERE id=?`,
     [id]
   );
   return row || null;
 }
 
-export async function createQuote({ customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms }) {
+export async function createQuote({
+  customer_id,
+  fleet_id,
+  job_id,
+  vehicle_id,
+  customer_reference,
+  po_number,
+  total_amount,
+  status,
+  terms,
+}) {
   const [{ insertId }] = await pool.query(
     `INSERT INTO quotes
-      (customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms)
-     VALUES (?,?,?,?,?,?,?)`,
+      (customer_id, fleet_id, job_id, vehicle_id, customer_reference, po_number, total_amount, status, terms)
+     VALUES (?,?,?,?,?,?,?,?,?)`,
     [
       customer_id || null,
       fleet_id || null,
       job_id || null,
       vehicle_id || null,
+      customer_reference || null,
+      po_number || null,
       total_amount || null,
       status || null,
       terms || null,
     ]
   );
-  return { id: insertId, customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms };
+  return {
+    id: insertId,
+    customer_id,
+    fleet_id,
+    job_id,
+    vehicle_id,
+    customer_reference,
+    po_number,
+    total_amount,
+    status,
+    terms,
+  };
 }
 
 export async function updateQuote(
   id,
-  { customer_id, fleet_id, job_id, vehicle_id, total_amount, status, terms }
+  {
+    customer_id,
+    fleet_id,
+    job_id,
+    vehicle_id,
+    customer_reference,
+    po_number,
+    total_amount,
+    status,
+    terms,
+  }
 ) {
   await pool.query(
     `UPDATE quotes SET
@@ -63,6 +96,8 @@ export async function updateQuote(
        fleet_id=?,
        job_id=?,
        vehicle_id=?,
+       customer_reference=?,
+       po_number=?,
        total_amount=?,
        status=?,
        terms=?
@@ -72,6 +107,8 @@ export async function updateQuote(
       fleet_id || null,
       job_id || null,
       vehicle_id || null,
+      customer_reference || null,
+      po_number || null,
       total_amount || null,
       status || null,
       terms || null,


### PR DESCRIPTION
## Summary
- add migration for new quote fields
- include `customer_reference` and `po_number` in quote service
- allow quote creation and update with new fields via API
- update tests for new fields

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686980a693a8833393416b1b9dbfee20