### PR TITLE
Add cost & markup to quote items

### DIFF
--- a/__tests__/quoteItemsService.test.js
+++ b/__tests__/quoteItemsService.test.js
@@ -21,10 +21,16 @@ test('updateQuoteItem updates row', async () => {
   const queryMock = jest.fn().mockResolvedValue([]);
   jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
   const { updateQuoteItem } = await import('../services/quoteItemsService.js');
-  const result = await updateQuoteItem(5, { description: 'x', qty: 2, unit_price: 3 });
+  const result = await updateQuoteItem(5, {
+    description: 'x',
+    qty: 2,
+    unit_cost: 1,
+    markup_percent: 20,
+    unit_price: 3,
+  });
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/UPDATE quote_items/),
-    ['x', 2, 3, 5]
+    ['x', 2, 1, 20, 3, 5]
   );
   expect(result).toEqual({ ok: true });
 });

--- a/generate_quote.py
+++ b/generate_quote.py
@@ -33,6 +33,18 @@ def validate_data(data: dict) -> None:
             raise KeyError(f"Missing top-level key: {key}")
 
 
+def calculate_totals(data: dict) -> None:
+    items = data.get("items", [])
+    total_cost = sum(it.get("qty", 0) * it.get("unit_cost", 0) for it in items)
+    total_price = sum(it.get("qty", 0) * it.get("unit_price", 0) for it in items)
+    profit = total_price - total_cost
+    markup = (profit / total_cost * 100) if total_cost else 0
+    totals = data.setdefault("totals", {})
+    totals["total_cost"] = round(total_cost, 2)
+    totals["markup_percent"] = round(markup, 2)
+    totals["profit"] = round(profit, 2)
+
+
 def render_docx(data: dict) -> str:
     template_path = os.path.join('templates', 'quotation_template_final.docx')
     if not os.path.exists(template_path):
@@ -71,6 +83,7 @@ def main() -> int:
     try:
         data = load_data(data_path)
         validate_data(data)
+        calculate_totals(data)
         docx_path = render_docx(data)
         pdf_path = convert_to_pdf(docx_path)
         print(f"Generated: {pdf_path}")

--- a/lib/pdf/itemsTable.js
+++ b/lib/pdf/itemsTable.js
@@ -1,4 +1,4 @@
-const cols = ['Part Number','Description','Qty','Unit Cost','Line Total'];
+const cols = ['Part Number','Description','Qty','Unit Cost','Markup %','Unit Price','Line Total'];
 export function addItemsTable(doc, { items }) {
   let y = doc.y;
   // Header
@@ -8,7 +8,7 @@ export function addItemsTable(doc, { items }) {
     .fillColor('#fff')
     .fontSize(10);
   cols.forEach((h, i) => {
-    const x = 40 + (i * 100);
+    const x = 40 + i * 70;
     doc.text(h, x + 5, y + 5);
   });
 
@@ -19,21 +19,34 @@ export function addItemsTable(doc, { items }) {
     doc
       .rect(40, rowY, 515, 20)
       .stroke('#ddd');
-    const vals = [it.partNumber, it.description, it.qty, it.unitCost.toFixed(2), (it.qty * it.unitCost).toFixed(2)];
+    const vals = [
+      it.partNumber,
+      it.description,
+      it.qty,
+      it.unit_cost.toFixed(2),
+      (it.markup_percent ?? 0).toFixed(2),
+      it.unit_price.toFixed(2),
+      (it.qty * it.unit_price).toFixed(2),
+    ];
     vals.forEach((v, i) => {
-      const x = 40 + (i * 100);
+      const x = 40 + i * 70;
       doc.text(v, x + 5, rowY + 5);
     });
   });
 
-  // Totals line
   const totalY = y + 20 + items.length * 20 + 10;
-  const total = items.reduce((sum, it) => sum + it.qty * it.unitCost, 0).toFixed(2);
+  const totalPrice = items.reduce((s, it) => s + it.qty * it.unit_price, 0).toFixed(2);
+  const totalCost = items.reduce((s, it) => s + it.qty * it.unit_cost, 0).toFixed(2);
+  const profit = (totalPrice - totalCost).toFixed(2);
+  const markup = totalCost != 0 ? (((totalPrice - totalCost) / totalCost) * 100).toFixed(2) : '0.00';
   doc
-    // Helvetica is a safe built-in font
     .font('Helvetica')
     .fontSize(12)
-    .text('Total', 440, totalY, { width: 100, align: 'right' })
-    .text(`$${total}`, 540, totalY, { align: 'right' })
-    .moveDown(2);
+    .text('Total Price', 40, totalY)
+    .text(`$${totalPrice}`, 485, totalY, { align: 'right' })
+    .text('Total Cost', 40, totalY + 15)
+    .text(`$${totalCost}`, 485, totalY + 15, { align: 'right' })
+    .text(`Markup ${markup}%`, 40, totalY + 30)
+    .text(`Profit $${profit}`, 40, totalY + 45)
+    .moveDown(4);
 }

