### PR TITLE
Simplify office fleet tiles

### DIFF
--- a/pages/office/fleets/index.js
+++ b/pages/office/fleets/index.js
@@ -19,11 +19,6 @@ const FleetsPage = () => {
 
   useEffect(load, []);
 
-  const handleDelete = async id => {
-    if (!confirm('Delete this fleet?')) return;
-    await fetch(`/api/fleets/${id}`, { method: 'DELETE' });
-    load();
-  };
 
   const filtered = fleets.filter(f => {
     const q = searchQuery.toLowerCase();
@@ -58,26 +53,6 @@ const FleetsPage = () => {
                 <h2 className="font-semibold text-black dark:text-white text-lg mb-1">
                   {f.company_name}
                 </h2>
-                <p className="text-sm text-black dark:text-white">
-                  {f.account_rep || '—'}
-                </p>
-                <p className="text-sm text-black dark:text-white">
-                  {f.payment_terms || '—'}
-                </p>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Link href={`/office/fleets/view/${f.id}`} className="button px-4 text-sm">
-                    View
-                  </Link>
-                  <Link href={`/office/fleets/${f.id}`} className="button px-4 text-sm">
-                    Edit
-                  </Link>
-                  <button
-                    onClick={() => handleDelete(f.id)}
-                    className="button px-4 text-sm bg-red-600 hover:bg-red-700"
-                  >
-                    Delete
-                  </button>
-                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- simplify the fleet tiles so they only display the fleet name

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8cde450083338f5bb046f22126cc