### PR TITLE
Change quote pdf header text

### DIFF
--- a/lib/pdf/header.js
+++ b/lib/pdf/header.js
@@ -1,5 +1,5 @@
 import path from 'path';
-export function addHeader(doc, { quoteNumber }) {
+export function addHeader(doc, { quoteNumber, title = 'QUOTE' }) {
   // Logo
   doc.image(path.join(process.cwd(), 'public', 'logo.png'), 40, 30, { width: 80 });
   // Title + number
@@ -7,8 +7,8 @@ export function addHeader(doc, { quoteNumber }) {
     // Helvetica is a built-in font provided by PDFKit
     .font('Helvetica')
     .fontSize(20)
-    .text('INVOICE', 0, 40, { align: 'right' })
+    .text(title, 0, 40, { align: 'right' })
     .fontSize(12)
-    .text(`Invoice # ${quoteNumber}`, { align: 'right' })
+    .text(`Quote #${quoteNumber}`, { align: 'right' })
     .moveDown(2);
 }


### PR DESCRIPTION
## Summary
- make the PDF header configurable and default to `QUOTE`
- show `Quote #<number>` in the generated PDF

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae5a703b083339766001c0d387675