### PR TITLE
Add links to quote entries

### DIFF
--- a/__tests__/client-vehicle-view-pages.test.js
+++ b/__tests__/client-vehicle-view-pages.test.js
@@ -25,7 +25,8 @@ test('client view page lists quotes', async () => {
   const { default: Page } = await import('../pages/office/clients/view/[id].js');
   render(<Page />);
 
-  await screen.findByText('Quote #2 - new');
+  const quoteLink = await screen.findByRole('link', { name: 'Quote #2 - new' });
+  expect(quoteLink).toHaveAttribute('href', '/office/quotations/2');
 });
 
 
@@ -44,5 +45,6 @@ test('vehicle view page lists quotes', async () => {
   const { default: Page } = await import('../pages/office/vehicles/view/[id].js');
   render(<Page />);
 
-  await screen.findByText('Quote #3 - sent');
+  const vehicleQuoteLink = await screen.findByRole('link', { name: 'Quote #3 - sent' });
+  expect(vehicleQuoteLink).toHaveAttribute('href', '/office/quotations/3');
 });

--- a/pages/office/clients/view/[id].js
+++ b/pages/office/clients/view/[id].js
@@ -120,7 +120,11 @@ export default function ClientViewPage() {
           ) : (
             <ul className="list-disc pl-5 space-y-1">
               {quotes.map(q => (
-                <li key={q.id}>Quote #{q.id} - {q.status}</li>
+                <li key={q.id}>
+                  <Link href={`/office/quotations/${q.id}`}>
+                    <a className="underline">Quote #{q.id} - {q.status}</a>
+                  </Link>
+                </li>
               ))}
             </ul>
           )}

--- a/pages/office/vehicles/view/[id].js
+++ b/pages/office/vehicles/view/[id].js
@@ -115,7 +115,11 @@ export default function VehicleViewPage() {
           ) : (
             <ul className="list-disc pl-5 space-y-1">
               {quotes.map(q => (
-                <li key={q.id}>Quote #{q.id} - {q.status}</li>
+                <li key={q.id}>
+                  <Link href={`/office/quotations/${q.id}`}>
+                    <a className="underline">Quote #{q.id} - {q.status}</a>
+                  </Link>
+                </li>
               ))}
             </ul>
           )}


### PR DESCRIPTION
## Summary
- wrap quote entries in client and vehicle view pages with links
- update tests to check for anchor elements

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686aeb2db3fc83338eaf3f2d059f9319