### PR TITLE
Show job schedule info

### DIFF
--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -4,6 +4,7 @@ import { Card } from './Card';
 import { updateQuote } from '../lib/quotes';
 import { fetchJobStatuses } from '../lib/jobStatuses.js';
 import { fetchInvoiceStatuses } from '../lib/invoiceStatuses.js';
+import { formatDateTime } from '../lib/datetime.js';
 
 export function computeDueDate(dateStr) {
   if (!dateStr) return null;
@@ -183,14 +184,14 @@ export function PortalDashboard({
         <ul className="list-disc ml-6">
           {jobsFiltered.map(j => (
             <li key={j.id}>
-              Job #{j.id} - {j.status} -{' '}
-              {j.scheduled_start
-                ? new Date(j.scheduled_start).toLocaleString()
-                : 'N/A'}{' '}
-              to{' '}
-              {j.scheduled_end
-                ? new Date(j.scheduled_end).toLocaleString()
-                : 'N/A'}
+              Job #{j.id} - {j.status}
+              {j.scheduled_start && (
+                <> -{' '}
+                  {j.scheduled_end
+                    ? `Scheduled from ${formatDateTime(j.scheduled_start)} to ${formatDateTime(j.scheduled_end)}`
+                    : `Scheduled for ${formatDateTime(j.scheduled_start)}`}
+                </>
+              )}
             </li>
           ))}
         </ul>

--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -1,0 +1,7 @@
+export function formatDateTime(dateStr) {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return null;
+  const pad = n => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/pages/fleet/jobs/index.js
+++ b/pages/fleet/jobs/index.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import logout from '../../../lib/logout.js';
 import { fetchJobs } from '../../../lib/jobs';
+import { formatDateTime } from '../../../lib/datetime.js';
 
 export default function FleetJobs() {
   const router = useRouter();
@@ -41,7 +42,17 @@ export default function FleetJobs() {
       </Link>
       <ul className="list-disc ml-6 space-y-1">
         {jobs.map(j => (
-          <li key={j.id}>Job #{j.id} - {j.status}</li>
+          <li key={j.id}>
+            Job #{j.id} - {j.status}
+            {j.scheduled_start && (
+              <>
+                {' '}-{' '}
+                {j.scheduled_end
+                  ? `Scheduled from ${formatDateTime(j.scheduled_start)} to ${formatDateTime(j.scheduled_end)}`
+                  : `Scheduled for ${formatDateTime(j.scheduled_start)}`}
+              </>
+            )}
+          </li>
         ))}
       </ul>
     </div>

--- a/pages/local/vehicles/[id].js
+++ b/pages/local/vehicles/[id].js
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import logout from '../../../lib/logout.js';
 import { fetchJobs } from '../../../lib/jobs.js';
 import { updateQuote } from '../../../lib/quotes.js';
+import { formatDateTime } from '../../../lib/datetime.js';
 
 export default function LocalVehicleDetails() {
   const router = useRouter();
@@ -150,7 +151,16 @@ export default function LocalVehicleDetails() {
         <h2 className="text-xl font-semibold mb-2">Jobs</h2>
         <ul className="list-disc ml-6 space-y-1">
           {jobs.map(j => (
-            <li key={j.id}>Job #{j.id} - {j.status}</li>
+            <li key={j.id}>
+              Job #{j.id} - {j.status}
+              {j.scheduled_start && (
+                <> -{' '}
+                  {j.scheduled_end
+                    ? `Scheduled from ${formatDateTime(j.scheduled_start)} to ${formatDateTime(j.scheduled_end)}`
+                    : `Scheduled for ${formatDateTime(j.scheduled_start)}`}
+                </>
+              )}
+            </li>
           ))}
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- add a helper to format date/time values
- show job schedule details in the fleet job list
- display schedules on vehicle detail pages
- display schedule info in portal dashboards

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dafb1a3588333abeb1ea8fb253d57