### PR TITLE
Add View link for vehicles in client view

### DIFF
--- a/pages/office/clients/view/[id].js
+++ b/pages/office/clients/view/[id].js
@@ -111,6 +111,9 @@ export default function ClientViewPage() {
                     <p className="text-sm">{v.color}</p>
                   </div>
                   <div className="space-x-2">
+                    <Link href={`/office/vehicles/view/${v.id}`}>
+                      <a className="underline text-sm">View</a>
+                    </Link>
                     <Link href={`/office/vehicles/${v.id}`}> <a className="underline text-sm">Edit</a> </Link>
                     <button onClick={() => deleteVehicle(v.id)} className="underline text-red-600 text-sm">Delete</button>
                   </div>


### PR DESCRIPTION
## Summary
- add a `View` link next to vehicle edit/delete actions on the client view page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_686c63d8249c83338b1405412646f09b