### PR TITLE
Add HR management section

### DIFF
--- a/components/HrShiftForm.jsx
+++ b/components/HrShiftForm.jsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+export default function HrShiftForm({ onSubmit }) {
+  const [form, setForm] = useState({ employee_id: '', start_time: '', end_time: '' });
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const submit = e => {
+    e.preventDefault();
+    onSubmit?.(form);
+    setForm({ employee_id: '', start_time: '', end_time: '' });
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-2 max-w-md mb-4">
+      <div>
+        <label className="block mb-1">Employee ID</label>
+        <input name="employee_id" value={form.employee_id} onChange={change} className="input w-full" />
+      </div>
+      <div>
+        <label className="block mb-1">Start Time</label>
+        <input type="datetime-local" name="start_time" value={form.start_time} onChange={change} className="input w-full" />
+      </div>
+      <div>
+        <label className="block mb-1">End Time</label>
+        <input type="datetime-local" name="end_time" value={form.end_time} onChange={change} className="input w-full" />
+      </div>
+      <button type="submit" className="button">Save</button>
+    </form>
+  );
+}

--- a/components/HrShiftTable.jsx
+++ b/components/HrShiftTable.jsx
@@ -1,0 +1,22 @@
+export default function HrShiftTable({ shifts = [] }) {
+  return (
+    <table className="mb-4 table-auto w-full">
+      <thead>
+        <tr>
+          <th className="px-2 py-1">Employee</th>
+          <th className="px-2 py-1">Start</th>
+          <th className="px-2 py-1">End</th>
+        </tr>
+      </thead>
+      <tbody>
+        {shifts.map(s => (
+          <tr key={s.id}>
+            <td className="px-2 py-1">{s.employee_id}</td>
+            <td className="px-2 py-1">{s.start_time}</td>
+            <td className="px-2 py-1">{s.end_time}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/components/OfficeLayout.jsx
+++ b/components/OfficeLayout.jsx
@@ -136,6 +136,17 @@ export default function OfficeLayout({ children }) {
             </ul>
           </div>
           <div>
+            <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">HR</h3>
+            <ul className="space-y-1">
+              <li>
+                <Link href="/office/hr" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  HR Home
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
             <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Assets</h3>
             <ul className="space-y-1">
               <li>

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -80,6 +80,9 @@ export function Sidebar() {
             <a href="/office" {...linkProps}>
               Office
             </a>
+            <a href="/office/hr" {...linkProps}>
+              HR
+            </a>
             <a href="/chat" {...linkProps}>
               Chat
             </a>

--- a/migrations/20260106_create_shifts.sql
+++ b/migrations/20260106_create_shifts.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS shifts (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  employee_id INT,
+  start_time DATETIME,
+  end_time DATETIME,
+  CONSTRAINT fk_shifts_employee FOREIGN KEY (employee_id) REFERENCES users(id)
+);

--- a/migrations/20260107_create_attendance_records.sql
+++ b/migrations/20260107_create_attendance_records.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS attendance_records (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  employee_id INT,
+  clock_in DATETIME,
+  clock_out DATETIME,
+  CONSTRAINT fk_attendance_employee FOREIGN KEY (employee_id) REFERENCES users(id)
+);

--- a/migrations/20260108_create_payroll_entries.sql
+++ b/migrations/20260108_create_payroll_entries.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS payroll_entries (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  employee_id INT,
+  amount DECIMAL(10,2),
+  pay_date DATE,
+  CONSTRAINT fk_payroll_employee FOREIGN KEY (employee_id) REFERENCES users(id)
+);

--- a/pages/api/hr/attendance/index.js
+++ b/pages/api/hr/attendance/index.js
@@ -1,0 +1,17 @@
+import * as service from '../../../../services/attendanceService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  if (req.method === 'GET') {
+    const records = await service.listAttendance();
+    return res.status(200).json(records);
+  }
+  if (req.method === 'POST') {
+    const created = await service.createAttendance(req.body || {});
+    return res.status(201).json(created);
+  }
+  res.setHeader('Allow', ['GET','POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/api/hr/holiday-requests/index.js
+++ b/pages/api/hr/holiday-requests/index.js
@@ -1,0 +1,17 @@
+import { listRequests, submitRequest } from '../../../../services/holidayRequestsService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  if (req.method === 'GET') {
+    const requests = await listRequests();
+    return res.status(200).json(requests);
+  }
+  if (req.method === 'POST') {
+    const created = await submitRequest(req.body || {});
+    return res.status(201).json(created);
+  }
+  res.setHeader('Allow', ['GET','POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/api/hr/payroll/index.js
+++ b/pages/api/hr/payroll/index.js
@@ -1,0 +1,17 @@
+import * as service from '../../../../services/payrollService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  if (req.method === 'GET') {
+    const entries = await service.listPayrollEntries();
+    return res.status(200).json(entries);
+  }
+  if (req.method === 'POST') {
+    const created = await service.createPayrollEntry(req.body || {});
+    return res.status(201).json(created);
+  }
+  res.setHeader('Allow', ['GET','POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/api/hr/shifts/index.js
+++ b/pages/api/hr/shifts/index.js
@@ -1,0 +1,17 @@
+import * as service from '../../../../services/shiftsService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  if (req.method === 'GET') {
+    const shifts = await service.listShifts();
+    return res.status(200).json(shifts);
+  }
+  if (req.method === 'POST') {
+    const created = await service.createShift(req.body || {});
+    return res.status(201).json(created);
+  }
+  res.setHeader('Allow', ['GET','POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/office/hr/attendance-overview.js
+++ b/pages/office/hr/attendance-overview.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import OfficeLayout from '../../../components/OfficeLayout.jsx';
+
+export default function AttendanceOverview() {
+  const [records, setRecords] = useState([]);
+  const [error, setError] = useState('');
+
+  const load = () => {
+    fetch('/api/hr/attendance')
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setRecords)
+      .catch(() => setError('Failed to load records'));
+  };
+
+  useEffect(load, []);
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Attendance Overview</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <table className="mb-4 table-auto w-full">
+        <thead>
+          <tr>
+            <th className="px-2 py-1">Employee</th>
+            <th className="px-2 py-1">Clock In</th>
+            <th className="px-2 py-1">Clock Out</th>
+          </tr>
+        </thead>
+        <tbody>
+          {records.map(r => (
+            <tr key={r.id}>
+              <td className="px-2 py-1">{r.employee_id}</td>
+              <td className="px-2 py-1">{r.clock_in}</td>
+              <td className="px-2 py-1">{r.clock_out}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </OfficeLayout>
+  );
+}

--- a/pages/office/hr/health-safety-info.js
+++ b/pages/office/hr/health-safety-info.js
@@ -1,0 +1,10 @@
+import OfficeLayout from '../../../components/OfficeLayout.jsx';
+
+export default function HealthSafetyInfo() {
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Health &amp; Safety Info</h1>
+      <p>Refer to company guidelines for workplace safety procedures.</p>
+    </OfficeLayout>
+  );
+}

--- a/pages/office/hr/holiday-request-management.js
+++ b/pages/office/hr/holiday-request-management.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import OfficeLayout from '../../../components/OfficeLayout.jsx';
+
+export default function HolidayRequestManagement() {
+  const [requests, setRequests] = useState([]);
+  const [error, setError] = useState('');
+
+  const load = () => {
+    fetch('/api/hr/holiday-requests')
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setRequests)
+      .catch(() => setError('Failed to load requests'));
+  };
+
+  useEffect(load, []);
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Holiday Request Management</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <table className="mb-4 table-auto w-full">
+        <thead>
+          <tr>
+            <th className="px-2 py-1">Employee</th>
+            <th className="px-2 py-1">Start</th>
+            <th className="px-2 py-1">End</th>
+            <th className="px-2 py-1">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {requests.map(r => (
+            <tr key={r.id}>
+              <td className="px-2 py-1">{r.employee_id}</td>
+              <td className="px-2 py-1">{r.start_date}</td>
+              <td className="px-2 py-1">{r.end_date}</td>
+              <td className="px-2 py-1">{r.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </OfficeLayout>
+  );
+}

--- a/pages/office/hr/index.js
+++ b/pages/office/hr/index.js
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import OfficeLayout from '../../../components/OfficeLayout.jsx';
+
+export default function HrHome() {
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">HR</h1>
+      <ul className="list-disc list-inside space-y-2">
+        <li><Link href="/office/hr/shift-scheduling" className="underline">Shift Scheduling</Link></li>
+        <li><Link href="/office/hr/holiday-request-management" className="underline">Holiday Request Management</Link></li>
+        <li><Link href="/office/hr/attendance-overview" className="underline">Attendance Overview</Link></li>
+        <li><Link href="/office/hr/health-safety-info" className="underline">Health &amp; Safety Info</Link></li>
+        <li><Link href="/office/hr/payroll-summaries" className="underline">Payroll Summaries</Link></li>
+      </ul>
+    </OfficeLayout>
+  );
+}

--- a/pages/office/hr/payroll-summaries.js
+++ b/pages/office/hr/payroll-summaries.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import OfficeLayout from '../../../components/OfficeLayout.jsx';
+
+export default function PayrollSummaries() {
+  const [entries, setEntries] = useState([]);
+  const [error, setError] = useState('');
+
+  const load = () => {
+    fetch('/api/hr/payroll')
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setEntries)
+      .catch(() => setError('Failed to load payroll entries'));
+  };
+
+  useEffect(load, []);
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Payroll Summaries</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <table className="mb-4 table-auto w-full">
+        <thead>
+          <tr>
+            <th className="px-2 py-1">Employee</th>
+            <th className="px-2 py-1">Amount</th>
+            <th className="px-2 py-1">Pay Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(e => (
+            <tr key={e.id}>
+              <td className="px-2 py-1">{e.employee_id}</td>
+              <td className="px-2 py-1">€{e.amount}</td>
+              <td className="px-2 py-1">{e.pay_date}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </OfficeLayout>
+  );
+}

--- a/pages/office/hr/shift-scheduling.js
+++ b/pages/office/hr/shift-scheduling.js
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import OfficeLayout from '../../../components/OfficeLayout.jsx';
+import HrShiftForm from '../../../components/HrShiftForm.jsx';
+import HrShiftTable from '../../../components/HrShiftTable.jsx';
+
+export default function ShiftSchedulingPage() {
+  const [shifts, setShifts] = useState([]);
+  const [error, setError] = useState('');
+
+  const load = () => {
+    fetch('/api/hr/shifts')
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setShifts)
+      .catch(() => setError('Failed to load shifts'));
+  };
+
+  useEffect(load, []);
+
+  const addShift = async data => {
+    try {
+      await fetch('/api/hr/shifts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      load();
+    } catch {
+      setError('Failed to create shift');
+    }
+  };
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Shift Scheduling</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <HrShiftForm onSubmit={addShift} />
+      <HrShiftTable shifts={shifts} />
+    </OfficeLayout>
+  );
+}

--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -1,0 +1,16 @@
+import pool from '../lib/db.js';
+
+export async function listAttendance() {
+  const [rows] = await pool.query(
+    'SELECT id, employee_id, clock_in, clock_out FROM attendance_records ORDER BY id'
+  );
+  return rows;
+}
+
+export async function createAttendance({ employee_id, clock_in, clock_out }) {
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO attendance_records (employee_id, clock_in, clock_out) VALUES (?,?,?)',
+    [employee_id || null, clock_in || null, clock_out || null]
+  );
+  return { id: insertId, employee_id, clock_in, clock_out };
+}

--- a/services/payrollService.js
+++ b/services/payrollService.js
@@ -1,0 +1,17 @@
+import pool from '../lib/db.js';
+
+export async function listPayrollEntries(employee_id) {
+  const base = 'SELECT id, employee_id, amount, pay_date FROM payroll_entries';
+  const [rows] = employee_id
+    ? await pool.query(`${base} WHERE employee_id=? ORDER BY id`, [employee_id])
+    : await pool.query(`${base} ORDER BY id`);
+  return rows;
+}
+
+export async function createPayrollEntry({ employee_id, amount, pay_date }) {
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO payroll_entries (employee_id, amount, pay_date) VALUES (?,?,?)',
+    [employee_id || null, amount || 0, pay_date || null]
+  );
+  return { id: insertId, employee_id, amount, pay_date };
+}

--- a/services/shiftsService.js
+++ b/services/shiftsService.js
@@ -1,0 +1,16 @@
+import pool from '../lib/db.js';
+
+export async function listShifts() {
+  const [rows] = await pool.query(
+    'SELECT id, employee_id, start_time, end_time FROM shifts ORDER BY id'
+  );
+  return rows;
+}
+
+export async function createShift({ employee_id, start_time, end_time }) {
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO shifts (employee_id, start_time, end_time) VALUES (?,?,?)',
+    [employee_id || null, start_time || null, end_time || null]
+  );
+  return { id: insertId, employee_id, start_time, end_time };
+}


### PR DESCRIPTION
## Summary
- implement new HR pages under office
- add HR API routes with shift/attendance/payroll/holiday request handlers
- create service modules for HR tables
- add migrations for shifts, attendance_records and payroll_entries
- include HR link in sidebars and layout navigation

## Testing
- `npm test` *(fails: Cannot find module 'node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686daa1c34f08333bd2ba7a96ef84a01