### PR TITLE
Add vehicle detail pages for fleet and local users

### DIFF
--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -13,6 +13,7 @@ export function PortalDashboard({
   setQuotes,
   invoices = [],
   vehicleFilter = () => true,
+  vehicleLinkBase = '/vehicles',
 }) {
   const [query, setQuery] = useState('');
   const [brand, setBrand] = useState('All');
@@ -93,7 +94,7 @@ export function PortalDashboard({
             <div className="p-4">
               <h2 className="text-xl font-medium">{v.licence_plate}</h2>
               <p className="text-sm text-black">{v.make} {v.model}</p>
-              <Link href={`/vehicles/${v.id}`} className="button-secondary mt-3 inline-block text-center">View Details</Link>
+              <Link href={`${vehicleLinkBase}/${v.id}`} className="button-secondary mt-3 inline-block text-center">View Details</Link>
             </div>
           </Card>
         ))}

--- a/pages/fleet/index.js
+++ b/pages/fleet/index.js
@@ -61,6 +61,7 @@ export default function FleetDashboard() {
         quotes={quotes}
         setQuotes={setQuotes}
         invoices={invoices}
+        vehicleLinkBase="/fleet/vehicles"
       />
     </>
   );

--- a/pages/fleet/vehicles/[id].js
+++ b/pages/fleet/vehicles/[id].js
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import logout from '../../../lib/logout.js';
+import { fetchJobs } from '../../../lib/jobs.js';
+import { updateQuote } from '../../../lib/quotes.js';
+
+export default function FleetVehicleDetails() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [fleet, setFleet] = useState(null);
+  const [vehicle, setVehicle] = useState(null);
+  const [quotes, setQuotes] = useState([]);
+  const [jobs, setJobs] = useState([]);
+  const [invoices, setInvoices] = useState([]);
+
+  useEffect(() => {
+    if (!id) return;
+    (async () => {
+      const res = await fetch('/api/portal/fleet/me');
+      if (!res.ok) return router.replace('/fleet/login');
+      const f = await res.json();
+      setFleet(f);
+      const [v, qAll, jAll, iAll] = await Promise.all([
+        fetch(`/api/vehicles/${id}`).then(r => r.json()),
+        fetch(`/api/quotes?fleet_id=${f.id}`).then(r => r.json()),
+        fetchJobs({ fleet_id: f.id }),
+        fetch(`/api/invoices?fleet_id=${f.id}`).then(r => r.json()),
+      ]);
+      setVehicle(v);
+      setQuotes(qAll.filter(q => q.vehicle_id == id));
+      setJobs(jAll.filter(j => j.vehicle_id == id));
+      setInvoices(iAll.filter(inv => inv.vehicle_id == id));
+    })();
+  }, [id, router]);
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } finally {
+      router.push('/fleet/login');
+    }
+  }
+
+  async function acceptQuote(qid) {
+    await updateQuote(qid, { status: 'accepted' });
+    setQuotes(quotes.map(q => (q.id === qid ? { ...q, status: 'accepted' } : q)));
+  }
+
+  async function rejectQuote(qid) {
+    await updateQuote(qid, { status: 'rejected' });
+    setQuotes(quotes.map(q => (q.id === qid ? { ...q, status: 'rejected' } : q)));
+  }
+
+  if (!fleet || !vehicle) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="min-h-screen p-8 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Vehicle Details</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      <Link href="/fleet/vehicles" className="button inline-block mb-4">
+        Back to Vehicles
+      </Link>
+      <div className="mb-6 space-y-1">
+        <p><strong>Plate:</strong> {vehicle.licence_plate}</p>
+        <p><strong>Make:</strong> {vehicle.make}</p>
+        <p><strong>Model:</strong> {vehicle.model}</p>
+        <p><strong>Color:</strong> {vehicle.color}</p>
+      </div>
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Quotes</h2>
+        <ul className="list-disc ml-6 space-y-1">
+          {quotes.map(q => (
+            <li key={q.id}>
+              Quote #{q.id} - {q.status}
+              {q.status !== 'accepted' && (
+                <button onClick={() => acceptQuote(q.id)} className="ml-2 underline">Accept</button>
+              )}
+              {q.status !== 'rejected' && (
+                <button onClick={() => rejectQuote(q.id)} className="ml-2 underline">Reject</button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Jobs</h2>
+        <ul className="list-disc ml-6 space-y-1">
+          {jobs.map(j => (
+            <li key={j.id}>Job #{j.id} - {j.status}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Invoices</h2>
+        <ul className="list-disc ml-6 space-y-1">
+          {invoices.map(inv => (
+            <li key={inv.id}>Invoice #{inv.id} - {inv.status}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/pages/fleet/vehicles/index.js
+++ b/pages/fleet/vehicles/index.js
@@ -43,6 +43,7 @@ export default function FleetVehicles() {
         {vehicles.map(v => (
           <li key={v.id}>
             {v.licence_plate} - {v.make} {v.model}
+            <Link href={`/fleet/vehicles/${v.id}`} className="underline ml-2">View Details</Link>
           </li>
         ))}
       </ul>

--- a/pages/local/index.js
+++ b/pages/local/index.js
@@ -56,6 +56,7 @@ export default function LocalDashboard() {
         quotes={quotes}
         setQuotes={setQuotes}
         invoices={invoices}
+        vehicleLinkBase="/local/vehicles"
       />
     </>
   );

--- a/pages/local/vehicles/[id].js
+++ b/pages/local/vehicles/[id].js
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import logout from '../../../lib/logout.js';
+import { fetchJobs } from '../../../lib/jobs.js';
+import { updateQuote } from '../../../lib/quotes.js';
+
+export default function LocalVehicleDetails() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [client, setClient] = useState(null);
+  const [vehicle, setVehicle] = useState(null);
+  const [quotes, setQuotes] = useState([]);
+  const [jobs, setJobs] = useState([]);
+  const [invoices, setInvoices] = useState([]);
+
+  useEffect(() => {
+    if (!id) return;
+    (async () => {
+      const res = await fetch('/api/portal/local/me');
+      if (!res.ok) return router.replace('/local/login');
+      const c = await res.json();
+      setClient(c);
+      const [v, qAll, jAll, iAll] = await Promise.all([
+        fetch(`/api/vehicles/${id}`).then(r => r.json()),
+        fetch(`/api/quotes?customer_id=${c.id}`).then(r => r.json()),
+        fetchJobs({ customer_id: c.id }),
+        fetch(`/api/invoices?customer_id=${c.id}`).then(r => r.json()),
+      ]);
+      setVehicle(v);
+      setQuotes(qAll.filter(q => q.vehicle_id == id));
+      setJobs(jAll.filter(j => j.vehicle_id == id));
+      setInvoices(iAll.filter(inv => inv.vehicle_id == id));
+    })();
+  }, [id, router]);
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } finally {
+      router.push('/local/login');
+    }
+  }
+
+  async function acceptQuote(qid) {
+    await updateQuote(qid, { status: 'accepted' });
+    setQuotes(quotes.map(q => (q.id === qid ? { ...q, status: 'accepted' } : q)));
+  }
+
+  async function rejectQuote(qid) {
+    await updateQuote(qid, { status: 'rejected' });
+    setQuotes(quotes.map(q => (q.id === qid ? { ...q, status: 'rejected' } : q)));
+  }
+
+  if (!client || !vehicle) return <p className="p-8">Loading…</p>;
+
+  return (
+    <div className="min-h-screen p-8 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">Vehicle Details</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      <Link href="/local" className="button inline-block mb-4">
+        Back to Dashboard
+      </Link>
+      <div className="mb-6 space-y-1">
+        <p><strong>Plate:</strong> {vehicle.licence_plate}</p>
+        <p><strong>Make:</strong> {vehicle.make}</p>
+        <p><strong>Model:</strong> {vehicle.model}</p>
+        <p><strong>Color:</strong> {vehicle.color}</p>
+      </div>
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Quotes</h2>
+        <ul className="list-disc ml-6 space-y-1">
+          {quotes.map(q => (
+            <li key={q.id}>
+              Quote #{q.id} - {q.status}
+              {q.status !== 'accepted' && (
+                <button onClick={() => acceptQuote(q.id)} className="ml-2 underline">Accept</button>
+              )}
+              {q.status !== 'rejected' && (
+                <button onClick={() => rejectQuote(q.id)} className="ml-2 underline">Reject</button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Jobs</h2>
+        <ul className="list-disc ml-6 space-y-1">
+          {jobs.map(j => (
+            <li key={j.id}>Job #{j.id} - {j.status}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Invoices</h2>
+        <ul className="list-disc ml-6 space-y-1">
+          {invoices.map(inv => (
+            <li key={inv.id}>Invoice #{inv.id} - {inv.status}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/pages/office/fleets/view/[id].js
+++ b/pages/office/fleets/view/[id].js
@@ -76,6 +76,7 @@ export default function FleetViewPage() {
         quotes={quotes}
         setQuotes={setQuotes}
         invoices={invoices}
+        vehicleLinkBase="/office/vehicles/view"
       />
     </OfficeLayout>
   );


### PR DESCRIPTION
## Summary
- create vehicle detail pages for fleet and local portals
- list related quotes, jobs and invoices
- allow accepting or rejecting quotes from the detail page
- link vehicles to detail pages in dashboards and fleet vehicle list
- add option to configure detail link base in `PortalDashboard`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6869870907608333b2a950984645622a