### PR TITLE
Parse numbers in quote items

### DIFF
--- a/__tests__/quoteItemsService.test.js
+++ b/__tests__/quoteItemsService.test.js
@@ -6,15 +6,22 @@ afterEach(() => {
 });
 
 test('getQuoteItems fetches items', async () => {
-  const rows = [{ id: 1 }];
+  const rows = [
+    { id: 1, description: 'x', unit_cost: '1.2', markup_percent: '10', unit_price: '1.3' },
+  ];
   const queryMock = jest.fn().mockResolvedValue([rows]);
   jest.unstable_mockModule('../lib/db.js', () => ({
     default: { query: queryMock },
   }));
   const { getQuoteItems } = await import('../services/quoteItemsService.js');
   const result = await getQuoteItems(2);
-  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/FROM quote_items/), [2]);
-  expect(result).toEqual(rows);
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/FROM quote_items/),
+    [2]
+  );
+  expect(result).toEqual([
+    { id: 1, description: 'x', unit_cost: 1.2, markup_percent: 10, unit_price: 1.3 },
+  ]);
 });
 
 test('updateQuoteItem updates row', async () => {

--- a/services/quoteItemsService.js
+++ b/services/quoteItemsService.js
@@ -12,7 +12,12 @@ export async function getQuoteItems(quote_id) {
    ORDER BY qi.id`,
     [quote_id]
   );
-  return rows;
+  return rows.map(row => ({
+    ...row,
+    unit_cost: row.unit_cost == null ? null : Number(row.unit_cost),
+    markup_percent: row.markup_percent == null ? null : Number(row.markup_percent),
+    unit_price: row.unit_price == null ? null : Number(row.unit_price),
+  }));
 }
 
 export async function createQuoteItem({


### PR DESCRIPTION
## Summary
- coerce quote item cost fields to numbers
- update quote item service test to check conversions

## Testing
- `npm test` *(fails: Cannot find module '.../jest')*

------
https://chatgpt.com/codex/tasks/task_e_686af45e96e8833395a28cca05a4657d