### PR TITLE
Add PDF links on portal pages

### DIFF
--- a/__tests__/portal-pdf-links.test.js
+++ b/__tests__/portal-pdf-links.test.js
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('PortalDashboard shows PDF link for each quote', async () => {
+  jest.unstable_mockModule('../lib/jobStatuses.js', () => ({
+    fetchJobStatuses: jest.fn().mockResolvedValue([])
+  }));
+  const { PortalDashboard } = await import('../components/PortalDashboard.js');
+  const quotes = [
+    { id: 1, status: 'new' },
+    { id: 2, status: 'sent' }
+  ];
+  render(
+    <PortalDashboard
+      title=""
+      requestJobPath="/"
+      vehicles={[]}
+      jobs={[]}
+      quotes={quotes}
+      setQuotes={() => {}}
+      invoices={[]}
+    />
+  );
+  const links = await screen.findAllByRole('link', { name: 'View PDF' });
+  expect(links).toHaveLength(quotes.length);
+  expect(links[0]).toHaveAttribute('href', '/api/quotes/1/pdf');
+});
+
+test('local vehicle detail page shows PDF link', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '5' }, replace: jest.fn(), push: jest.fn() })
+  }));
+  jest.unstable_mockModule('../lib/jobs.js', () => ({
+    fetchJobs: jest.fn().mockResolvedValue([])
+  }));
+  jest.unstable_mockModule('../lib/logout.js', () => ({ default: jest.fn() }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1 }) }) // local/me
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 5 }) }) // vehicle
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 10, vehicle_id: 5, status: 'new' }] }) // quotes
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }) // invoices
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }); // mileage
+
+  const { default: Page } = await import('../pages/local/vehicles/[id].js');
+  render(<Page />);
+
+  const link = await screen.findByRole('link', { name: 'View PDF' });
+  expect(link).toHaveAttribute('href', '/api/quotes/10/pdf');
+});
+
+
+test('fleet vehicle detail page shows PDF link', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '5' }, replace: jest.fn(), push: jest.fn() })
+  }));
+  jest.unstable_mockModule('../lib/jobs.js', () => ({
+    fetchJobs: jest.fn().mockResolvedValue([])
+  }));
+  jest.unstable_mockModule('../lib/logout.js', () => ({ default: jest.fn() }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1 }) }) // fleet/me
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 5 }) }) // vehicle
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 11, vehicle_id: 5, status: 'sent' }] }) // quotes
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }) // invoices
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }); // mileage
+
+  const { default: Page } = await import('../pages/fleet/vehicles/[id].js');
+  render(<Page />);
+
+  const link = await screen.findByRole('link', { name: 'View PDF' });
+  expect(link).toHaveAttribute('href', '/api/quotes/11/pdf');
+});

--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -132,6 +132,21 @@ export function PortalDashboard({
                     Accept
                   </button>
                 )}
+                <a
+                  href={`/api/quotes/${q.id}/pdf`}
+                  target="_blank"
+                  rel="noopener"
+                  className="ml-2 underline"
+                >
+                  View PDF
+                </a>
+                <a
+                  href={`/api/quotes/${q.id}/pdf`}
+                  download
+                  className="ml-2 underline"
+                >
+                  Download PDF
+                </a>
               </li>
             );
           })}

--- a/pages/fleet/vehicles/[id].js
+++ b/pages/fleet/vehicles/[id].js
@@ -109,6 +109,17 @@ export default function FleetVehicleDetails() {
               {q.status !== 'rejected' && (
                 <button onClick={() => rejectQuote(q.id)} className="ml-2 underline">Reject</button>
               )}
+              <a
+                href={`/api/quotes/${q.id}/pdf`}
+                target="_blank"
+                rel="noopener"
+                className="ml-2 underline"
+              >
+                View PDF
+              </a>
+              <a href={`/api/quotes/${q.id}/pdf`} download className="ml-2 underline">
+                Download PDF
+              </a>
             </li>
           ))}
         </ul>

--- a/pages/local/vehicles/[id].js
+++ b/pages/local/vehicles/[id].js
@@ -109,6 +109,17 @@ export default function LocalVehicleDetails() {
               {q.status !== 'rejected' && (
                 <button onClick={() => rejectQuote(q.id)} className="ml-2 underline">Reject</button>
               )}
+              <a
+                href={`/api/quotes/${q.id}/pdf`}
+                target="_blank"
+                rel="noopener"
+                className="ml-2 underline"
+              >
+                View PDF
+              </a>
+              <a href={`/api/quotes/${q.id}/pdf`} download className="ml-2 underline">
+                Download PDF
+              </a>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- add PDF view/download links to quotes on portal dashboard
- add PDF view/download links to quotes on client vehicle pages
- add PDF view/download links to quotes on fleet vehicle pages
- test that PDF links appear

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686c585f182c8333b0d148ce60330462