### PR TITLE
Fix quote links to open edit page

### DIFF
--- a/__tests__/client-vehicle-view-pages.test.js
+++ b/__tests__/client-vehicle-view-pages.test.js
@@ -26,7 +26,7 @@ test('client view page lists quotes', async () => {
   render(<Page />);
 
   const quoteLink = await screen.findByRole('link', { name: 'Quote #2 - new' });
-  expect(quoteLink).toHaveAttribute('href', '/office/quotations/2');
+  expect(quoteLink).toHaveAttribute('href', '/office/quotations/2/edit');
 });
 
 
@@ -46,5 +46,5 @@ test('vehicle view page lists quotes', async () => {
   render(<Page />);
 
   const vehicleQuoteLink = await screen.findByRole('link', { name: 'Quote #3 - sent' });
-  expect(vehicleQuoteLink).toHaveAttribute('href', '/office/quotations/3');
+  expect(vehicleQuoteLink).toHaveAttribute('href', '/office/quotations/3/edit');
 });

--- a/pages/office/clients/view/[id].js
+++ b/pages/office/clients/view/[id].js
@@ -127,7 +127,7 @@ export default function ClientViewPage() {
             <ul className="list-disc pl-5 space-y-1">
               {quotes.map(q => (
                 <li key={q.id}>
-                  <Link href={`/office/quotations/${q.id}`}>
+                  <Link href={`/office/quotations/${q.id}/edit`}>
                     <a className="underline">Quote #{q.id} - {q.status}</a>
                   </Link>
                 </li>

--- a/pages/office/vehicles/view/[id].js
+++ b/pages/office/vehicles/view/[id].js
@@ -117,7 +117,7 @@ export default function VehicleViewPage() {
             <ul className="list-disc pl-5 space-y-1">
               {quotes.map(q => (
                 <li key={q.id}>
-                  <Link href={`/office/quotations/${q.id}`}>
+                  <Link href={`/office/quotations/${q.id}/edit`}>
                     <a className="underline">Quote #{q.id} - {q.status}</a>
                   </Link>
                 </li>


### PR DESCRIPTION
## Summary
- link to edit quotation page from client and vehicle view pages
- update view-page tests for new edit paths

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686af9b415d88333b0130b0bc1909c4c