### PR TITLE
Implement master search service and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ results so it can be run repeatedly without errors.
 - `/api/suppliers/[id]` - view, update and delete a supplier.
 - `/api/purchase-orders` - create purchase orders with items.
 - `/api/quote-items` - create or fetch quote items.
+- `/api/search` - search across clients, vehicles, jobs, quotes, invoices and parts.
 
 ## Invoice Generation
 
@@ -69,3 +70,10 @@ The resulting files are written to the `output/` directory as
 From the office interface you can view any quotes linked to a client or vehicle.
 Open a client or vehicle record and all associated quotes will appear beneath
 their documents list.
+
+## Master Search
+
+The header on the office layout includes a search bar that queries multiple
+entities at once. Results are grouped by type and link to the relevant
+view or edit pages. Behind the scenes the `/api/search` endpoint performs
+`LIKE` searches across clients, vehicles, jobs, quotes, invoices and parts.

--- a/__tests__/search-api.test.js
+++ b/__tests__/search-api.test.js
@@ -1,0 +1,49 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('search endpoint returns results', async () => {
+  const result = { clients: [] };
+  const searchMock = jest.fn().mockResolvedValue(result);
+  jest.unstable_mockModule('../services/masterSearchService.js', () => ({
+    masterSearch: searchMock,
+  }));
+  const { default: handler } = await import('../pages/api/search.js');
+  const req = { method: 'GET', query: { q: 'abc' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(searchMock).toHaveBeenCalledWith('abc');
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(result);
+});
+
+test('search endpoint rejects unsupported method', async () => {
+  jest.unstable_mockModule('../services/masterSearchService.js', () => ({
+    masterSearch: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/search.js');
+  const req = { method: 'POST', query: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method POST Not Allowed');
+});
+
+test('search endpoint handles errors', async () => {
+  const searchMock = jest.fn().mockRejectedValue(new Error('fail'));
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.unstable_mockModule('../services/masterSearchService.js', () => ({
+    masterSearch: searchMock,
+  }));
+  const { default: handler } = await import('../pages/api/search.js');
+  const req = { method: 'GET', query: { q: 'x' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(500);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  console.error.mockRestore();
+});

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,0 +1,6 @@
+export async function fetchSearch(q) {
+  const params = new URLSearchParams({ q });
+  const res = await fetch(`/api/search?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to search');
+  return res.json();
+}

--- a/pages/api/search.js
+++ b/pages/api/search.js
@@ -1,0 +1,14 @@
+import apiHandler from '../../lib/apiHandler.js';
+import { masterSearch } from '../../services/masterSearchService.js';
+
+async function handler(req, res) {
+  if (req.method === 'GET') {
+    const q = req.query.q || '';
+    const results = await masterSearch(q);
+    return res.status(200).json(results);
+  }
+  res.setHeader('Allow', ['GET']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/services/masterSearchService.js
+++ b/services/masterSearchService.js
@@ -1,0 +1,44 @@
+import pool from '../lib/db.js';
+import { searchParts } from './partsService.js';
+
+export async function masterSearch(query) {
+  const like = `%${query}%`;
+
+  const [clients] = await pool.query(
+    `SELECT id, first_name, last_name, email, mobile, landline
+       FROM clients
+      WHERE first_name LIKE ? OR last_name LIKE ? OR email LIKE ?
+         OR mobile LIKE ? OR landline LIKE ? OR garage_name LIKE ? OR vehicle_reg LIKE ?
+      ORDER BY first_name, last_name
+      LIMIT 20`,
+    [like, like, like, like, like, like, like]
+  );
+
+  const [vehicles] = await pool.query(
+    `SELECT id, licence_plate, make, model, vin_number
+       FROM vehicles
+      WHERE licence_plate LIKE ? OR make LIKE ? OR model LIKE ? OR vin_number LIKE ?
+      ORDER BY licence_plate
+      LIMIT 20`,
+    [like, like, like, like]
+  );
+
+  const [quotes] = await pool.query(
+    `SELECT id FROM quotes WHERE CAST(id AS CHAR) LIKE ? ORDER BY id LIMIT 20`,
+    [like]
+  );
+
+  const [jobs] = await pool.query(
+    `SELECT id FROM jobs WHERE CAST(id AS CHAR) LIKE ? ORDER BY id LIMIT 20`,
+    [like]
+  );
+
+  const [invoices] = await pool.query(
+    `SELECT id FROM invoices WHERE CAST(id AS CHAR) LIKE ? ORDER BY id LIMIT 20`,
+    [like]
+  );
+
+  const parts = await searchParts(query);
+
+  return { clients, vehicles, quotes, jobs, invoices, parts };
+}


### PR DESCRIPTION
## Summary
- search across multiple tables via `masterSearch`
- expose new `/api/search` endpoint
- add `fetchSearch` client helper
- include search bar in `OfficeLayout` header
- document master search usage
- test the search API

## Testing
- `npm test` *(fails: Cannot find module 'node_modules/.bin/jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dba04e6088333bd88a5691d29ed77