### PR TITLE
Job assignment API and UI

### DIFF
--- a/__tests__/jobs-assign-api.test.js
+++ b/__tests__/jobs-assign-api.test.js
@@ -15,11 +15,18 @@ test('assign endpoint assigns engineer and updates job', async () => {
     updateJob: updateMock,
     getJobDetails: getMock,
   }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 9 }),
+  }));
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn().mockResolvedValue([[{ name: 'office' }]]) },
+  }));
   const { default: handler } = await import('../pages/api/jobs/[id]/assign.js');
   const req = {
     method: 'POST',
     query: { id: '1' },
     body: { engineer_id: 5, scheduled_start: '2024-01-02', scheduled_end: '2024-01-03' },
+    headers: {},
   };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
   await handler(req, res);
@@ -30,6 +37,37 @@ test('assign endpoint assigns engineer and updates job', async () => {
     scheduled_end: '2024-01-03',
   });
   expect(getMock).toHaveBeenCalledWith('1');
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(job);
+});
+
+test('assign endpoint sets awaiting parts status', async () => {
+  const assignMock = jest.fn();
+  const updateMock = jest.fn().mockResolvedValue({ ok: true });
+  const job = { id: 2, status: 'awaiting parts' };
+  const getMock = jest.fn().mockResolvedValue(job);
+  jest.unstable_mockModule('../services/jobsService.js', () => ({
+    assignUser: assignMock,
+    updateJob: updateMock,
+    getJobDetails: getMock,
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 10 }),
+  }));
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn().mockResolvedValue([[{ name: 'office' }]]) },
+  }));
+  const { default: handler } = await import('../pages/api/jobs/[id]/assign.js');
+  const req = {
+    method: 'POST',
+    query: { id: '2' },
+    body: { awaiting_parts: true },
+    headers: {},
+  };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(assignMock).not.toHaveBeenCalled();
+  expect(updateMock).toHaveBeenCalledWith('2', { status: 'awaiting parts' });
   expect(res.status).toHaveBeenCalledWith(200);
   expect(res.json).toHaveBeenCalledWith(job);
 });
@@ -65,4 +103,41 @@ test('assign endpoint handles errors', async () => {
   expect(res.status).toHaveBeenCalledWith(500);
   expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
   console.error.mockRestore();
+});
+
+test('assign endpoint returns 401 when not logged in', async () => {
+  jest.unstable_mockModule('../services/jobsService.js', () => ({
+    assignUser: jest.fn(),
+    updateJob: jest.fn(),
+    getJobDetails: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => null,
+  }));
+  const { default: handler } = await import('../pages/api/jobs/[id]/assign.js');
+  const req = { method: 'POST', query: { id: '3' }, body: { engineer_id: 2 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(401);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+});
+
+test('assign endpoint returns 403 for non-office role', async () => {
+  jest.unstable_mockModule('../services/jobsService.js', () => ({
+    assignUser: jest.fn(),
+    updateJob: jest.fn(),
+    getJobDetails: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/auth.js', () => ({
+    getTokenFromReq: () => ({ sub: 4 }),
+  }));
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: jest.fn().mockResolvedValue([[{ name: 'engineer' }]]) },
+  }));
+  const { default: handler } = await import('../pages/api/jobs/[id]/assign.js');
+  const req = { method: 'POST', query: { id: '3' }, body: { engineer_id: 2 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
 });

--- a/pages/api/jobs/[id]/assign.js
+++ b/pages/api/jobs/[id]/assign.js
@@ -1,17 +1,42 @@
 import { assignUser, updateJob, getJobDetails } from '../../../../services/jobsService.js';
 import apiHandler from '../../../../lib/apiHandler.js';