--- a/migrations/20251227_add_unit_cost_markup_to_quote_items.sql
+++ b/migrations/20251227_add_unit_cost_markup_to_quote_items.sql
@@ -1,0 +1,3 @@
+ALTER TABLE quote_items
+  ADD COLUMN unit_cost DECIMAL(10,2) DEFAULT NULL,
+  ADD COLUMN markup_percent DECIMAL(5,2) DEFAULT NULL;

--- a/pages/office/quotations/[id]/edit.js
+++ b/pages/office/quotations/[id]/edit.js
@@ -5,7 +5,16 @@ import { fetchFleets } from '../../../../lib/fleets';
 import { fetchVehicles } from '../../../../lib/vehicles';
 import { updateQuote } from '../../../../lib/quotes';
 
-const emptyItem = { id: null, part_number: '', part_id: '', description: '', qty: 1, price: 0 };
+const emptyItem = {
+  id: null,
+  part_number: '',
+  part_id: '',
+  description: '',
+  qty: 1,
+  unit_cost: 0,
+  markup: 0,
+  price: 0,
+};
 import PartAutocomplete from '../../../../components/PartAutocomplete';
 import ClientAutocomplete from '../../../../components/ClientAutocomplete';
 
@@ -128,6 +137,8 @@ export default function EditQuotationPage() {
             part_number,
             description: it.description || '',
             qty: it.qty || 1,
+            unit_cost: it.unit_cost || 0,
+            markup: it.markup_percent || 0,
             price: it.unit_price || 0,
           };
         })
@@ -144,15 +155,27 @@ export default function EditQuotationPage() {
   const changeItem = (i, field, value) => {
     setItems(itms => {
       const copy = [...itms];
-      copy[i] = { ...copy[i], [field]: value };
+      const it = { ...copy[i], [field]: value };
+      if (field === 'unit_cost' || field === 'markup') {
+        const cost = Number(field === 'unit_cost' ? value : it.unit_cost);
+        const markup = Number(field === 'markup' ? value : it.markup);
+        it.price = cost * (1 + markup / 100);
+      }
+      copy[i] = it;
       return copy;
     });
   };
 
+  const totalCost = items.reduce(
+    (sum, it) => sum + Number(it.qty) * Number(it.unit_cost),
+    0
+  );
   const total = items.reduce(
     (sum, it) => sum + Number(it.qty) * Number(it.price),
     0
   );
+  const markupPercent = totalCost ? ((total - totalCost) / totalCost) * 100 : 0;
+  const profit = total - totalCost;
 
   const formatEuro = n =>
     new Intl.NumberFormat('en-IE', { style: 'currency', currency: 'EUR' }).format(
@@ -178,6 +201,8 @@ export default function EditQuotationPage() {
             body: JSON.stringify({
               description: it.description,
               qty: it.qty,
+              unit_cost: it.unit_cost,
+              markup_percent: it.markup,
               unit_price: it.price,
             }),
           });
@@ -190,6 +215,8 @@ export default function EditQuotationPage() {
               part_id: it.part_id || null,
               description: it.description,
               qty: it.qty,
+              unit_cost: it.unit_cost,
+              markup_percent: it.markup,
               unit_price: it.price,
             }),
           });
