### PR TITLE
Fix client selection resetting customer_id

### DIFF
--- a/__tests__/client-autocomplete.test.js
+++ b/__tests__/client-autocomplete.test.js
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('selecting a client keeps vehicles loaded', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: {}, push: jest.fn(), isReady: true }),
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }) // fleets
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 1, first_name: 'A', last_name: 'B' }] }) // client search
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, licence_plate: 'XYZ' }] }); // vehicles
+
+  const { default: NewPage } = await import('../pages/office/quotations/new.js');
+  render(<NewPage />);
+
+  fireEvent.change(screen.getByPlaceholderText('Client name or email'), { target: { value: 'A' } });
+  await screen.findByText('A B');
+  fireEvent.click(screen.getByText('A B'));
+
+  await screen.findByText('XYZ');
+  expect(screen.getByText('XYZ')).toBeInTheDocument();
+});

--- a/components/ClientAutocomplete.js
+++ b/components/ClientAutocomplete.js
@@ -50,7 +50,6 @@ export default function ClientAutocomplete({ value, onChange, onSelect }) {
                   setTerm('');
                 } else {
                   setTerm(name);
-                  onChange && onChange(name);
                 }
                 setResults([]);
               }}


### PR DESCRIPTION
## Summary
- avoid firing `onChange` when selecting from client autocomplete results
- add regression test covering vehicle list

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_686997adbfb0833382d3d15dbd42f2f3