### PR TITLE
Add vehicle mileage tracking

### DIFF
--- a/__tests__/client-vehicle-view-pages.test.js
+++ b/__tests__/client-vehicle-view-pages.test.js
@@ -48,3 +48,23 @@ test('vehicle view page lists quotes', async () => {
   const vehicleQuoteLink = await screen.findByRole('link', { name: 'Quote #3 - sent' });
   expect(vehicleQuoteLink).toHaveAttribute('href', '/office/quotations/3/edit');
 });
+
+test('vehicle view page shows mileage history', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '6' } })
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 6 }) }) // vehicle
+    .mockResolvedValueOnce({ ok: true, json: async () => null }) // client
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }) // documents
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }) // quotes
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 1, mileage: 100, recorded_at: '2024-01-01' }] }); // mileage
+
+  const { default: Page } = await import('../pages/office/vehicles/view/[id].js');
+  render(<Page />);
+
+  await screen.findByText('Mileage History');
+  expect(screen.getByText('100')).toBeInTheDocument();
+});

--- a/__tests__/vehicle-mileage-api.test.js
+++ b/__tests__/vehicle-mileage-api.test.js
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('vehicle mileage GET returns rows', async () => {
+  const rows = [{ id: 1 }];
+  const listMock = jest.fn().mockResolvedValue(rows);
+  jest.unstable_mockModule('../services/vehicleMileageService.js', () => ({
+    getMileageForVehicle: listMock,
+    addMileage: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/vehicle-mileage/index.js');
+  const req = { method: 'GET', query: { vehicle_id: '2' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(listMock).toHaveBeenCalledWith('2');
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(rows);
+});
+
+test('vehicle mileage POST creates entry', async () => {
+  const entry = { id: 2 };
+  const createMock = jest.fn().mockResolvedValue(entry);
+  jest.unstable_mockModule('../services/vehicleMileageService.js', () => ({
+    getMileageForVehicle: jest.fn(),
+    addMileage: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/vehicle-mileage/index.js');
+  const req = { method: 'POST', body: { vehicle_id: 1, mileage: 100 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(entry);
+});

--- a/migrations/20260102_create_vehicle_mileage.sql
+++ b/migrations/20260102_create_vehicle_mileage.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS vehicle_mileage (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  vehicle_id INT NOT NULL,
+  mileage INT NOT NULL,
+  recorded_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_vehicle_mileage_vehicle FOREIGN KEY (vehicle_id) REFERENCES vehicles(id)
+);

--- a/pages/api/vehicle-mileage/index.js
+++ b/pages/api/vehicle-mileage/index.js
@@ -1,0 +1,23 @@
+import { addMileage, getMileageForVehicle } from '../../../services/vehicleMileageService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  try {
+    if (req.method === 'GET') {
+      const { vehicle_id } = req.query || {};
+      const rows = await getMileageForVehicle(vehicle_id);
+      return res.status(200).json(rows);
+    }
+    if (req.method === 'POST') {
+      const entry = await addMileage(req.body);
+      return res.status(201).json(entry);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+export default apiHandler(handler);

--- a/pages/fleet/vehicles/[id].js
+++ b/pages/fleet/vehicles/[id].js
@@ -13,6 +13,7 @@ export default function FleetVehicleDetails() {
   const [quotes, setQuotes] = useState([]);
   const [jobs, setJobs] = useState([]);
   const [invoices, setInvoices] = useState([]);
+  const [mileage, setMileage] = useState([]);
 
   useEffect(() => {
     if (!id) return;
@@ -21,16 +22,18 @@ export default function FleetVehicleDetails() {
       if (!res.ok) return router.replace('/fleet/login');
       const f = await res.json();
       setFleet(f);
-      const [v, qAll, jAll, iAll] = await Promise.all([
+      const [v, qAll, jAll, iAll, mAll] = await Promise.all([
         fetch(`/api/vehicles/${id}`).then(r => r.json()),
         fetch(`/api/quotes?fleet_id=${f.id}`).then(r => r.json()),
         fetchJobs({ fleet_id: f.id }),
         fetch(`/api/invoices?fleet_id=${f.id}`).then(r => r.json()),
+        fetch(`/api/vehicle-mileage?vehicle_id=${id}`).then(r => r.json()),
       ]);
       setVehicle(v);
       setQuotes(qAll.filter(q => q.vehicle_id == id));
       setJobs(jAll.filter(j => j.vehicle_id == id));
       setInvoices(iAll.filter(inv => inv.vehicle_id == id));
+      setMileage(mAll);
     })();
   }, [id, router]);
 
@@ -71,6 +74,29 @@ export default function FleetVehicleDetails() {
         <p><strong>Service Date:</strong> {vehicle.service_date || 'N/A'}</p>
         <p><strong>ITV Date:</strong> {vehicle.itv_date || 'N/A'}</p>
       </div>
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Mileage History</h2>
+        {mileage.length === 0 ? (
+          <p>No entries</p>
+        ) : (
+          <table className="min-w-full bg-white border text-black">
+            <thead>
+              <tr>
+                <th className="px-2 py-1 border">Date</th>
+                <th className="px-2 py-1 border">Mileage</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mileage.map(m => (
+                <tr key={m.id}>
+                  <td className="px-2 py-1 border">{new Date(m.recorded_at).toLocaleDateString()}</td>
+                  <td className="px-2 py-1 border">{m.mileage}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
       <section className="mb-6">
         <h2 className="text-xl font-semibold mb-2">Quotes</h2>
         <ul className="list-disc ml-6 space-y-1">

--- a/pages/local/vehicles/[id].js
+++ b/pages/local/vehicles/[id].js
@@ -13,6 +13,7 @@ export default function LocalVehicleDetails() {
   const [quotes, setQuotes] = useState([]);
   const [jobs, setJobs] = useState([]);
   const [invoices, setInvoices] = useState([]);
+  const [mileage, setMileage] = useState([]);
 
   useEffect(() => {
     if (!id) return;
@@ -21,16 +22,18 @@ export default function LocalVehicleDetails() {
       if (!res.ok) return router.replace('/local/login');
       const c = await res.json();
       setClient(c);
-      const [v, qAll, jAll, iAll] = await Promise.all([
+      const [v, qAll, jAll, iAll, mAll] = await Promise.all([
         fetch(`/api/vehicles/${id}`).then(r => r.json()),
         fetch(`/api/quotes?customer_id=${c.id}`).then(r => r.json()),
         fetchJobs({ customer_id: c.id }),
         fetch(`/api/invoices?customer_id=${c.id}`).then(r => r.json()),
+        fetch(`/api/vehicle-mileage?vehicle_id=${id}`).then(r => r.json()),
       ]);
       setVehicle(v);
       setQuotes(qAll.filter(q => q.vehicle_id == id));
       setJobs(jAll.filter(j => j.vehicle_id == id));
       setInvoices(iAll.filter(inv => inv.vehicle_id == id));
+      setMileage(mAll);
     })();
   }, [id, router]);
 
@@ -71,6 +74,29 @@ export default function LocalVehicleDetails() {
         <p><strong>Service Date:</strong> {vehicle.service_date || 'N/A'}</p>
         <p><strong>ITV Date:</strong> {vehicle.itv_date || 'N/A'}</p>
       </div>
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Mileage History</h2>
+        {mileage.length === 0 ? (
+          <p>No entries</p>
+        ) : (
+          <table className="min-w-full bg-white border text-black">
+            <thead>
+              <tr>
+                <th className="px-2 py-1 border">Date</th>
+                <th className="px-2 py-1 border">Mileage</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mileage.map(m => (
+                <tr key={m.id}>
+                  <td className="px-2 py-1 border">{new Date(m.recorded_at).toLocaleDateString()}</td>
+                  <td className="px-2 py-1 border">{m.mileage}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
       <section className="mb-6">
         <h2 className="text-xl font-semibold mb-2">Quotes</h2>
         <ul className="list-disc ml-6 space-y-1">

--- a/pages/office/job-cards/index.js
+++ b/pages/office/job-cards/index.js
@@ -36,8 +36,16 @@ const JobCardsPage = () => {
       .catch(() => setVehicles([]));
   }, []);
 
-  const completeJob = async id => {
-    await updateQuote(id, { status: 'completed' });
+  const completeJob = async job => {
+    const mileageStr = prompt('Current mileage');
+    const mileage = Number.parseInt(mileageStr, 10);
+    if (!Number.isFinite(mileage)) return;
+    await fetch('/api/vehicle-mileage', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ vehicle_id: job.vehicle_id, mileage }),
+    });
+    await updateQuote(job.id, { status: 'completed' });
     load();
   };
 
@@ -112,7 +120,7 @@ const JobCardsPage = () => {
               <div className="mt-3 flex flex-wrap gap-2">
                 {j.status === 'job-card' && (
                   <button
-                    onClick={() => completeJob(j.id)}
+                    onClick={() => completeJob(j)}
                     className="button px-4 text-sm"
                   >
                     Mark Completed

--- a/pages/office/vehicles/view/[id].js
+++ b/pages/office/vehicles/view/[id].js
@@ -13,6 +13,7 @@ export default function VehicleViewPage() {
   const [documents, setDocuments] = useState([]);
   const [fleet, setFleet] = useState(null);
   const [quotes, setQuotes] = useState([]);
+  const [mileage, setMileage] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -38,6 +39,8 @@ export default function VehicleViewPage() {
         setDocuments(docs);
         const qs = await fetch(`/api/quotes?vehicle_id=${id}`).then(r => r.json());
         setQuotes(qs);
+        const ms = await fetch(`/api/vehicle-mileage?vehicle_id=${id}`).then(r => r.json());
+        setMileage(ms);
       } catch (err) {
         setError('Failed to load');
       } finally {
@@ -94,6 +97,29 @@ export default function VehicleViewPage() {
           <p><strong>Service Date:</strong> {vehicle.service_date || 'N/A'}</p>
           <p><strong>ITV Date:</strong> {vehicle.itv_date || 'N/A'}</p>
           <p><strong>Fleet:</strong> {fleet ? fleet.company_name : (vehicle.fleet_id || 'N/A')}</p>
+        </Card>
+        <Card>
+          <h2 className="text-xl font-semibold mb-4">Mileage History</h2>
+          {mileage.length === 0 ? (
+            <p>No entries</p>
+          ) : (
+            <table className="min-w-full bg-white border text-black">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1 border">Date</th>
+                  <th className="px-2 py-1 border">Mileage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {mileage.map(m => (
+                  <tr key={m.id}>
+                    <td className="px-2 py-1 border">{new Date(m.recorded_at).toLocaleDateString()}</td>
+                    <td className="px-2 py-1 border">{m.mileage}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </Card>
         <Card>
           <h2 className="text-xl font-semibold mb-4">Documents</h2>

--- a/services/vehicleMileageService.js
+++ b/services/vehicleMileageService.js
@@ -1,0 +1,17 @@
+import pool from '../lib/db.js';
+
+export async function addMileage({ vehicle_id, mileage, recorded_at }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO vehicle_mileage (vehicle_id, mileage, recorded_at) VALUES (?,?,?)`,
+    [vehicle_id, mileage, recorded_at || new Date()]
+  );
+  return { id: insertId, vehicle_id, mileage, recorded_at: recorded_at || new Date() };
+}
+
+export async function getMileageForVehicle(vehicle_id) {
+  const [rows] = await pool.query(
+    `SELECT id, vehicle_id, mileage, recorded_at FROM vehicle_mileage WHERE vehicle_id=? ORDER BY recorded_at DESC`,
+    [vehicle_id]
+  );
+  return rows;
+}


### PR DESCRIPTION
## Summary
- create `vehicle_mileage` table
- implement service and API for mileage entries
- prompt for mileage when completing job cards
- show mileage history on vehicle view pages
- test mileage API and UI

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686c56c84c088333b37b20529a9f5b1d