### PR TITLE
Add mandatory job statuses and protect deletion

### DIFF
--- a/__tests__/jobStatusesService.test.js
+++ b/__tests__/jobStatusesService.test.js
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('deleteJobStatus rejects for unassigned status', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ name: 'unassigned' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deleteJobStatus } = await import('../services/jobStatusesService.js');
+  await expect(deleteJobStatus(1)).rejects.toThrow('Cannot delete default status');
+  expect(queryMock).toHaveBeenCalledTimes(1);
+});
+
+test('deleteJobStatus rejects for engineer completed status', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ name: 'engineer completed' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deleteJobStatus } = await import('../services/jobStatusesService.js');
+  await expect(deleteJobStatus(2)).rejects.toThrow('Cannot delete default status');
+  expect(queryMock).toHaveBeenCalledTimes(1);
+});
+
+test('deleteJobStatus rejects for notified client for collection status', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ name: 'notified client for collection' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deleteJobStatus } = await import('../services/jobStatusesService.js');
+  await expect(deleteJobStatus(3)).rejects.toThrow('Cannot delete default status');
+  expect(queryMock).toHaveBeenCalledTimes(1);
+});

--- a/migrations/20260104_add_mandatory_job_statuses.sql
+++ b/migrations/20260104_add_mandatory_job_statuses.sql
@@ -1,0 +1,11 @@
+INSERT INTO job_statuses (name)
+SELECT 'engineer completed'
+WHERE NOT EXISTS (
+  SELECT 1 FROM job_statuses WHERE name='engineer completed'
+);
+
+INSERT INTO job_statuses (name)
+SELECT 'notified client for collection'
+WHERE NOT EXISTS (
+  SELECT 1 FROM job_statuses WHERE name='notified client for collection'
+);

--- a/services/jobStatusesService.js
+++ b/services/jobStatusesService.js
@@ -20,7 +20,12 @@ export async function deleteJobStatus(id) {
     'SELECT name FROM job_statuses WHERE id=?',
     [id]
   );
-  if (row && row.name === 'unassigned') {
+  const mandatory = [
+    'unassigned',
+    'engineer completed',
+    'notified client for collection',
+  ];
+  if (row && mandatory.includes(row.name)) {
     throw new Error('Cannot delete default status');
   }
   await pool.query('DELETE FROM job_statuses WHERE id=?', [id]);


### PR DESCRIPTION
## Summary
- add migration to populate required job statuses
- protect mandatory statuses in `deleteJobStatus`
- test deleting mandatory job statuses throws

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest module not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da28fe4548333913657545393022b