### PR TITLE
Add client profile page and update endpoint

### DIFF
--- a/__tests__/portal-me-api.test.js
+++ b/__tests__/portal-me-api.test.js
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('client profile update calls updateClient with id from token', async () => {
+  const updateMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getClientById: jest.fn(),
+    updateClient: updateMock,
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    verifyToken: () => ({ client_id: 5 }),
+  }));
+
+  const { default: handler } = await import('../pages/api/portal/local/me.js');
+  const req = {
+    method: 'PUT',
+    headers: { cookie: 'local_token=tok' },
+    body: { first_name: 'Bob' },
+  };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(updateMock).toHaveBeenCalledWith(5, req.body);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ ok: true });
+});

--- a/pages/local/profile.js
+++ b/pages/local/profile.js
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import logout from '../../lib/logout.js';
+
+export default function LocalProfile() {
+  const router = useRouter();
+  const [client, setClient] = useState(null);
+  const [form, setForm] = useState(null);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/portal/local/me');
+      if (!res.ok) return router.replace('/local/login');
+      const c = await res.json();
+      setClient(c);
+      setForm(c);
+    })();
+  }, [router]);
+
+  if (!form) return <p className="p-8">Loading…</p>;
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } finally {
+      router.push('/local/login');
+    }
+  }
+
+  const submit = async e => {
+    e.preventDefault();
+    setMessage('');
+    const res = await fetch('/api/portal/local/me', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) setMessage('Saved');
+  };
+
+  const fields = [
+    'first_name',
+    'last_name',
+    'email',
+    'mobile',
+    'landline',
+    'nie_number',
+    'street_address',
+    'town',
+    'province',
+    'post_code',
+    'garage_name',
+    'vehicle_reg',
+    'password',
+  ];
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-bold">My Profile</h1>
+        <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
+      </div>
+      {message && <p className="text-green-600 mb-2">{message}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        {fields.map(f => (
+          <div key={f}>
+            <label className="block mb-1">
+              {f.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase())}
+            </label>
+            <input
+              type={f === 'password' ? 'password' : 'text'}
+              name={f}
+              value={form[f] || ''}
+              onChange={change}
+              className="w-full border px-3 py-2 rounded text-black"
+            />
+          </div>
+        ))}
+        <button type="submit" className="button">Save</button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement PUT `/api/portal/local/me` and return full client data
- add portal page for clients to edit their profile
- test that API calls `updateClient`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686c59fc87348333a37487b2d71d0230