### PR TITLE
Add workflow tests for job completion and invoice status checks

### DIFF
--- a/__tests__/invoicesService.test.js
+++ b/__tests__/invoicesService.test.js
@@ -40,6 +40,7 @@ test('createInvoice inserts invoice', async () => {
   const { createInvoice } = await import('../services/invoicesService.js');
   const data = { job_id: 1, customer_id: 2, amount: 99, due_date: '2024-06-01', status: 'open' };
   const result = await createInvoice(data);
+  expect(existsMock).toHaveBeenCalledWith('open');
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/INSERT INTO invoices/),
     [1, 2, 99, '2024-06-01', 'open', null]
@@ -57,6 +58,7 @@ test('updateInvoice updates row', async () => {
   const { updateInvoice } = await import('../services/invoicesService.js');
   const data = { job_id: 4, customer_id: 5, amount: 8, due_date: '2024-07-01', status: 'paid' };
   const result = await updateInvoice(6, data);
+  expect(existsMock).toHaveBeenCalledWith('paid');
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/UPDATE invoices/),
     [4, 5, 8, '2024-07-01', 'paid', null, 6]


### PR DESCRIPTION
## Summary
- add workflow test covering engineer completion followed by office notification
- ensure invoice status existence is verified in invoice service tests

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686da82da2c88333b610526bb796d60c