### PR TITLE
Create job on quote acceptance

### DIFF
--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -42,8 +42,28 @@ export function PortalDashboard({
 
   async function acceptQuote(id) {
     await updateQuote(id, { status: 'accepted' });
+    let jobId = null;
+    const qObj = quotes.find(q => q.id === id);
+    if (qObj) {
+      const res = await fetch('/api/jobs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          customer_id: qObj.customer_id,
+          fleet_id: qObj.fleet_id,
+          vehicle_id: qObj.vehicle_id,
+        }),
+      });
+      if (res.ok) {
+        const job = await res.json();
+        jobId = job.id;
+        await updateQuote(id, { job_id: jobId });
+      }
+    }
     setQuotes(
-      quotes.map(q => (q.id === id ? { ...q, status: 'accepted' } : q))
+      quotes.map(q =>
+        q.id === id ? { ...q, status: 'accepted', job_id: jobId ?? q.job_id } : q
+      )
     );
   }
 

--- a/pages/local/vehicles/[id].js
+++ b/pages/local/vehicles/[id].js
@@ -47,7 +47,29 @@ export default function LocalVehicleDetails() {
 
   async function acceptQuote(qid) {
     await updateQuote(qid, { status: 'accepted' });
-    setQuotes(quotes.map(q => (q.id === qid ? { ...q, status: 'accepted' } : q)));
+    let jobId = null;
+    const qObj = quotes.find(q => q.id === qid);
+    if (qObj) {
+      const res = await fetch('/api/jobs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          customer_id: qObj.customer_id,
+          fleet_id: qObj.fleet_id,
+          vehicle_id: qObj.vehicle_id,
+        }),
+      });
+      if (res.ok) {
+        const job = await res.json();
+        jobId = job.id;
+        await updateQuote(qid, { job_id: jobId });
+      }
+    }
+    setQuotes(
+      quotes.map(q =>
+        q.id === qid ? { ...q, status: 'accepted', job_id: jobId ?? q.job_id } : q
+      )
+    );
   }
 
   async function rejectQuote(qid) {


### PR DESCRIPTION
## Summary
- create a job when a quote is accepted
- store returned job id on the quote

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686dac8ebd08833395d66e61195e4adf