### PR TITLE
Fix part supplier display and add vehicle creation link

### DIFF
--- a/pages/fleet/vehicles/index.js
+++ b/pages/fleet/vehicles/index.js
@@ -36,6 +36,9 @@ export default function FleetVehicles() {
         <h1 className="text-2xl font-bold">Vehicles</h1>
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
       </div>
+      <Link href="/fleet/vehicles/new" className="button inline-block mb-4 mr-2">
+        Add Vehicle
+      </Link>
       <Link href="/fleet/home" className="button inline-block mb-4">
         Return to Home
       </Link>

--- a/services/partsService.js
+++ b/services/partsService.js
@@ -4,7 +4,7 @@ export async function searchParts(query) {
   const q = `%${query}%`;
   const [rows] = query
     ? await pool.query(
-        `SELECT id, part_number, description, unit_cost
+        `SELECT id, part_number, description, unit_cost, supplier_id
            FROM parts
           WHERE part_number LIKE ? OR description LIKE ?
           ORDER BY part_number
@@ -12,7 +12,7 @@ export async function searchParts(query) {
         [q, q]
       )
     : await pool.query(
-        `SELECT id, part_number, description, unit_cost
+        `SELECT id, part_number, description, unit_cost, supplier_id
            FROM parts
           ORDER BY part_number
           LIMIT 20`


### PR DESCRIPTION
## Summary
- expose `supplier_id` when fetching parts so the supplier is shown in the UI
- add a link to create a vehicle on the fleet vehicles page

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6869954c78dc8333a7b99ae2f2c026c9