### PR TITLE
Add PortalDashboard and mileage history tests

### DIFF
--- a/__tests__/client-vehicle-view-pages.test.js
+++ b/__tests__/client-vehicle-view-pages.test.js
@@ -68,3 +68,23 @@ test('vehicle view page shows mileage history', async () => {
   await screen.findByText('Mileage History');
   expect(screen.getByText('100')).toBeInTheDocument();
 });
+
+test('vehicle view page shows no mileage entries when empty', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '7' } })
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 7 }) }) // vehicle
+    .mockResolvedValueOnce({ ok: true, json: async () => null }) // client
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }) // documents
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }) // quotes
+    .mockResolvedValueOnce({ ok: true, json: async () => [] }); // mileage
+
+  const { default: Page } = await import('../pages/office/vehicles/view/[id].js');
+  render(<Page />);
+
+  await screen.findByText('Mileage History');
+  expect(screen.getByText('No entries')).toBeInTheDocument();
+});

--- a/__tests__/portal-pdf-links.test.js
+++ b/__tests__/portal-pdf-links.test.js
@@ -83,3 +83,26 @@ test('fleet vehicle detail page shows PDF link', async () => {
   const link = await screen.findByRole('link', { name: 'View PDF' });
   expect(link).toHaveAttribute('href', '/api/quotes/11/pdf');
 });
+
+test('PortalDashboard shows vehicle service and ITV dates', async () => {
+  jest.unstable_mockModule('../lib/jobStatuses.js', () => ({
+    fetchJobStatuses: jest.fn().mockResolvedValue([])
+  }));
+  const { PortalDashboard } = await import('../components/PortalDashboard.js');
+  const vehicles = [
+    { id: 1, licence_plate: 'XYZ', make: 'Ford', model: 'Focus', service_date: '2024-05-01', itv_date: '2024-06-01' }
+  ];
+  render(
+    <PortalDashboard
+      title=""
+      requestJobPath="/"
+      vehicles={vehicles}
+      jobs={[]}
+      quotes={[]}
+      setQuotes={() => {}}
+      invoices={[]}
+    />
+  );
+  await screen.findByText('Service Date: 2024-05-01');
+  expect(screen.getByText('ITV Date: 2024-06-01')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- test PortalDashboard rendering of service/ITV dates
- test office vehicle page mileage history when no entries

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686c6580aa108333ab94111112c3839a