### PR TITLE
Handle quotation query params

### DIFF
--- a/__tests__/quote-new-page.test.js
+++ b/__tests__/quote-new-page.test.js
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('client and vehicle query params populate new quote form', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { client_id: '1', vehicle_id: '2' }, push: jest.fn(), isReady: true }),
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }) // fleets
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1, first_name: 'A', last_name: 'B' }) }) // client
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 2, licence_plate: 'XYZ', customer_id: 1 }) }) // vehicle
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1, first_name: 'A', last_name: 'B' }) }) // client again
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, licence_plate: 'XYZ' }] }); // vehicles
+
+  const { default: NewPage } = await import('../pages/office/quotations/new.js');
+  render(<NewPage />);
+
+  await screen.findByDisplayValue('A B');
+  expect(screen.getByDisplayValue('A B')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('XYZ')).toBeInTheDocument();
+});

--- a/lib/clients.js
+++ b/lib/clients.js
@@ -3,3 +3,9 @@ export async function fetchClients() {
   if (!res.ok) throw new Error('Failed to fetch clients');
   return res.json();
 }
+
+export async function fetchClient(id) {
+  const res = await fetch(`/api/clients/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch client');
+  return res.json();
+}

--- a/lib/vehicles.js
+++ b/lib/vehicles.js
@@ -9,3 +9,9 @@ export async function fetchVehicles(customer_id, fleet_id) {
   if (!res.ok) throw new Error('Failed to fetch vehicles');
   return res.json();
 }
+
+export async function fetchVehicle(id) {
+  const res = await fetch(`/api/vehicles/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch vehicle');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- populate new quote page using client_id and vehicle_id query params
- support fetching a single client/vehicle
- catch vehicle loading errors
- test new query param functionality

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68699356f06083338ee4d8e93445f75c