### PR TITLE
Fix PDF logo path

### DIFF
--- a/lib/pdf/header.js
+++ b/lib/pdf/header.js
@@ -1,7 +1,7 @@
 import path from 'path';
 export function addHeader(doc, { quoteNumber }) {
   // Logo
-  doc.image(path.join(process.cwd(), '/public/assets/logo.png'), 40, 30, { width: 80 });
+  doc.image(path.join(process.cwd(), 'public', 'logo.png'), 40, 30, { width: 80 });
   // Title + number
   doc
     .font('Brand')


### PR DESCRIPTION
## Summary
- fix header logo path to use `public/logo.png`

## Testing
- `node -e "const path=require('path');console.log(path.join(process.cwd(),'public','logo.png'))"`
- `NODE_ENV=production node -e "const path=require('path');console.log(path.join(process.cwd(),'public','logo.png'))"`
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686ae1e993f483338209b616bec8e4dd