### PR TITLE
Fix dark mode for secondary buttons

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -40,7 +40,7 @@
   @apply inline-flex items-center bg-[var(--color-accent)] text-white rounded-full py-3 shadow-xl hover:brightness-110 transition;
 }
 .button-secondary {
-  @apply bg-gray-300 text-[var(--color-text-primary)] rounded-full py-3 shadow-xl hover:bg-gray-400 transition;
+  @apply bg-gray-300 text-[var(--color-text-primary)] rounded-full py-3 shadow-xl hover:bg-gray-400 transition dark:bg-gray-600 dark:text-white dark:hover:bg-gray-500;
 }
 
 .item-card {


### PR DESCRIPTION
## Summary
- ensure `.button-secondary` styles remain legible in dark mode

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af7c6e480833385f14ce05cbef25f