### PR TITLE
Update quote PDF endpoint

### DIFF
--- a/__tests__/quotePdfApi.test.js
+++ b/__tests__/quotePdfApi.test.js
@@ -23,7 +23,7 @@ test('quote pdf endpoint returns PDF', async () => {
   jest.unstable_mockModule('../services/quoteItemsService.js', () => ({
     getQuoteItems: jest.fn().mockResolvedValue([])
   }));
-  jest.unstable_mockModule('../lib/pdf.js', () => ({
+  jest.unstable_mockModule('../lib/pdf/buildQuotePdf.js', () => ({
     buildQuotePdf: buildMock
   }));
   jest.unstable_mockModule('../lib/db.js', () => ({

--- a/pages/api/quotes/[id]/pdf.js
+++ b/pages/api/quotes/[id]/pdf.js
@@ -23,16 +23,27 @@ async function handler(req, res) {
     const company = await getSettings();
     const client = quote.customer_id ? await getClientById(quote.customer_id) : null;
     const items = await getQuoteItems(id);
-    const pdf = await buildQuotePdf({
-      company,
-      quote,
-      client,
-      vehicle: vehicle || {},
-      items
-    });
-    res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader('Content-Disposition', `attachment; filename=quote-${id}.pdf`);
-    res.send(pdf);
+
+    const quoteNumber = quote.id;
+    const garage = company;
+    const terms = quote.terms || company.terms || '';
+
+    try {
+      const pdf = await buildQuotePdf({
+        quoteNumber,
+        garage,
+        client,
+        vehicle: vehicle || {},
+        items,
+        terms,
+      });
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename=quote-${id}.pdf`);
+      res.send(pdf);
+    } catch (err) {
+      console.error('QUOTE_PDF_ERROR:', err);
+      return res.status(500).json({ error: 'Failed to generate PDF' });
+    }
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Internal Server Error' });


### PR DESCRIPTION
## Summary
- include quote number, garage, and terms when generating PDFs
- adjust API to handle PDF generation errors
- update tests for new module path

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686ae3f9f7748333afee63eff646f7c6