@@ -297,15 +324,17 @@ export default function EditQuotationPage() {
         </div>
         <div>
           <h2 className="font-semibold mb-2">Item Details</h2>
-          <div className="grid grid-cols-6 gap-2 mb-2 font-semibold text-sm">
+          <div className="grid grid-cols-7 gap-2 mb-2 font-semibold text-sm">
             <div>Part #</div>
             <div className="col-span-2">Description</div>
             <div>Qty</div>
             <div>Unit Cost</div>
-            <div>Line Cost</div>
+            <div>Markup %</div>
+            <div>Unit Price</div>
+            <div>Line Price</div>
           </div>
           {items.map((it, i) => (
-            <div key={i} className="grid grid-cols-6 gap-2 mb-2">
+            <div key={i} className="grid grid-cols-7 gap-2 mb-2">
               <PartAutocomplete
                 value={it.part_number}
                 onChange={v => changeItem(i, 'part_number', v)}
@@ -313,7 +342,7 @@ export default function EditQuotationPage() {
                   changeItem(i, 'part_number', p.part_number);
                   changeItem(i, 'part_id', p.id);
                   changeItem(i, 'description', p.description || '');
-                  changeItem(i, 'price', p.unit_cost || 0);
+                  changeItem(i, 'unit_cost', p.unit_cost || 0);
                 }}
               />
               <input
@@ -333,9 +362,19 @@ export default function EditQuotationPage() {
                 type="number"
                 className="input"
                 placeholder="Unit cost"
-                value={it.price}
-                onChange={e => changeItem(i, 'price', e.target.value)}
+                value={it.unit_cost}
+                onChange={e => changeItem(i, 'unit_cost', e.target.value)}
               />
+              <input
+                type="number"
+                className="input"
+                placeholder="Markup %"
+                value={it.markup}
+                onChange={e => changeItem(i, 'markup', e.target.value)}
+              />
+              <div className="flex items-center px-2 border rounded bg-gray-50 justify-end">
+                {formatEuro(it.price)}
+              </div>
               <div className="flex items-center px-2 border rounded bg-gray-50">
                 {formatEuro(Number(it.qty) * Number(it.price))}
               </div>
@@ -347,7 +386,12 @@ export default function EditQuotationPage() {
         </div>
         <div>
           <h2 className="font-semibold mb-2">Summary</h2>
-          <p className="font-semibold">Total: {formatEuro(total)}</p>
+          <p className="font-semibold">Total Cost: {formatEuro(totalCost)}</p>
+          <p className="font-semibold">Total Price: {formatEuro(total)}</p>
+          <p className="font-semibold">
+            Global Markup: {markupPercent.toFixed(2)}%
+          </p>
+          <p className="font-semibold">Expected Profit: {formatEuro(profit)}</p>
         </div>
         <button type="submit" className="button">
           Update Quote

--- a/services/quoteItemsService.js
+++ b/services/quoteItemsService.js
@@ -2,9 +2,10 @@ import pool from '../lib/db.js';
 
 export async function getQuoteItems(quote_id) {
   const [rows] = await pool.query(
-    `SELECT qi.id, qi.quote_id, qi.part_id, qi.description, qi.qty, qi.unit_price,
-            p.supplier_id, p.part_number AS partNumber,
-            COALESCE(qi.unit_price, p.unit_cost) AS unitCost
+    `SELECT qi.id, qi.quote_id, qi.part_id, qi.description, qi.qty,
+            qi.unit_cost, qi.markup_percent,
+            qi.unit_price,
+            p.supplier_id, p.part_number AS partNumber
        FROM quote_items qi
   LEFT JOIN parts p ON qi.part_id=p.id
       WHERE qi.quote_id=?
@@ -14,27 +15,53 @@ export async function getQuoteItems(quote_id) {
   return rows;
 }
 
-export async function createQuoteItem({ quote_id, part_id, description, qty, unit_price }) {
+export async function createQuoteItem({
+  quote_id,
+  part_id,
+  description,
+  qty,
+  unit_cost,
+  markup_percent,
+  unit_price,
+}) {
   const [{ insertId }] = await pool.query(
-    `INSERT INTO quote_items (quote_id, part_id, description, qty, unit_price)
-     VALUES (?,?,?,?,?)`,
-    [quote_id, part_id || null, description || null, qty || null, unit_price || null]
+    `INSERT INTO quote_items (quote_id, part_id, description, qty, unit_cost, markup_percent, unit_price)
+     VALUES (?,?,?,?,?,?,?)`,
+    [
+      quote_id,
+      part_id || null,
+      description || null,
+      qty || null,
+      unit_cost || null,
+      markup_percent || null,
+      unit_price || null,
+    ]
   );
-  return { id: insertId, quote_id, part_id, description, qty, unit_price };
+  return {
+    id: insertId,
+    quote_id,
+    part_id,
+    description,
+    qty,
+    unit_cost,
+    markup_percent,
+    unit_price,
+  };
 }
 
 export async function getQuoteItemById(id) {
   const [[row]] = await pool.query(
-    `SELECT id, quote_id, part_id, description, qty, unit_price FROM quote_items WHERE id=?`,
+    `SELECT id, quote_id, part_id, description, qty, unit_cost, markup_percent, unit_price
+       FROM quote_items WHERE id=?`,
     [id]
   );
   return row || null;
 }
 
-export async function updateQuoteItem(id, { description, qty, unit_price }) {
+export async function updateQuoteItem(id, { description, qty, unit_cost, markup_percent, unit_price }) {
   await pool.query(
-    `UPDATE quote_items SET description=?, qty=?, unit_price=? WHERE id=?`,
-    [description || null, qty || null, unit_price || null, id]
+    `UPDATE quote_items SET description=?, qty=?, unit_cost=?, markup_percent=?, unit_price=? WHERE id=?`,
+    [description || null, qty || null, unit_cost || null, markup_percent || null, unit_price || null, id]
   );
   return { ok: true };
 }


### PR DESCRIPTION
## Summary
- extend `quote_items` with unit cost & markup percent
- allow creating/editing cost and markup in quote forms
- compute global markup and profit in quote forms
- include new totals in generated PDFs
- update quote item service and tests

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686af092573883338a1274ecc7370b1e