+import { getTokenFromReq } from '../../../../lib/auth.js';
+import pool from '../../../../lib/db.js';
 
 async function handler(req, res) {
   const { id } = req.query;
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const [[roleRow]] = await pool.query(
+    `SELECT r.name FROM user_roles ur
+       JOIN roles r ON ur.role_id = r.id
+     WHERE ur.user_id = ?`,
+    [t.sub]
+  );
+  if (!roleRow || !['office', 'admin', 'developer'].includes(roleRow.name)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   try {
     if (req.method === 'POST') {
-      const { engineer_id, scheduled_start, scheduled_end } = req.body || {};
-      await assignUser(id, engineer_id);
-      await updateJob(id, {
-        status: 'awaiting assessment',
+      const {
+        engineer_id,
         scheduled_start,
         scheduled_end,
-      });
+        awaiting_parts,
+      } = req.body || {};
+      if (awaiting_parts) {
+        await updateJob(id, { status: 'awaiting parts' });
+      } else {
+        if (!engineer_id) {
+          return res.status(400).json({ error: 'engineer_id required' });
+        }
+        await assignUser(id, engineer_id);
+        await updateJob(id, {
+          status: 'awaiting assessment',
+          scheduled_start,
+          scheduled_end,
+        });
+      }
       const job = await getJobDetails(id);
       return res.status(200).json(job);
     }

--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -1,11 +1,132 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import OfficeLayout from '../../../components/OfficeLayout';
+import { fetchJobs } from '../../../lib/jobs';
+import { fetchEngineers } from '../../../lib/engineers';
 
-const JobManagementPage = () => (
-  <OfficeLayout>
-    <h1 className="text-xl font-semibold">Job Management</h1>
-    {/* TODO: Kanban or board view */}
-  </OfficeLayout>
-);
+export default function JobManagementPage() {
+  const [jobs, setJobs] = useState([]);
+  const [engineers, setEngineers] = useState([]);
+  const [forms, setForms] = useState({});
+  const [error, setError] = useState(null);
 
-export default JobManagementPage;
+  useEffect(() => {
+    fetchJobs({ status: 'unassigned' })
+      .then(setJobs)
+      .catch(() => setJobs([]));
+    fetchEngineers()
+      .then(setEngineers)
+      .catch(() => setEngineers([]));
+  }, []);
+
+  const change = (id, field, value) =>
+    setForms(f => ({ ...f, [id]: { ...f[id], [field]: value } }));
+
+  const assign = async id => {
+    const data = forms[id] || {};
+    try {
+      const res = await fetch(`/api/jobs/${id}/assign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          engineer_id: data.engineer_id,
+          scheduled_start: data.scheduled_start,
+          scheduled_end: data.scheduled_end,
+        }),
+      });
+      if (!res.ok) throw new Error();
+      setJobs(j => j.filter(job => job.id !== id));
+    } catch {
+      setError('Failed to assign job');
+    }
+  };
+
+  const markAwaitingParts = async id => {
+    try {
+      const res = await fetch(`/api/jobs/${id}/assign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ awaiting_parts: true }),
+      });
+      if (!res.ok) throw new Error();
+      setJobs(j => j.filter(job => job.id !== id));
+    } catch {
+      setError('Failed to update job');
+    }
+  };
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-xl font-semibold mb-4">Unassigned Jobs</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      {jobs.length === 0 ? (
+        <p>No unassigned jobs.</p>
+      ) : (
+        <div className="space-y-6">
+          {jobs.map(job => {
+            const f = forms[job.id] || {};
+            return (
+              <form
+                key={job.id}
+                onSubmit={e => {
+                  e.preventDefault();
+                  assign(job.id);
+                }}
+                className="space-y-2 bg-white text-black p-4 rounded"
+              >
+                <p className="font-semibold">Job #{job.id}</p>
+                <div>
+                  <label className="block mb-1">Engineer</label>
+                  <select
+                    value={f.engineer_id || ''}
+                    onChange={e => change(job.id, 'engineer_id', e.target.value)}
+                    className="input w-full"
+                    required
+                  >
+                    <option value="">Select…</option>
+                    {engineers.map(e => (
+                      <option key={e.id} value={e.id}>
+                        {e.username}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block mb-1">Scheduled Start</label>
+                  <input
+                    type="datetime-local"
+                    value={f.scheduled_start || ''}
+                    onChange={e => change(job.id, 'scheduled_start', e.target.value)}
+                    className="input w-full"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block mb-1">Scheduled End</label>
+                  <input
+                    type="datetime-local"
+                    value={f.scheduled_end || ''}
+                    onChange={e => change(job.id, 'scheduled_end', e.target.value)}
+                    className="input w-full"
+                    required
+                  />
+                </div>
+                <div className="flex gap-2">
+                  <button type="submit" className="button px-4">
+                    Schedule
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => markAwaitingParts(job.id)}
+                    className="button-secondary px-4"
+                  >
+                    Awaiting Parts
+                  </button>
+                </div>
+              </form>
+            );
+          })}
+        </div>
+      )}
+    </OfficeLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- validate office users and add awaiting parts logic in job assignment API
- show and schedule unassigned jobs under job management page
- test new API behaviours

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686db230cf508333bc21b3d0811a4771