### PR TITLE
Add invoice status management

### DIFF
--- a/__tests__/invoiceStatusesService.test.js
+++ b/__tests__/invoiceStatusesService.test.js
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('deleteInvoiceStatus rejects for issued status', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ name: 'issued' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deleteInvoiceStatus } = await import('../services/invoiceStatusesService.js');
+  await expect(deleteInvoiceStatus(1)).rejects.toThrow('Cannot delete default status');
+  expect(queryMock).toHaveBeenCalledTimes(1);
+});
+
+test('deleteInvoiceStatus rejects for paid status', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ name: 'paid' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deleteInvoiceStatus } = await import('../services/invoiceStatusesService.js');
+  await expect(deleteInvoiceStatus(2)).rejects.toThrow('Cannot delete default status');
+  expect(queryMock).toHaveBeenCalledTimes(1);
+});
+
+test('deleteInvoiceStatus rejects for unpaid status', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ name: 'unpaid' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deleteInvoiceStatus } = await import('../services/invoiceStatusesService.js');
+  await expect(deleteInvoiceStatus(3)).rejects.toThrow('Cannot delete default status');
+  expect(queryMock).toHaveBeenCalledTimes(1);
+});

--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { Card } from './Card';
 import { updateQuote } from '../lib/quotes';
 import { fetchJobStatuses } from '../lib/jobStatuses.js';
+import { fetchInvoiceStatuses } from '../lib/invoiceStatuses.js';
 
 export function computeDueDate(dateStr) {
   if (!dateStr) return null;
@@ -28,11 +29,15 @@ export function PortalDashboard({
   const [filter, setFilter] = useState('all');
   const [jobFilter, setJobFilter] = useState('all');
   const [statuses, setStatuses] = useState([]);
+  const [invoiceStatuses, setInvoiceStatuses] = useState([]);
 
   useEffect(() => {
     fetchJobStatuses()
       .then(setStatuses)
       .catch(() => setStatuses([]));
+    fetchInvoiceStatuses()
+      .then(setInvoiceStatuses)
+      .catch(() => setInvoiceStatuses([]));
   }, []);
 
   async function acceptQuote(id) {
@@ -82,7 +87,7 @@ export function PortalDashboard({
   );
 
   const invFiltered = invoices.filter(i =>
-    filter === 'all' ? true : i.status === filter
+    filter === 'all' ? true : (i.status || '').toLowerCase() === filter.toLowerCase()
   );
 
   return (
@@ -203,8 +208,11 @@ export function PortalDashboard({
           className="input mb-2"
         >
           <option value="all">All</option>
-          <option value="paid">Paid</option>
-          <option value="unpaid">Unpaid</option>
+          {invoiceStatuses.map(s => (
+            <option key={s.name} value={s.name}>
+              {s.name}
+            </option>
+          ))}
         </select>
         <ul className="list-disc ml-6">
           {invFiltered.map(inv => (

--- a/lib/invoiceStatuses.js
+++ b/lib/invoiceStatuses.js
@@ -1,0 +1,19 @@
+export async function fetchInvoiceStatuses() {
+  const res = await fetch('/api/invoice-statuses');
+  if (!res.ok) throw new Error('Failed to fetch invoice statuses');
+  return res.json();
+}
+
+export async function createInvoiceStatus(name) {
+  const res = await fetch('/api/invoice-statuses', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) throw new Error('Failed to create invoice status');
+  return res.json();
+}
+
+export async function deleteInvoiceStatus(id) {
+  await fetch(`/api/invoice-statuses/${id}`, { method: 'DELETE' });
+}

--- a/migrations/20260105_create_invoice_statuses.sql
+++ b/migrations/20260105_create_invoice_statuses.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS invoice_statuses (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(50) NOT NULL UNIQUE
+);
+
+INSERT IGNORE INTO invoice_statuses (name) VALUES
+  ('issued'),
+  ('paid'),
+  ('unpaid');

--- a/pages/api/invoice-statuses/[id].js
+++ b/pages/api/invoice-statuses/[id].js
@@ -1,0 +1,19 @@
+import { deleteInvoiceStatus } from '../../../services/invoiceStatusesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'DELETE') {
+      await deleteInvoiceStatus(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+export default apiHandler(handler);

--- a/pages/api/invoice-statuses/index.js
+++ b/pages/api/invoice-statuses/index.js
@@ -1,0 +1,17 @@
+import * as service from '../../../services/invoiceStatusesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+    if (req.method === 'GET') {
+      const statuses = await service.getInvoiceStatuses();
+      return res.status(200).json(statuses);
+    }
+    if (req.method === 'POST') {
+      const status = await service.createInvoiceStatus(req.body);
+      return res.status(201).json(status);
+    }
+    res.setHeader('Allow', ['GET','POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/services/invoiceStatusesService.js
+++ b/services/invoiceStatusesService.js
@@ -1,0 +1,37 @@
+import pool from '../lib/db.js';
+
+export async function getInvoiceStatuses() {
+  const [rows] = await pool.query(
+    'SELECT id, name FROM invoice_statuses ORDER BY id'
+  );
+  return rows;
+}
+
+export async function createInvoiceStatus({ name }) {
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO invoice_statuses (name) VALUES (?)',
+    [name]
+  );
+  return { id: insertId, name };
+}
+
+export async function deleteInvoiceStatus(id) {
+  const [[row]] = await pool.query(
+    'SELECT name FROM invoice_statuses WHERE id=?',
+    [id]
+  );
+  const mandatory = ['issued', 'paid', 'unpaid'];
+  if (row && mandatory.includes(row.name)) {
+    throw new Error('Cannot delete default status');
+  }
+  await pool.query('DELETE FROM invoice_statuses WHERE id=?', [id]);
+  return { ok: true };
+}
+
+export async function invoiceStatusExists(name) {
+  const [[row]] = await pool.query(
+    'SELECT id FROM invoice_statuses WHERE name=?',
+    [name]
+  );
+  return !!row;
+}

--- a/services/invoicesService.js
+++ b/services/invoicesService.js
@@ -1,4 +1,5 @@
 import pool from '../lib/db.js';
+import { invoiceStatusExists } from './invoiceStatusesService.js';
 
 export async function getAllInvoices() {
   const [rows] = await pool.query(
@@ -38,6 +39,9 @@ export async function getInvoiceById(id) {
 }
 
 export async function createInvoice({ job_id, customer_id, amount, due_date, status, terms }) {
+  if (status && !(await invoiceStatusExists(status))) {
+    throw new Error('Invalid invoice status');
+  }
   const [{ insertId }] = await pool.query(
     `INSERT INTO invoices
       (job_id, customer_id, amount, due_date, status, terms)
@@ -51,6 +55,9 @@ export async function updateInvoice(
   id,
   { job_id, customer_id, amount, due_date, status, terms }
 ) {
+  if (status && !(await invoiceStatusExists(status))) {
+    throw new Error('Invalid invoice status');
+  }
   await pool.query(
     `UPDATE invoices SET
        job_id=?,


### PR DESCRIPTION
## Summary
- add migration for invoice_statuses
- implement invoiceStatusesService with CRUD helpers
- validate invoice status in invoicesService
- expose `/api/invoice-statuses` endpoints
- support invoice status selection in UI
- tests for invoice status logic

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686da50d3b5c8333ad9f72d1627f6ed7