### PR TITLE
Add service and itv dates

### DIFF
--- a/__tests__/vehicles-api.test.js
+++ b/__tests__/vehicles-api.test.js
@@ -8,7 +8,7 @@ afterEach(() => {
 // GET /vehicles success
 
 test('vehicles index returns list of vehicles', async () => {
-  const vehicles = [{ id: 1, licence_plate: 'ABC' }];
+  const vehicles = [{ id: 1, licence_plate: 'ABC', service_date: '2024-01-01', itv_date: '2024-06-01' }];
   const getAllMock = jest.fn().mockResolvedValue(vehicles);
   jest.unstable_mockModule('../services/vehiclesService.js', () => ({
     getAllVehicles: getAllMock,
@@ -24,14 +24,14 @@ test('vehicles index returns list of vehicles', async () => {
 });
 
 test('vehicles index creates vehicle', async () => {
-  const newVehicle = { id: 2, licence_plate: 'XYZ' };
+  const newVehicle = { id: 2, licence_plate: 'XYZ', service_date: '2024-01-01', itv_date: '2024-06-01' };
   const createMock = jest.fn().mockResolvedValue(newVehicle);
   jest.unstable_mockModule('../services/vehiclesService.js', () => ({
     getAllVehicles: jest.fn(),
     createVehicle: createMock,
   }));
   const { default: handler } = await import('../pages/api/vehicles/index.js');
-  const req = { method: 'POST', body: { licence_plate: 'XYZ' }, headers: {} };
+  const req = { method: 'POST', body: { licence_plate: 'XYZ', service_date: '2024-01-01', itv_date: '2024-06-01' }, headers: {} };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
   await handler(req, res);
   expect(res.status).toHaveBeenCalledWith(201);
@@ -71,7 +71,7 @@ test('vehicles index handles errors', async () => {
 });
 
 test('vehicle detail returns vehicle by id', async () => {
-  const vehicle = { id: 1, licence_plate: 'AAA' };
+  const vehicle = { id: 1, licence_plate: 'AAA', service_date: '2024-01-01', itv_date: '2024-06-01' };
   const getMock = jest.fn().mockResolvedValue(vehicle);
   jest.unstable_mockModule('../services/vehiclesService.js', () => ({
     getVehicleById: getMock,

--- a/migrations/20260101_add_service_and_itv_dates.sql
+++ b/migrations/20260101_add_service_and_itv_dates.sql
@@ -1,0 +1,2 @@
+ALTER TABLE vehicles ADD COLUMN service_date DATE;
+ALTER TABLE vehicles ADD COLUMN itv_date DATE;

--- a/pages/fleet/vehicles/[id].js
+++ b/pages/fleet/vehicles/[id].js
@@ -68,6 +68,8 @@ export default function FleetVehicleDetails() {
         <p><strong>Make:</strong> {vehicle.make}</p>
         <p><strong>Model:</strong> {vehicle.model}</p>
         <p><strong>Color:</strong> {vehicle.color}</p>
+        <p><strong>Service Date:</strong> {vehicle.service_date || 'N/A'}</p>
+        <p><strong>ITV Date:</strong> {vehicle.itv_date || 'N/A'}</p>
       </div>
       <section className="mb-6">
         <h2 className="text-xl font-semibold mb-2">Quotes</h2>

--- a/pages/fleet/vehicles/new.js
+++ b/pages/fleet/vehicles/new.js
@@ -12,6 +12,8 @@ export default function FleetNewVehicle() {
     model: '',
     color: '',
     company_vehicle_id: '',
+    service_date: '',
+    itv_date: '',
   });
 
   useEffect(() => {
@@ -36,7 +38,7 @@ export default function FleetNewVehicle() {
     });
     if (res.ok) {
       setMessage('Vehicle added');
-      setForm({ licence_plate: '', make: '', model: '', color: '', company_vehicle_id: '' });
+      setForm({ licence_plate: '', make: '', model: '', color: '', company_vehicle_id: '', service_date: '', itv_date: '' });
     }
   }
 
@@ -58,12 +60,13 @@ export default function FleetNewVehicle() {
       </div>
       {message && <p className="text-green-600 mb-2">{message}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-sm">
-        {['licence_plate','make','model','color','company_vehicle_id'].map(field => (
+        {['licence_plate','make','model','color','company_vehicle_id','service_date','itv_date'].map(field => (
           <input
             key={field}
             name={field}
             value={form[field]}
             onChange={change}
+            type={field.includes('date') ? 'date' : 'text'}
             placeholder={field.replace('_',' ')}
             className="input w-full"
           />

--- a/pages/local/vehicles/[id].js
+++ b/pages/local/vehicles/[id].js
@@ -68,6 +68,8 @@ export default function LocalVehicleDetails() {
         <p><strong>Make:</strong> {vehicle.make}</p>
         <p><strong>Model:</strong> {vehicle.model}</p>
         <p><strong>Color:</strong> {vehicle.color}</p>
+        <p><strong>Service Date:</strong> {vehicle.service_date || 'N/A'}</p>
+        <p><strong>ITV Date:</strong> {vehicle.itv_date || 'N/A'}</p>
       </div>
       <section className="mb-6">
         <h2 className="text-xl font-semibold mb-2">Quotes</h2>

--- a/pages/office/vehicles/[id].js
+++ b/pages/office/vehicles/[id].js
@@ -14,6 +14,8 @@ const EditVehiclePage = () => {
     company_vehicle_id: '',
     customer_id: '',
     fleet_id: '',
+    service_date: '',
+    itv_date: '',
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -51,13 +53,14 @@ const EditVehiclePage = () => {
       <h1 className="text-2xl font-semibold mb-4">Edit Vehicle</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
-        {['licence_plate','make','model','color','vin_number','company_vehicle_id','customer_id','fleet_id'].map(field => (
+        {['licence_plate','make','model','color','vin_number','company_vehicle_id','customer_id','fleet_id','service_date','itv_date'].map(field => (
           <div key={field}>
             <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
             <input
               name={field}
               value={form[field] || ''}
               onChange={change}
+              type={field.includes('date') ? 'date' : 'text'}
               className="w-full border px-3 py-2 rounded text-black"
             />
           </div>

--- a/pages/office/vehicles/new.js
+++ b/pages/office/vehicles/new.js
@@ -13,6 +13,8 @@ const NewVehiclePage = () => {
     company_vehicle_id: '',
     customer_id: router.query.customer_id || '',
     fleet_id: '',
+    service_date: '',
+    itv_date: '',
   });
   const [error, setError] = useState(null);
 
@@ -38,13 +40,14 @@ const NewVehiclePage = () => {
       <h1 className="text-2xl font-semibold mb-4">New Vehicle</h1>
       {error && <p className="text-red-500">{error}</p>}
       <form onSubmit={submit} className="space-y-4 max-w-md">
-        {['licence_plate','make','model','color','vin_number','company_vehicle_id','customer_id','fleet_id'].map(field => (
+        {['licence_plate','make','model','color','vin_number','company_vehicle_id','customer_id','fleet_id','service_date','itv_date'].map(field => (
           <div key={field}>
             <label className="block mb-1">{field.replace('_',' ').replace(/\b\w/g,c=>c.toUpperCase())}</label>
             <input
               name={field}
               value={form[field]}
               onChange={change}
+              type={field.includes('date') ? 'date' : 'text'}
               className="w-full border px-3 py-2 rounded text-black"
             />
           </div>

--- a/pages/office/vehicles/view/[id].js
+++ b/pages/office/vehicles/view/[id].js
@@ -91,6 +91,8 @@ export default function VehicleViewPage() {
           <p><strong>Model:</strong> {vehicle.model}</p>
           <p><strong>Color:</strong> {vehicle.color}</p>
           <p><strong>VIN:</strong> {vehicle.vin_number}</p>
+          <p><strong>Service Date:</strong> {vehicle.service_date || 'N/A'}</p>
+          <p><strong>ITV Date:</strong> {vehicle.itv_date || 'N/A'}</p>
           <p><strong>Fleet:</strong> {fleet ? fleet.company_name : (vehicle.fleet_id || 'N/A')}</p>
         </Card>
         <Card>

--- a/services/vehiclesService.js
+++ b/services/vehiclesService.js
@@ -3,6 +3,7 @@ import pool from '../lib/db.js';
 export async function getAllVehicles(customer_id, fleet_id) {
   const base = `SELECT v.id, v.licence_plate, v.make, v.model, v.color,
                        v.vin_number, v.company_vehicle_id, v.customer_id, v.fleet_id,
+                       v.service_date, v.itv_date,
                        CONCAT(c.first_name, ' ', c.last_name) AS customer_name
                   FROM vehicles v
              LEFT JOIN clients c ON v.customer_id=c.id`;
@@ -16,7 +17,7 @@ export async function getAllVehicles(customer_id, fleet_id) {
 
 export async function getVehicleById(id) {
   const [[row]] = await pool.query(
-    `SELECT id, licence_plate, make, model, color, vin_number, company_vehicle_id, customer_id, fleet_id FROM vehicles WHERE id=?`,
+    `SELECT id, licence_plate, make, model, color, vin_number, company_vehicle_id, customer_id, fleet_id, service_date, itv_date FROM vehicles WHERE id=?`,
     [id],
   );
   return row || null;
@@ -31,12 +32,15 @@ export async function createVehicle({
   company_vehicle_id,
   customer_id,
   fleet_id,
+  service_date,
+  itv_date,
 }) {
   const [{ insertId }] = await pool.query(
     `INSERT INTO vehicles (
        licence_plate, make, model, color, vin_number,
-       company_vehicle_id, customer_id, fleet_id
-     ) VALUES (?,?,?,?,?,?,?,?)`,
+       company_vehicle_id, customer_id, fleet_id,
+       service_date, itv_date
+     ) VALUES (?,?,?,?,?,?,?,?,?,?)`,
     [
       licence_plate,
       make,
@@ -46,6 +50,8 @@ export async function createVehicle({
       company_vehicle_id || null,
       customer_id || null,
       fleet_id || null,
+      service_date || null,
+      itv_date || null,
     ],
   );
   return {
@@ -58,15 +64,17 @@ export async function createVehicle({
     company_vehicle_id,
     customer_id,
     fleet_id,
+    service_date,
+    itv_date,
   };
 }
 
 export async function updateVehicle(
   id,
-  { licence_plate, make, model, color, vin_number, company_vehicle_id, customer_id, fleet_id }
+  { licence_plate, make, model, color, vin_number, company_vehicle_id, customer_id, fleet_id, service_date, itv_date }
 ) {
   await pool.query(
-    `UPDATE vehicles SET licence_plate=?, make=?, model=?, color=?, vin_number=?, company_vehicle_id=?, customer_id=?, fleet_id=? WHERE id=?`,
+    `UPDATE vehicles SET licence_plate=?, make=?, model=?, color=?, vin_number=?, company_vehicle_id=?, customer_id=?, fleet_id=?, service_date=?, itv_date=? WHERE id=?`,
     [
       licence_plate,
       make,
@@ -76,6 +84,8 @@ export async function updateVehicle(
       company_vehicle_id || null,
       customer_id || null,
       fleet_id || null,
+      service_date || null,
+      itv_date || null,
       id,
     ],
   );


### PR DESCRIPTION
## Summary
- add service_date and itv_date columns
- read/write these fields in vehicle service
- extend vehicle forms to capture new dates
- show service/ITV dates on vehicle detail pages across portals
- update vehicle API tests

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686c55967b0883339c1ccf7cb9cd5e61