### PR TITLE
Add profile shortcut on local dashboard

### DIFF
--- a/pages/local/index.js
+++ b/pages/local/index.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import { fetchVehicles } from '../../lib/vehicles';
 import { fetchInvoices } from '../../lib/invoices';
 import { fetchJobs } from '../../lib/jobs.js';
@@ -45,7 +46,10 @@ export default function LocalDashboard() {
 
   return (
     <>
-      <div className="p-4 text-right">
+      <div className="p-4 flex justify-end space-x-2">
+        <Link href="/local/profile" className="button-secondary px-4">
+          My Profile
+        </Link>
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
       </div>
       <PortalDashboard


### PR DESCRIPTION
## Summary
- import `Link` in `LocalDashboard`
- add **My Profile** link beside **Logout** button

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next: not found)*
- `npm run dev` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c61a067848333a558c9d9bc158301