### PR TITLE
Add default job status

### DIFF
--- a/migrations/20251224_insert_unassigned_job_status.sql
+++ b/migrations/20251224_insert_unassigned_job_status.sql
@@ -1,0 +1,5 @@
+INSERT INTO job_statuses (name)
+SELECT 'unassigned'
+WHERE NOT EXISTS (
+  SELECT 1 FROM job_statuses WHERE name='unassigned'
+);

--- a/pages/office/company-settings.js
+++ b/pages/office/company-settings.js
@@ -174,12 +174,14 @@ export default function CompanySettingsPage() {
                 className="flex justify-between bg-gray-100 px-2 py-1 rounded text-black"
               >
                 <span>{s.name}</span>
-                <button
-                  onClick={() => removeStatus(s.id)}
-                  className="text-red-600 hover:underline"
-                >
-                  Delete
-                </button>
+                {s.name !== 'unassigned' && (
+                  <button
+                    onClick={() => removeStatus(s.id)}
+                    className="text-red-600 hover:underline"
+                  >
+                    Delete
+                  </button>
+                )}
               </li>
             ))}
           </ul>

--- a/pages/office/quotations/index.js
+++ b/pages/office/quotations/index.js
@@ -34,7 +34,7 @@ const QuotationsPage = () => {
     const res = await fetch('/api/jobs', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ customer_id: quote.customer_id, vehicle_id: null, status: 'new' }),
+      body: JSON.stringify({ customer_id: quote.customer_id, vehicle_id: null }),
     });
     const job = res.ok ? await res.json() : null;
     await updateQuote(quote.id, { status: 'approved', job_id: job?.id });

--- a/services/jobStatusesService.js
+++ b/services/jobStatusesService.js
@@ -16,6 +16,13 @@ export async function createJobStatus({ name }) {
 }
 
 export async function deleteJobStatus(id) {
+  const [[row]] = await pool.query(
+    'SELECT name FROM job_statuses WHERE id=?',
+    [id]
+  );
+  if (row && row.name === 'unassigned') {
+    throw new Error('Cannot delete default status');
+  }
   await pool.query('DELETE FROM job_statuses WHERE id=?', [id]);
   return { ok: true };
 }

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -41,15 +41,16 @@ export async function getJobById(id) {
 }
 
 export async function createJob({ customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay }) {
-  if (status && !(await jobStatusExists(status))) {
+  const finalStatus = status || 'unassigned';
+  if (!(await jobStatusExists(finalStatus))) {
     throw new Error('Invalid job status');
   }
   const [{ insertId }] = await pool.query(
     `INSERT INTO jobs (customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay)
      VALUES (?,?,?,?,?,?)`,
-    [customer_id || null, vehicle_id || null, scheduled_start || null, scheduled_end || null, status || null, bay || null]
+    [customer_id || null, vehicle_id || null, scheduled_start || null, scheduled_end || null, finalStatus, bay || null]
   );
-  return { id: insertId, customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay };
+  return { id: insertId, customer_id, vehicle_id, scheduled_start, scheduled_end, status: finalStatus, bay };
 }
 
 export async function updateJob(id, { customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay }) {


### PR DESCRIPTION
## Summary
- create migration inserting default `unassigned` job status
- prevent deleting the default status
- default new jobs to use the `unassigned` status
- create jobs from quotations without setting a status explicitly
- hide the delete button for `unassigned` job status

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686981c211788333a106d6bb3240271b