### PR TITLE
Add engineer assignment page and show job schedules

### DIFF
--- a/components/OfficeDashboard.jsx
+++ b/components/OfficeDashboard.jsx
@@ -138,6 +138,15 @@ export default function OfficeDashboard() {
                 <Link href={`/office/jobs/${j.id}`} className="underline">
                   {j.licence_plate} - {j.engineers || 'Unassigned'} - {j.status}
                 </Link>
+                <div className="text-xs">
+                  {j.scheduled_start
+                    ? new Date(j.scheduled_start).toLocaleString()
+                    : 'N/A'}{' '}
+                  -{' '}
+                  {j.scheduled_end
+                    ? new Date(j.scheduled_end).toLocaleString()
+                    : 'N/A'}
+                </div>
               </li>
             ))}
           </ul>

--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -182,7 +182,16 @@ export function PortalDashboard({
         </select>
         <ul className="list-disc ml-6">
           {jobsFiltered.map(j => (
-            <li key={j.id}>Job #{j.id} - {j.status}</li>
+            <li key={j.id}>
+              Job #{j.id} - {j.status} -{' '}
+              {j.scheduled_start
+                ? new Date(j.scheduled_start).toLocaleString()
+                : 'N/A'}{' '}
+              to{' '}
+              {j.scheduled_end
+                ? new Date(j.scheduled_end).toLocaleString()
+                : 'N/A'}
+            </li>
           ))}
         </ul>
       </section>

--- a/pages/office/jobs/[id].js
+++ b/pages/office/jobs/[id].js
@@ -72,6 +72,21 @@ export default function JobViewPage() {
               ? job.assignments.map(a => a.username || a.user_id).join(', ')
               : 'Unassigned'}
           </p>
+          <p>
+            <strong>Scheduled:</strong>{' '}
+            {job.scheduled_start
+              ? new Date(job.scheduled_start).toLocaleString()
+              : 'N/A'}{' '}
+            -{' '}
+            {job.scheduled_end
+              ? new Date(job.scheduled_end).toLocaleString()
+              : 'N/A'}
+          </p>
+          <div className="mt-4">
+            <Link href={`/office/jobs/assign?id=${id}`} className="button">
+              Assign Engineer
+            </Link>
+          </div>
           <p><strong>Notes:</strong> {job.notes || 'None'}</p>
         </div>
       )}

--- a/pages/office/jobs/assign.js
+++ b/pages/office/jobs/assign.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import OfficeLayout from '../../../components/OfficeLayout';
+import { fetchEngineers } from '../../../lib/engineers';
+
+export default function AssignJobPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [engineers, setEngineers] = useState([]);
+  const [form, setForm] = useState({ engineer_id: '', scheduled_start: '', scheduled_end: '' });
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchEngineers()
+      .then(setEngineers)
+      .catch(() => setEngineers([]));
+  }, []);
+
+  const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`/api/jobs/${id}/assign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error();
+      router.push(`/office/jobs/${id}`);
+    } catch {
+      setError('Failed to assign engineer');
+    }
+  };
+
+  if (!id) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Assign Engineer</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-sm">
+        <div>
+          <label className="block mb-1">Engineer</label>
+          <select
+            name="engineer_id"
+            value={form.engineer_id}
+            onChange={change}
+            className="input w-full"
+            required
+          >
+            <option value="">Select…</option>
+            {engineers.map(e => (
+              <option key={e.id} value={e.id}>{e.username}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Scheduled Start</label>
+          <input
+            type="datetime-local"
+            name="scheduled_start"
+            value={form.scheduled_start}
+            onChange={change}
+            className="input w-full"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Scheduled End</label>
+          <input
+            type="datetime-local"
+            name="scheduled_end"
+            value={form.scheduled_end}
+            onChange={change}
+            className="input w-full"
+            required
+          />
+        </div>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Assign</button>
+          <Link href={`/office/jobs/${id}`} className="button-secondary">Cancel</Link>
+        </div>
+      </form>
+    </OfficeLayout>
+  );
+}

--- a/pages/office/live-screen/index.js
+++ b/pages/office/live-screen/index.js
@@ -81,6 +81,15 @@ const LiveScreenPage = () => {
                   <Link href={`/office/jobs/${j.id}`} className="underline">
                     Job #{j.id} – {j.status}
                   </Link>
+                  <div className="text-xs">
+                    {j.scheduled_start
+                      ? new Date(j.scheduled_start).toLocaleString()
+                      : 'N/A'}{' '}
+                    -{' '}
+                    {j.scheduled_end
+                      ? new Date(j.scheduled_end).toLocaleString()
+                      : 'N/A'}
+                  </div>
                 </li>
               ))}
             </ul>

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -111,7 +111,7 @@ export async function getJobsForDate(date) {
   const [rows] = await pool.query(
     `SELECT j.id, v.licence_plate,
             GROUP_CONCAT(u.username ORDER BY u.username SEPARATOR ', ') AS engineers,
-            j.status
+            j.status, j.scheduled_start, j.scheduled_end
        FROM jobs j
        JOIN vehicles v ON j.vehicle_id = v.id
   LEFT JOIN job_assignments ja ON j.id = ja.job_id


### PR DESCRIPTION
## Summary
- create an engineer assignment page for jobs
- display scheduled times in job details and job lists
- include schedule data when querying jobs for a date

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686dae791e8c8333ab43104e0879b568