### PR TITLE
Fix fleet login query to include company

### DIFF
--- a/__tests__/portal-login.test.js
+++ b/__tests__/portal-login.test.js
@@ -76,12 +76,12 @@ test('fleet login succeeds with valid credentials', async () => {
     signToken: signMock,
   }));
   const { default: handler } = await import('../pages/api/portal/fleet/login.js');
-  const req = { method: 'POST', body: { garage_name: 'G2', pin: '1234' }, headers: {} };
+  const req = { method: 'POST', body: { garage_name: 'G2', company_name: 'FleetCo', pin: '1234' }, headers: {} };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn() };
   await handler(req, res);
   expect(queryMock).toHaveBeenCalledWith(
-    'SELECT id, pin_hash FROM fleets WHERE garage_name=?',
-    ['G2']
+    'SELECT id, pin_hash FROM fleets WHERE garage_name=? AND company_name=?',
+    ['G2', 'FleetCo']
   );
   expect(verifyMock).toHaveBeenCalledWith('1234', 'hash2');
   expect(signMock).toHaveBeenCalledWith({ fleet_id: 3 });
@@ -102,12 +102,12 @@ test('fleet login fails with wrong pin', async () => {
     signToken: signMock,
   }));
   const { default: handler } = await import('../pages/api/portal/fleet/login.js');
-  const req = { method: 'POST', body: { garage_name: 'G2', pin: '0000' }, headers: {} };
+  const req = { method: 'POST', body: { garage_name: 'G2', company_name: 'FleetCo', pin: '0000' }, headers: {} };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn() };
   await handler(req, res);
   expect(queryMock).toHaveBeenCalledWith(
-    'SELECT id, pin_hash FROM fleets WHERE garage_name=?',
-    ['G2']
+    'SELECT id, pin_hash FROM fleets WHERE garage_name=? AND company_name=?',
+    ['G2', 'FleetCo']
   );
   expect(verifyMock).toHaveBeenCalledWith('0000', 'hash2');
   expect(signMock).not.toHaveBeenCalled();

--- a/pages/api/portal/fleet/login.js
+++ b/pages/api/portal/fleet/login.js
@@ -3,8 +3,11 @@ import { verifyPassword, signToken } from '../../../../lib/auth';
 import apiHandler from '../../../../lib/apiHandler.js';
 
 async function handler(req, res) {
-  const { garage_name, pin } = req.body || {};
-  const [rows] = await pool.query('SELECT id, pin_hash FROM fleets WHERE garage_name=?', [garage_name]);
+  const { garage_name, company_name, pin } = req.body || {};
+  const [rows] = await pool.query(
+    'SELECT id, pin_hash FROM fleets WHERE garage_name=? AND company_name=?',
+    [garage_name, company_name]
+  );
   if (!rows.length || !(await verifyPassword(pin, rows[0].pin_hash))) {
     return res.status(401).json({ error: 'Invalid credentials' });
   }


### PR DESCRIPTION
## Summary
- check `company_name` when a fleet logs in via API
- update tests for company name requirement

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686d89c77c2c83338e8eca977a9ed198