### PR TITLE
Add cancel buttons for office forms

### DIFF
--- a/pages/office/clients/[id].js
+++ b/pages/office/clients/[id].js
@@ -99,7 +99,16 @@ const EditClientPage = () => {
             />
           </div>
         ))}
+        <div className="flex gap-2">
           <button type="submit" className="button">Update</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
       <div className="mt-8">
         <div className="flex justify-between items-center mb-2">

--- a/pages/office/clients/new.js
+++ b/pages/office/clients/new.js
@@ -92,7 +92,16 @@ const NewClientPage = () => {
             />
           </div>
         ))}
+        <div className="flex gap-2">
           <button type="submit" className="button">Save</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/engineers/[id].js
+++ b/pages/office/engineers/[id].js
@@ -65,7 +65,16 @@ const EditEngineerPage = () => {
             className="w-full border px-3 py-2 rounded text-black"
           />
         </div>
-        <button type="submit" className="button">Update</button>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Update</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/engineers/new.js
+++ b/pages/office/engineers/new.js
@@ -44,7 +44,16 @@ const NewEngineerPage = () => {
             />
           </div>
         ))}
-        <button type="submit" className="button">Save</button>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Save</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/fleets/[id].js
+++ b/pages/office/fleets/[id].js
@@ -112,7 +112,16 @@ const EditFleetPage = () => {
             />
           </div>
         ))}
-        <button type="submit" className="button">Update</button>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Update</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
       <div className="mt-8">
         <div className="flex justify-between items-center mb-2">

--- a/pages/office/fleets/new.js
+++ b/pages/office/fleets/new.js
@@ -69,7 +69,16 @@ const NewFleetPage = () => {
             />
           </div>
         ))}
-        <button type="submit" className="button">Save</button>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Save</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/parts/[id].js
+++ b/pages/office/parts/[id].js
@@ -86,7 +86,16 @@ export default function EditPartPage() {
             ))}
           </select>
         </div>
-        <button type="submit" className="button">Save</button>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Save</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/parts/new.js
+++ b/pages/office/parts/new.js
@@ -68,7 +68,16 @@ export default function NewPartPage() {
             ))}
           </select>
         </div>
-        <button type="submit" className="button">Save</button>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Save</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -318,9 +318,16 @@ export default function NewQuotationPage() {
           <h2 className="font-semibold mb-2">Summary</h2>
           <p className="font-semibold">Total: {formatEuro(total)}</p>
         </div>
-        <button type="submit" className="button">
-          Create Quote
-        </button>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Create Quote</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/suppliers/[id].js
+++ b/pages/office/suppliers/[id].js
@@ -55,7 +55,16 @@ export default function EditSupplierPage() {
             />
           </div>
         ))}
-        <button type="submit" className="button">Save</button>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Save</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/suppliers/new.js
+++ b/pages/office/suppliers/new.js
@@ -48,7 +48,16 @@ export default function NewSupplierPage() {
             />
           </div>
         ))}
-        <button type="submit" className="button">Save</button>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Save</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/vehicles/[id].js
+++ b/pages/office/vehicles/[id].js
@@ -62,7 +62,16 @@ const EditVehiclePage = () => {
             />
           </div>
         ))}
+        <div className="flex gap-2">
           <button type="submit" className="button">Update</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );

--- a/pages/office/vehicles/new.js
+++ b/pages/office/vehicles/new.js
@@ -49,7 +49,16 @@ const NewVehiclePage = () => {
             />
           </div>
         ))}
+        <div className="flex gap-2">
           <button type="submit" className="button">Save</button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="button-secondary"
+          >
+            Cancel
+          </button>
+        </div>
       </form>
     </OfficeLayout>
   );


### PR DESCRIPTION
## Summary
- add a cancel button to each `new.js` and `[id].js` form under `/pages/office`
- use `router.back()` to return to the previous page
- apply `button-secondary` styling so it matches other buttons

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686aeefbb234833386cc9044c42d39d3