### PR TITLE
Fix quote PDF service to provide item cost fields

### DIFF
--- a/services/quoteItemsService.js
+++ b/services/quoteItemsService.js
@@ -3,7 +3,8 @@ import pool from '../lib/db.js';
 export async function getQuoteItems(quote_id) {
   const [rows] = await pool.query(
     `SELECT qi.id, qi.quote_id, qi.part_id, qi.description, qi.qty, qi.unit_price,
-            p.supplier_id
+            p.supplier_id, p.part_number AS partNumber,
+            COALESCE(qi.unit_price, p.unit_cost) AS unitCost
        FROM quote_items qi
   LEFT JOIN parts p ON qi.part_id=p.id
       WHERE qi.quote_id=?


### PR DESCRIPTION
## Summary
- include part number and unit cost when fetching quote items

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae8b2c310833384fafd0ac7451fe2