### PR TITLE
Add awaiting supplier information status

### DIFF
--- a/__tests__/jobStatusesService.test.js
+++ b/__tests__/jobStatusesService.test.js
@@ -28,3 +28,20 @@ test('deleteJobStatus rejects for notified client for collection status', async 
   await expect(deleteJobStatus(3)).rejects.toThrow('Cannot delete default status');
   expect(queryMock).toHaveBeenCalledTimes(1);
 });
+
+test('deleteJobStatus rejects for awaiting supplier information status', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ name: 'awaiting supplier information' }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deleteJobStatus } = await import('../services/jobStatusesService.js');
+  await expect(deleteJobStatus(4)).rejects.toThrow('Cannot delete default status');
+  expect(queryMock).toHaveBeenCalledTimes(1);
+});
+
+test('jobStatusExists returns true for awaiting supplier information', async () => {
+  const queryMock = jest.fn().mockResolvedValueOnce([[{ id: 9 }]]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { jobStatusExists } = await import('../services/jobStatusesService.js');
+  const result = await jobStatusExists('awaiting supplier information');
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/WHERE name=\?/), ['awaiting supplier information']);
+  expect(result).toBe(true);
+});

--- a/migrations/20260109_insert_awaiting_supplier_job_status.sql
+++ b/migrations/20260109_insert_awaiting_supplier_job_status.sql
@@ -1,0 +1,5 @@
+INSERT INTO job_statuses (name)
+SELECT 'awaiting supplier information'
+WHERE NOT EXISTS (
+  SELECT 1 FROM job_statuses WHERE name='awaiting supplier information'
+);

--- a/pages/office/company-settings.js
+++ b/pages/office/company-settings.js
@@ -174,7 +174,7 @@ export default function CompanySettingsPage() {
                 className="flex justify-between bg-gray-100 px-2 py-1 rounded text-black"
               >
                 <span>{s.name}</span>
-                {s.name !== 'unassigned' && (
+                {s.name !== 'unassigned' && s.name !== 'awaiting supplier information' && (
                   <button
                     onClick={() => removeStatus(s.id)}
                     className="text-red-600 hover:underline"

--- a/services/jobStatusesService.js
+++ b/services/jobStatusesService.js
@@ -24,6 +24,7 @@ export async function deleteJobStatus(id) {
     'unassigned',
     'engineer completed',
     'notified client for collection',
+    'awaiting supplier information',
   ];
   if (row && mandatory.includes(row.name)) {
     throw new Error('Cannot delete default status');


### PR DESCRIPTION
## Summary
- insert new `awaiting supplier information` status via migration
- protect this status from deletion
- hide delete button for it in the company settings page
- extend job status service tests

## Testing
- `npm test` *(fails: Cannot find module '.../jest')*

------
https://chatgpt.com/codex/tasks/task_e_686db65ba4148333b72682ff0e8282f0