### PR TITLE
Add purchase order creation for jobs

### DIFF
--- a/__tests__/job-management-link.test.js
+++ b/__tests__/job-management-link.test.js
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('unassigned jobs page links to purchase orders', async () => {
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobs: jest.fn().mockResolvedValue([{ id: 9 }])
+  }));
+  jest.unstable_mockModule('../lib/engineers', () => ({
+    fetchEngineers: jest.fn().mockResolvedValue([])
+  }));
+
+  const { default: Page } = await import('../pages/office/job-management/index.js');
+  render(<Page />);
+
+  const link = await screen.findByRole('link', { name: 'Purchase Orders' });
+  expect(link).toHaveAttribute('href', '/office/jobs/9/purchase-orders');
+});

--- a/__tests__/job-purchase-orders-page.test.js
+++ b/__tests__/job-purchase-orders-page.test.js
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('job purchase orders page posts grouped orders', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '3' }, push: jest.fn() })
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [
+      { id: 1, part_number: 'A', description: 'a', supplier_id: 5 },
+      { id: 2, part_number: 'B', description: 'b', supplier_id: 6 }
+    ] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [
+      { id: 5, name: 'S1' },
+      { id: 6, name: 'S2' }
+    ] })
+    .mockResolvedValue({ ok: true, json: async () => ({}) });
+
+  const { default: Page } = await import('../pages/office/jobs/[id]/purchase-orders.js');
+  render(<Page />);
+
+  await screen.findByText('Job #3 Parts');
+
+  fireEvent.click(screen.getByLabelText('A - a'));
+  fireEvent.click(screen.getByLabelText('B - b'));
+  fireEvent.click(screen.getByText('Send Purchase Order'));
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(4));
+  expect(global.fetch.mock.calls[2][0]).toBe('/api/purchase-orders');
+  expect(global.fetch.mock.calls[3][0]).toBe('/api/purchase-orders');
+});
+
+test('request supplier quote updates job status', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '4' }, push: jest.fn() })
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValue({ ok: true, json: async () => ({}) });
+
+  const { default: Page } = await import('../pages/office/jobs/[id]/purchase-orders.js');
+  render(<Page />);
+
+  await screen.findByText('Job #4 Parts');
+  fireEvent.click(screen.getByText('Request Supplier Quote'));
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+  expect(global.fetch.mock.calls[2][0]).toBe('/api/jobs/4');
+  expect(global.fetch.mock.calls[2][1].method).toBe('PUT');
+});

--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchJobs } from '../../../lib/jobs';
 import { fetchEngineers } from '../../../lib/engineers';
@@ -121,6 +122,12 @@ export default function JobManagementPage() {
                   >
                     Awaiting Parts
                   </button>
+                  <Link
+                    href={`/office/jobs/${job.id}/purchase-orders`}
+                    className="button-secondary px-4"
+                  >
+                    Purchase Orders
+                  </Link>
                 </div>
               </form>
             );

--- a/pages/office/jobs/[id]/purchase-orders.js
+++ b/pages/office/jobs/[id]/purchase-orders.js
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import OfficeLayout from '../../../../components/OfficeLayout';
+
+export default function JobPurchaseOrdersPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [parts, setParts] = useState([]);
+  const [suppliers, setSuppliers] = useState([]);
+  const [selected, setSelected] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    async function load() {
+      setLoading(true);
+      try {
+        const [partsRes, suppRes] = await Promise.all([
+          fetch('/api/parts'),
+          fetch('/api/suppliers'),
+        ]);
+        const p = partsRes.ok ? await partsRes.json() : [];
+        const s = suppRes.ok ? await suppRes.json() : [];
+        setParts(p);
+        setSuppliers(s);
+      } catch {
+        setError('Failed to load');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id]);
+
+  const toggle = pid =>
+    setSelected(sel => ({ ...sel, [pid]: !sel[pid] }));
+
+  const supplierName = sid => suppliers.find(s => s.id === sid)?.name || 'Supplier';
+
+  const groups = parts.reduce((acc, p) => {
+    if (selected[p.id]) {
+      acc[p.supplier_id] ||= [];
+      acc[p.supplier_id].push(p);
+    }
+    return acc;
+  }, {});
+
+  const createOrders = async updateStatus => {
+    for (const [sid, items] of Object.entries(groups)) {
+      await fetch('/api/purchase-orders', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          order: { job_id: id, supplier_id: Number(sid), status: 'new' },
+          items: items.map(it => ({ part_id: it.id })),
+        }),
+      });
+    }
+    if (updateStatus) {
+      await fetch(`/api/jobs/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'awaiting supplier information' }),
+      });
+    }
+    router.push(`/office/jobs/${id}`);
+  };
+
+  if (loading) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Job #{id} Parts</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <div className="space-y-2 mb-4 text-black">
+        {parts.map(p => (
+          <label key={p.id} className="block">
+            <input
+              type="checkbox"
+              checked={!!selected[p.id]}
+              onChange={() => toggle(p.id)}
+              className="mr-2"
+            />
+            {p.part_number} - {p.description}
+          </label>
+        ))}
+      </div>
+      {Object.keys(groups).length > 0 && (
+        <div className="mb-4">
+          {Object.entries(groups).map(([sid, items]) => (
+            <div key={sid} className="mb-2 text-sm">
+              <p className="font-semibold mb-1">{supplierName(Number(sid))}</p>
+              <ul className="list-disc ml-4">
+                {items.map(it => (
+                  <li key={it.id}>{it.part_number} - {it.description}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex gap-2">
+        <button onClick={() => createOrders(false)} className="button px-4">
+          Send Purchase Order
+        </button>
+        <button onClick={() => createOrders(true)} className="button-secondary px-4">
+          Request Supplier Quote
+        </button>
+        <Link href={`/office/jobs/${id}`} className="button-secondary px-4">
+          Cancel
+        </Link>
+      </div>
+    </OfficeLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- create job purchase order page with part selection and supplier quote option
- link unassigned jobs page to the new purchase order flow
- test purchase order grouping and job status update
- test link to purchase order page in job management

## Testing
- `npm test` *(fails: Cannot find module 'node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686db513d2888333baf984385ca51d50