### PR TITLE
Implement fleet quote request form

### DIFF
--- a/__tests__/fleet-request-quotation-page.test.js
+++ b/__tests__/fleet-request-quotation-page.test.js
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('fleet request quote form submits and redirects', async () => {
+  const push = jest.fn();
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ push, replace: jest.fn() })
+  }));
+  jest.unstable_mockModule('../lib/logout.js', () => ({ default: jest.fn() }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1 }) }) // fleet/me
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, licence_plate: 'XYZ' }] }) // vehicles
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 3 }) }); // createQuote
+
+  const { default: Page } = await import('../pages/fleet/request-quotation.js');
+  render(<Page />);
+
+  await screen.findByRole('option', { name: 'XYZ' });
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: '2' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Request Quote' }));
+
+  await waitFor(() => expect(push).toHaveBeenCalledWith('/fleet/quotes'));
+  expect(global.fetch).toHaveBeenLastCalledWith(
+    '/api/quotes',
+    expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fleet_id: 1, vehicle_id: '2', status: 'new' })
+    })
+  );
+});

--- a/pages/fleet/request-quotation.js
+++ b/pages/fleet/request-quotation.js
@@ -3,11 +3,14 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import logout from '../../lib/logout.js';
 import { fetchVehicles } from '../../lib/vehicles';
+import { createQuote } from '../../lib/quotes';
 
 export default function FleetRequestQuotation() {
   const router = useRouter();
   const [fleet, setFleet] = useState(null);
   const [vehicles, setVehicles] = useState([]);
+  const [vehicleId, setVehicleId] = useState('');
+  const [message, setMessage] = useState('');
 
   async function handleLogout() {
     try {
@@ -28,6 +31,16 @@ export default function FleetRequestQuotation() {
     })();
   }, [router]);
 
+  async function submit(e) {
+    e.preventDefault();
+    try {
+      await createQuote({ fleet_id: fleet.id, vehicle_id: vehicleId, status: 'new' });
+      router.push('/fleet/quotes');
+    } catch {
+      setMessage('Failed to submit request');
+    }
+  }
+
   if (!fleet) return <p className="p-8">Loading…</p>;
 
   return (
@@ -36,15 +49,22 @@ export default function FleetRequestQuotation() {
         <h1 className="text-2xl font-bold">Request Quotation</h1>
         <button onClick={handleLogout} className="button-secondary px-4">Logout</button>
       </div>
+      <Link href="/fleet/vehicles/new" className="button inline-block mb-4 mr-2">
+        Add Vehicle
+      </Link>
       <Link href="/fleet/home" className="button inline-block mb-4">
         Return to Home
       </Link>
-      <p className="mb-2">Select a vehicle to request a quote:</p>
-      <ul className="list-disc ml-6 space-y-1">
-        {vehicles.map(v => (
-          <li key={v.id}>{v.licence_plate} - {v.make} {v.model}</li>
-        ))}
-      </ul>
+      {message && <p className="text-red-500 mb-2">{message}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-sm">
+        <select value={vehicleId} onChange={e => setVehicleId(e.target.value)} className="input w-full" required>
+          <option value="">Select Vehicle</option>
+          {vehicles.map(v => (
+            <option key={v.id} value={v.id}>{v.licence_plate}</option>
+          ))}
+        </select>
+        <button type="submit" className="button">Request Quote</button>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add quote creation utilities to `FleetRequestQuotation`
- provide UI form for vehicle selection and quoting
- allow fleets to request quotes and redirect to their quotes list
- test the quote request flow

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686d9707d25c8333bd1a9896d800495a