### PR TITLE
Update email pdf generation

### DIFF
--- a/__tests__/email-service.test.js
+++ b/__tests__/email-service.test.js
@@ -30,8 +30,14 @@ test('sendQuoteEmail sends mail', async () => {
   jest.unstable_mockModule('../services/quoteItemsService.js', () => ({
     getQuoteItems: () => []
   }));
+  const buildMock = jest.fn().mockResolvedValue(Buffer.from('PDF'));
+  jest.unstable_mockModule('../lib/pdf.js', () => ({
+    buildQuotePdf: buildMock,
+    buildInvoicePdf: jest.fn()
+  }));
   const { sendQuoteEmail } = await import('../services/emailService.js');
   await sendQuoteEmail(1);
   expect(sendMock).toHaveBeenCalled();
+  expect(buildMock).toHaveBeenCalled();
 });
 

--- a/services/emailService.js
+++ b/services/emailService.js
@@ -23,10 +23,18 @@ export async function sendQuoteEmail(quoteId, to) {
   const transporter = createTransport(settings);
   const quote = await getQuoteById(quoteId);
   const company = await getSettings();
-  const client = quote.customer_id ? await getClientById(quote.customer_id) : {};
-  const items = await getQuoteItems(quoteId);
-  const pdf = await buildQuotePdf({ company, quote, client, items });
-  const recipient = to || client.email || client.email_1 || client.email_2;
+  const garage = company;
+  const clientInfo = quote.customer_id ? await getClientById(quote.customer_id) : {};
+  const itemList = await getQuoteItems(quoteId);
+  const pdf = await buildQuotePdf({
+    quoteNumber: quote.id,
+    garage,
+    client: clientInfo,
+    vehicle: {},
+    items: itemList,
+    terms: quote.terms || company.terms || ''
+  });
+  const recipient = to || clientInfo.email || clientInfo.email_1 || clientInfo.email_2;
   await transporter.sendMail({
     from: settings.from_email,
     to: recipient,


### PR DESCRIPTION
## Summary
- restructure `sendQuoteEmail` to build data for the PDF generator
- mock `buildQuotePdf` in email-service tests

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6869a39911108333931905e72dd9d62b