### PR TITLE
Implement invoice creation on job update

### DIFF
--- a/__tests__/jobsService.test.js
+++ b/__tests__/jobsService.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('updateJob creates invoice when notifying client for collection', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  const createInvoiceMock = jest.fn().mockResolvedValue({ id: 9 });
+  const existsMock = jest.fn().mockResolvedValue(true);
+
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({ createInvoice: createInvoiceMock }));
+  jest.unstable_mockModule('../services/jobStatusesService.js', () => ({ jobStatusExists: existsMock }));
+
+  const { updateJob } = await import('../services/jobsService.js');
+  const data = { customer_id: 4, status: 'notified client for collection' };
+  const result = await updateJob(2, data);
+
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/UPDATE jobs/),
+    [4, null, null, null, 'notified client for collection', null, 2]
+  );
+  expect(createInvoiceMock).toHaveBeenCalledWith({ job_id: 2, customer_id: 4, status: 'awaiting collection' });
+  expect(result).toEqual({ ok: true });
+});
+
+test('updateJob does not create invoice for other statuses', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  const createInvoiceMock = jest.fn();
+  const existsMock = jest.fn().mockResolvedValue(true);
+
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({ createInvoice: createInvoiceMock }));
+  jest.unstable_mockModule('../services/jobStatusesService.js', () => ({ jobStatusExists: existsMock }));
+
+  const { updateJob } = await import('../services/jobsService.js');
+  await updateJob(3, { status: 'in progress' });
+
+  expect(createInvoiceMock).not.toHaveBeenCalled();
+});
+
+test('updateJob validates status exists', async () => {
+  const existsMock = jest.fn().mockResolvedValue(false);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: jest.fn() } }));
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({ createInvoice: jest.fn() }));
+  jest.unstable_mockModule('../services/jobStatusesService.js', () => ({ jobStatusExists: existsMock }));
+
+  const { updateJob } = await import('../services/jobsService.js');
+  await expect(updateJob(1, { status: 'bad status' })).rejects.toThrow('Invalid job status');
+});

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -1,5 +1,6 @@
 import pool from '../lib/db.js';
 import { jobStatusExists } from './jobStatusesService.js';
+import { createInvoice } from './invoicesService.js';
 
 export async function getAllJobs(status) {
   const base =
@@ -61,6 +62,9 @@ export async function updateJob(id, { customer_id, vehicle_id, scheduled_start, 
     `UPDATE jobs SET customer_id=?, vehicle_id=?, scheduled_start=?, scheduled_end=?, status=?, bay=? WHERE id=?`,
     [customer_id || null, vehicle_id || null, scheduled_start || null, scheduled_end || null, status || null, bay || null, id]
   );
+  if (status === 'notified client for collection') {
+    await createInvoice({ job_id: id, customer_id: customer_id || null, status: 'awaiting collection' });
+  }
   return { ok: true };
 }
 


### PR DESCRIPTION
## Summary
- add invoice generation logic when job status is set to `notified client for collection`
- test job update behaviour and validation

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686da3d83ce48333bd2457275d0bfc23