### PR TITLE
Fix missing Link imports and unescaped string

### DIFF
--- a/components/OfficeDashboard.jsx
+++ b/components/OfficeDashboard.jsx
@@ -128,7 +128,7 @@ export default function OfficeDashboard() {
         )}
       </div>
       <div className="bg-white text-black rounded-2xl p-4 shadow mt-6">
-        <h2 className="text-lg font-semibold mb-2">Today's Jobs</h2>
+        <h2 className="text-lg font-semibold mb-2">Today&apos;s Jobs</h2>
         {todayJobs.length === 0 ? (
           <p>No jobs today.</p>
         ) : (

--- a/pages/office/job-cards/index.js
+++ b/pages/office/job-cards/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import Link from 'next/link';
 import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchQuotes, updateQuote } from '../../../lib/quotes';
 import { createInvoice } from '../../../lib/invoices';

--- a/pages/office/live-screen/index.js
+++ b/pages/office/live-screen/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import Link from 'next/link';
 import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchQuotes } from '../../../lib/quotes';
 import { fetchJobs } from '../../../lib/jobs';


### PR DESCRIPTION
## Summary
- add missing `Link` imports in office pages
- escape apostrophe in OfficeDashboard heading

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686db0e883f483339e94cd54b78449b4