### PR TITLE
Add job detail page

### DIFF
--- a/__tests__/job-view-page.test.js
+++ b/__tests__/job-view-page.test.js
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('job view page displays data from api', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '1' } })
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1, customer_id: 2, vehicle_id: 3, status: 'in progress', notes: 'x', assignments: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 2, first_name: 'A', last_name: 'B' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 3, licence_plate: 'XYZ' }) });
+
+  const { default: Page } = await import('../pages/office/jobs/[id].js');
+  render(<Page />);
+
+  await screen.findByText('Job #1');
+  expect(screen.getByText('A B')).toBeInTheDocument();
+  expect(screen.getByText('XYZ')).toBeInTheDocument();
+  expect(screen.getByText('in progress')).toBeInTheDocument();
+});

--- a/__tests__/office-dashboard.test.js
+++ b/__tests__/office-dashboard.test.js
@@ -34,7 +34,7 @@ test('OfficeDashboard lists todays jobs', async () => {
   render(<OfficeDashboard />);
 
   const link = await screen.findByRole('link', { name: /XYZ/ });
-  expect(link).toHaveAttribute('href', '/office/job-cards/1');
+  expect(link).toHaveAttribute('href', '/office/jobs/1');
   expect(link.textContent).toContain('Alice');
   expect(link.textContent).toContain('in progress');
 });

--- a/components/OfficeDashboard.jsx
+++ b/components/OfficeDashboard.jsx
@@ -135,7 +135,7 @@ export default function OfficeDashboard() {
           <ul className="text-sm space-y-1">
             {todayJobs.map(j => (
               <li key={j.id}>
-                <Link href={`/office/job-cards/${j.id}`} className="underline">
+                <Link href={`/office/jobs/${j.id}`} className="underline">
                   {j.licence_plate} - {j.engineers || 'Unassigned'} - {j.status}
                 </Link>
               </li>

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -18,3 +18,9 @@ export async function fetchJobsForDate(date) {
   return res.json();
 }
 
+export async function fetchJob(id) {
+  const res = await fetch(`/api/jobs/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch job');
+  return res.json();
+}
+

--- a/pages/api/jobs/[id].js
+++ b/pages/api/jobs/[id].js
@@ -1,0 +1,28 @@
+import * as service from '../../../services/jobsService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const job = await (service.getJobDetails ? service.getJobDetails(id) : service.getJobById(id));
+      if (!job) return res.status(404).json({ error: 'Not Found' });
+      return res.status(200).json(job);
+    }
+    if (req.method === 'PUT') {
+      const updated = await service.updateJob(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await service.deleteJob(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+export default apiHandler(handler);

--- a/pages/office/job-cards/index.js
+++ b/pages/office/job-cards/index.js
@@ -109,7 +109,11 @@ const JobCardsPage = () => {
           <div className="grid gap-4 sm:grid-cols-2">
           {filteredJobs.map(j => (
             <div key={j.id} className="item-card">
-              <h2 className="font-semibold mb-1">Job #{j.id}</h2>
+              <h2 className="font-semibold mb-1">
+                <Link href={`/office/jobs/${j.id}`} className="underline">
+                  Job #{j.id}
+                </Link>
+              </h2>
               <p className="text-sm">{clientMap[j.customer_id] || ''}</p>
               <p className="text-sm">{vehicleMap[j.vehicle_id]?.licence_plate || ''}</p>
               <p className="text-sm">{vehicleMap[j.vehicle_id]?.make || ''}</p>

--- a/pages/office/jobs/[id].js
+++ b/pages/office/jobs/[id].js
@@ -1,0 +1,80 @@
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import OfficeLayout from '../../../components/OfficeLayout';
+
+export default function JobViewPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [job, setJob] = useState(null);
+  const [client, setClient] = useState(null);
+  const [vehicle, setVehicle] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    async function load() {
+      try {
+        const res = await fetch(`/api/jobs/${id}`);
+        if (!res.ok) throw new Error();
+        const j = await res.json();
+        setJob(j);
+        if (j.customer_id) {
+          const c = await fetch(`/api/clients/${j.customer_id}`);
+          if (c.ok) setClient(await c.json());
+        }
+        if (j.vehicle_id) {
+          const v = await fetch(`/api/vehicles/${j.vehicle_id}`);
+          if (v.ok) setVehicle(await v.json());
+        }
+      } catch (err) {
+        setError('Failed to load');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id]);
+
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
+  if (error) return <OfficeLayout><p className="text-red-500">{error}</p></OfficeLayout>;
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Job #{id}</h1>
+      {job && (
+        <div className="space-y-2 text-black">
+          <p><strong>Status:</strong> {job.status}</p>
+          <p>
+            <strong>Client:</strong>{' '}
+            {client ? (
+              <Link href={`/office/clients/${client.id}`} className="underline">
+                {client.first_name} {client.last_name}
+              </Link>
+            ) : (
+              'N/A'
+            )}
+          </p>
+          <p>
+            <strong>Vehicle:</strong>{' '}
+            {vehicle ? (
+              <Link href={`/office/vehicles/view/${vehicle.id}`} className="underline">
+                {vehicle.licence_plate}
+              </Link>
+            ) : (
+              'N/A'
+            )}
+          </p>
+          <p>
+            <strong>Engineers:</strong>{' '}
+            {Array.isArray(job.assignments) && job.assignments.length > 0
+              ? job.assignments.map(a => a.username || a.user_id).join(', ')
+              : 'Unassigned'}
+          </p>
+          <p><strong>Notes:</strong> {job.notes || 'None'}</p>
+        </div>
+      )}
+    </OfficeLayout>
+  );
+}

--- a/pages/office/live-screen/index.js
+++ b/pages/office/live-screen/index.js
@@ -77,7 +77,11 @@ const LiveScreenPage = () => {
             </ul>
             <ul className="space-y-1 max-h-60 overflow-y-auto mt-2">
               {jobs.map(j => (
-                <li key={j.id}>Job #{j.id} – {j.status}</li>
+                <li key={j.id}>
+                  <Link href={`/office/jobs/${j.id}`} className="underline">
+                    Job #{j.id} – {j.status}
+                  </Link>
+                </li>
               ))}
             </ul>
           </div>

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -119,3 +119,18 @@ export async function getJobsForDate(date) {
   );
   return rows;
 }
+
+export async function getJobDetails(id) {
+  const job = await getJobById(id);
+  if (!job) return null;
+  const [assignments] = await pool.query(
+    `SELECT ja.id, ja.user_id, u.username, ja.assigned_at
+       FROM job_assignments ja
+  LEFT JOIN users u ON ja.user_id = u.id
+      WHERE ja.job_id=?
+      ORDER BY ja.id`,
+    [id]
+  );
+  job.assignments = assignments;
+  return job;
+}


### PR DESCRIPTION
## Summary
- implement `GET /api/jobs/[id]` endpoint and data helper
- create office job detail page showing client, vehicle and engineer info
- link job listings to the new page
- add client-side helper `fetchJob`
- test office dashboard link and job view page

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686d9f1aa1ac8333a9f4aa4f5f5e1a90