### PR TITLE
Use fleet vehicle ID in quote PDFs

### DIFF
--- a/__tests__/quotePdfApi.test.js
+++ b/__tests__/quotePdfApi.test.js
@@ -6,7 +6,14 @@ afterEach(() => {
 });
 
 test('quote pdf endpoint returns PDF', async () => {
-  const quote = { id: 1, customer_id: 2, job_id: null, total_amount: 10 };
+  const quote = {
+    id: 1,
+    customer_id: 2,
+    vehicle_id: 3,
+    fleet_vehicle_id: 'FV1',
+    job_id: null,
+    total_amount: 10,
+  };
   const buildMock = jest.fn().mockResolvedValue(Buffer.from('PDF'));
   jest.unstable_mockModule('../services/quotesService.js', () => ({
     getQuoteById: jest.fn().mockResolvedValue(quote),
@@ -33,7 +40,11 @@ test('quote pdf endpoint returns PDF', async () => {
   const req = { method: 'GET', query: { id: '1' }, headers: {} };
   const res = { setHeader: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn(), json: jest.fn(), end: jest.fn() };
   await handler(req, res);
-  expect(buildMock).toHaveBeenCalled();
+  expect(buildMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      vehicle: expect.objectContaining({ id: 'FV1' })
+    })
+  );
   expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
   expect(res.send).toHaveBeenCalledWith(Buffer.from('PDF'));
 });

--- a/pages/api/quotes/[id]/pdf.js
+++ b/pages/api/quotes/[id]/pdf.js
@@ -18,7 +18,9 @@ export default async function handler(req, res) {
     if (!quote) throw new Error(`Quote ${id} not found`);
     const client = await getClientById(quote.customer_id);
     if (!client) throw new Error(`Client ${quote.customer_id} not found`);
-    const vehicle = await getVehicleById(quote.vehicle_id);
+    let vehicle = await getVehicleById(quote.vehicle_id);
+    vehicle = vehicle || {};
+    vehicle.vehicle_id = quote.fleet_vehicle_id;
     const items = await getQuoteItems(id);
 
     // Build payload
@@ -45,7 +47,7 @@ export default async function handler(req, res) {
         model: vehicle.model,
         color: vehicle.color,
         vin_number: vehicle.vin_number,
-        id: vehicle.id
+        id: vehicle.vehicle_id
       },
       items: items.map(it => ({
         partNumber:  it.partNumber,


### PR DESCRIPTION
## Summary
- attach the fleet vehicle id to the vehicle record when building quote PDFs
- check that the generated payload includes this id in tests

## Testing
- `npm test --silent` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686c50d3fb288333ae74b3fb3600bc4e