### PR TITLE
Fix quote PDF endpoint data mapping

### DIFF
--- a/pages/api/quotes/[id]/pdf.js
+++ b/pages/api/quotes/[id]/pdf.js
@@ -25,16 +25,34 @@ async function handler(req, res) {
     const items = await getQuoteItems(id);
 
     const quoteNumber = quote.id;
-    const garage = company;
+    const garage = {
+      name: company?.company_name,
+      logo: company?.logo_url,
+      address: company?.address,
+      phone: company?.phone,
+      email: company?.email,
+    };
+    const clientInfo = client
+      ? {
+          name: `${client.first_name} ${client.last_name}`.trim(),
+          phone: client.mobile || client.landline,
+          email: client.email,
+          address: client.street_address,
+          city: client.town,
+          postcode: client.post_code,
+        }
+      : {};
     const terms = quote.terms || company.terms || '';
 
     try {
       const pdf = await buildQuotePdf({
         quoteNumber,
+        title: 'QUOTE',
         garage,
-        client,
+        client: clientInfo,
         vehicle: vehicle || {},
         items,
+        defect_description: quote.defect_description,
         terms,
       });
       res.setHeader('Content-Type', 'application/pdf');


### PR DESCRIPTION
## Summary
- map garage/client fields to new buildQuotePdf format
- forward defect description and title
- update quote email generation to send new PDF payload

## Testing
- `npm test` *(fails: Cannot find module '.../jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b03c0916c8333b153f05bb6ccb7f6