### PR TITLE
Display maintenance dates in portal dashboard

### DIFF
--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -94,6 +94,8 @@ export function PortalDashboard({
             <div className="p-4">
               <h2 className="text-xl font-medium">{v.licence_plate}</h2>
               <p className="text-sm text-black">{v.make} {v.model}</p>
+              <p className="text-sm text-black">Service Date: {v.service_date || 'N/A'}</p>
+              <p className="text-sm text-black">ITV Date: {v.itv_date || 'N/A'}</p>
               <Link href={`${vehicleLinkBase}/${v.id}`} className="button-secondary mt-3 inline-block text-center">View Details</Link>
             </div>
           </Card>


### PR DESCRIPTION
## Summary
- show service and ITV dates on each vehicle tile in the portal dashboard

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686c64dcc81483338523a76dd76ef9ff