### PR TITLE
Update fleet services to default garage name

### DIFF
--- a/__tests__/fleetsService.test.js
+++ b/__tests__/fleetsService.test.js
@@ -50,3 +50,40 @@ test('resetFleetPin updates hash and returns pin', async () => {
   );
   Math.random.mockRestore();
 });
+
+test('createFleet defaults garage_name from company settings', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 5 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const hashMock = jest.fn(async () => 'HASH');
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    hashPassword: hashMock,
+  }));
+  const settingsMock = jest.fn().mockResolvedValue({ company_name: 'GarageCo' });
+  jest.unstable_mockModule('../services/companySettingsService.js', () => ({
+    getSettings: settingsMock,
+  }));
+  jest.spyOn(Math, 'random').mockReturnValue(0.5);
+  const { createFleet } = await import('../services/fleetsService.js');
+  const res = await createFleet({ company_name: 'C' });
+  expect(settingsMock).toHaveBeenCalled();
+  expect(res.garage_name).toBe('GarageCo');
+  expect(queryMock.mock.calls[0][1][1]).toBe('GarageCo');
+  Math.random.mockRestore();
+});
+
+test('updateFleet defaults garage_name from company settings', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const settingsMock = jest.fn().mockResolvedValue({ company_name: 'GarageCo' });
+  jest.unstable_mockModule('../services/companySettingsService.js', () => ({
+    getSettings: settingsMock,
+  }));
+  const { updateFleet } = await import('../services/fleetsService.js');
+  await updateFleet(6, { company_name: 'D' });
+  expect(settingsMock).toHaveBeenCalled();
+  expect(queryMock.mock.calls[0][1][1]).toBe('GarageCo');
+});

--- a/migrations/20251230_populate_fleet_garage_name.sql
+++ b/migrations/20251230_populate_fleet_garage_name.sql
@@ -1,0 +1,3 @@
+UPDATE fleets
+   SET garage_name = (SELECT company_name FROM company_settings LIMIT 1)
+ WHERE garage_name IS NULL OR garage_name='';

--- a/services/fleetsService.js
+++ b/services/fleetsService.js
@@ -1,4 +1,5 @@
 import pool from '../lib/db.js';
+import { getSettings } from './companySettingsService.js';
 
 export async function getAllFleets() {
   const [rows] = await pool.query(
@@ -37,6 +38,10 @@ export async function createFleet({
   contact_name_1,
   contact_name_2,
 }) {
+  if (!garage_name) {
+    const settings = await getSettings();
+    garage_name = settings?.company_name || garage_name;
+  }
   const pin = String(Math.floor(1000 + Math.random() * 9000));
   const { hashPassword } = await import('../lib/auth.js');
   const pin_hash = await hashPassword(pin);
@@ -103,6 +108,10 @@ export async function updateFleet(
     contact_name_2,
   }
 ) {
+  if (!garage_name) {
+    const settings = await getSettings();
+    garage_name = settings?.company_name || garage_name;
+  }
   await pool.query(
     `UPDATE fleets SET
        company_name=?,


### PR DESCRIPTION
## Summary
- add migration to populate missing fleet garage names
- default `garage_name` from company settings on fleet create/update
- test fleet service garage name defaulting

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686c4e852ff483339deeef88bffacd61