### PR TITLE
Implement client password reset flag

### DIFF
--- a/__tests__/clients-service.test.js
+++ b/__tests__/clients-service.test.js
@@ -88,6 +88,7 @@ test('updateClient hashes password when provided', async () => {
   expect(hashMock).toHaveBeenCalledWith('newpw');
   expect(hashedArg).toBe('newpw');
   expect(queryMock.mock.calls[0][0]).toMatch(/password_hash/);
+  expect(queryMock.mock.calls[0][0]).toMatch(/must_change_password=0/);
   expect(queryMock.mock.calls[0][1]).toContain('HASHED');
 });
 
@@ -108,7 +109,7 @@ test('resetClientPassword updates hash and returns password', async () => {
   expect(password).toBe('bmV3cGFzcw');
   expect(hashMock).toHaveBeenCalledWith('bmV3cGFzcw');
   expect(queryMock).toHaveBeenCalledWith(
-    'UPDATE clients SET password_hash=? WHERE id=?',
+    'UPDATE clients SET password_hash=?, must_change_password=1 WHERE id=?',
     ['HASH', 3]
   );
 });

--- a/migrations/20260103_add_client_password_change_flag.sql
+++ b/migrations/20260103_add_client_password_change_flag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE clients ADD COLUMN must_change_password BOOLEAN DEFAULT 0;

--- a/pages/api/portal/local/login.js
+++ b/pages/api/portal/local/login.js
@@ -5,7 +5,7 @@ import apiHandler from '../../../../lib/apiHandler.js';
 async function handler(req, res) {
   const { garage_name, vehicle_reg, password } = req.body || {};
   const [rows] = await pool.query(
-    `SELECT c.id, c.password_hash
+    `SELECT c.id, c.password_hash, c.must_change_password
        FROM clients c
        JOIN vehicles v ON v.customer_id = c.id
       WHERE c.garage_name=? AND v.licence_plate=?
@@ -18,7 +18,7 @@ async function handler(req, res) {
   const token = signToken({ client_id: rows[0].id });
   const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
   res.setHeader('Set-Cookie', `local_token=${token}; HttpOnly; Path=/; Max-Age=3600; SameSite=Strict${secure}`);
-  res.status(200).json({ ok: true });
+  res.status(200).json({ ok: true, must_change_password: !!rows[0].must_change_password });
 }
 
 export default apiHandler(handler);

--- a/services/clientsService.js
+++ b/services/clientsService.js
@@ -77,8 +77,9 @@ export async function createClient({
     `INSERT INTO clients
       (first_name, last_name, email, mobile, landline, nie_number,
        street_address, town, province, post_code,
-       garage_name, vehicle_reg, password_hash, pin_hash, pin)
-     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+       garage_name, vehicle_reg, password_hash, pin_hash, pin,
+       must_change_password)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
     [
       first_name,
       last_name,
@@ -95,6 +96,7 @@ export async function createClient({
       password_hash,
       pin_hash,
       pin,
+      0,
     ]
   );
   return {
@@ -167,7 +169,7 @@ export async function updateClient(
   ];
   if (password) {
     const password_hash = await hashPassword(password);
-    sql += ', password_hash=?';
+    sql += ', password_hash=?, must_change_password=0';
     params.push(password_hash);
   }
   sql += ' WHERE id=?';
@@ -184,7 +186,10 @@ export async function deleteClient(id) {
 export async function resetClientPassword(id) {
   const password = randomBytes(12).toString('base64url');
   const password_hash = await hashPassword(password);
-  await pool.query('UPDATE clients SET password_hash=? WHERE id=?', [password_hash, id]);
+  await pool.query(
+    'UPDATE clients SET password_hash=?, must_change_password=1 WHERE id=?',
+    [password_hash, id]
+  );
   return password;
 }
 


### PR DESCRIPTION
## Summary
- add `must_change_password` flag to clients table
- include flag in client creation, update, reset operations
- expose flag in portal login API
- update unit tests

## Testing
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686c5b5c32ac8333bc7b6656e128c4e8