### PR TITLE
Add scheduling calendar with drag-and-drop

### DIFF
--- a/__tests__/scheduling-page.test.js
+++ b/__tests__/scheduling-page.test.js
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('jobs fetch and display in calendar and side panel', async () => {
+  const jobs = [
+    {
+      id: 1,
+      scheduled_start: '2024-05-01T10:00:00Z',
+      scheduled_end: '2024-05-01T11:00:00Z',
+      status: 'awaiting assessment',
+      assignments: [{ user_id: 2 }],
+    },
+    { id: 2, status: 'unassigned', assignments: [] },
+  ];
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobsInRange: jest.fn().mockResolvedValue(jobs),
+    assignJob: jest.fn(),
+  }));
+  const { default: Page } = await import('../pages/office/scheduling/index.js');
+  render(<Page />);
+  await screen.findByText('Job #1');
+  expect(screen.getByTestId('side-panel')).toHaveTextContent('Job #2');
+});
+
+test('dragging unassigned job calls assign endpoint', async () => {
+  const jobs = [{ id: 3, status: 'unassigned', assignments: [] }];
+  const assignMock = jest.fn().mockResolvedValue({});
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobsInRange: jest.fn().mockResolvedValue(jobs),
+    assignJob: assignMock,
+  }));
+  const { default: Page } = await import('../pages/office/scheduling/index.js');
+  render(<Page />);
+  const item = await screen.findByTestId('unassigned-job');
+  fireEvent.dragStart(item);
+  await act(() => {
+    window.__scheduleDrop({ start: new Date('2024-05-02T09:00:00Z'), end: new Date('2024-05-02T10:00:00Z') });
+    return Promise.resolve();
+  });
+  expect(assignMock).toHaveBeenCalled();
+  expect(assignMock.mock.calls[0][0]).toBe(3);
+});

--- a/components/SchedulingCalendar.jsx
+++ b/components/SchedulingCalendar.jsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { Calendar, dateFnsLocalizer, Views } from 'react-big-calendar';
+import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop/index.js';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { parse, format, startOfWeek, getDay } from 'date-fns';
+import enUS from 'date-fns/locale/en-US/index.js';
+import { fetchJobsInRange, assignJob } from '../lib/jobs.js';
+
+const locales = { 'en-US': enUS };
+const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
+const DnDCalendar = withDragAndDrop(Calendar);
+const COLORS = ['#2563eb', '#d97706', '#047857', '#b91c1c', '#6d28d9', '#be185d'];
+
+export default function SchedulingCalendar() {
+  const [events, setEvents] = useState([]);
+  const [unassigned, setUnassigned] = useState([]);
+  const [dragJob, setDragJob] = useState(null);
+
+  const load = () => {
+    const s = new Date();
+    s.setDate(s.getDate() - 7);
+    const e = new Date();
+    e.setDate(e.getDate() + 30);
+    fetchJobsInRange(s.toISOString().slice(0, 10), e.toISOString().slice(0, 10))
+      .then(jobs => {
+        setUnassigned(
+          jobs.filter(j =>
+            ['unassigned', 'awaiting parts', 'awaiting supplier information'].includes(j.status)
+          )
+        );
+        setEvents(
+          jobs
+            .filter(j => j.scheduled_start && j.scheduled_end)
+            .map(j => ({
+              id: j.id,
+              title: `Job #${j.id}`,
+              start: new Date(j.scheduled_start),
+              end: new Date(j.scheduled_end),
+              engineer_id: j.assignments?.[0]?.user_id,
+            }))
+        );
+      })
+      .catch(() => {
+        setUnassigned([]);
+        setEvents([]);
+      });
+  };
+
+  useEffect(load, []);
+
+  const eventPropGetter = event => {
+    const idx = event.engineer_id ? event.engineer_id % COLORS.length : 0;
+    return { style: { backgroundColor: COLORS[idx] } };
+  };
+
+  const onDropFromOutside = ({ start, end }) => {
+    if (!dragJob) return;
+    assignJob(dragJob.id, {
+      engineer_id: dragJob.engineer_id || 1,
+      scheduled_start: start.toISOString(),
+      scheduled_end: end.toISOString(),
+    }).finally(load);
+    setDragJob(null);
+  };
+
+  useEffect(() => {
+    window.__scheduleDrop = onDropFromOutside;
+  }, [dragJob]);
+
+  const dragFromOutsideItem = dragJob ? { title: `Job #${dragJob.id}` } : null;
+
+  return (
+    <div className="flex space-x-4">
+      <div className="w-64 bg-white text-black p-2 rounded shadow space-y-2" data-testid="side-panel">
+        <h3 className="font-semibold">Unscheduled Jobs</h3>
+        {unassigned.map(j => (
+          <div
+            key={j.id}
+            draggable
+            onDragStart={() => {
+              setDragJob(j);
+              window.__dragJob = j;
+            }}
+            className="p-1 bg-gray-200 rounded cursor-move"
+            data-testid="unassigned-job"
+          >
+            Job #{j.id}
+          </div>
+        ))}
+      </div>
+      <div className="flex-1" data-testid="calendar">
+        <DndProvider backend={HTML5Backend}>
+          <DnDCalendar
+            localizer={localizer}
+            events={events}
+            defaultView={Views.WEEK}
+            views={[Views.DAY, Views.WEEK, Views.MONTH]}
+            style={{ height: 600 }}
+            eventPropGetter={eventPropGetter}
+            onDropFromOutside={onDropFromOutside}
+            dragFromOutsideItem={() => dragFromOutsideItem}
+            selectable
+          />
+        </DndProvider>
+      </div>
+    </div>
+  );
+}

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -24,3 +24,21 @@ export async function fetchJob(id) {
   return res.json();
 }
 
+export async function fetchJobsInRange(start, end, engineer_id) {
+  const params = new URLSearchParams({ start, end });
+  if (engineer_id) params.set('engineer_id', engineer_id);
+  const res = await fetch(`/api/jobs?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch jobs');
+  return res.json();
+}
+
+export async function assignJob(id, data) {
+  const res = await fetch(`/api/jobs/${id}/assign`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to assign job');
+  return res.json();
+}
+

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
     "react-dom": "18.x",
     "socket.io": "^4.7.5",
     "nodemailer": "^6.9.8",
-    "node-cron": "^3.0.3"
+    "node-cron": "^3.0.3",
+    "react-big-calendar": "^1.11.3",
+    "date-fns": "^3.6.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/pages/api/jobs/index.js
+++ b/pages/api/jobs/index.js
@@ -3,7 +3,11 @@ import apiHandler from '../../../lib/apiHandler.js';
 
 async function handler(req, res) {
     if (req.method === 'GET') {
-      const { fleet_id, customer_id, status, date } = req.query || {};
+      const { fleet_id, customer_id, status, date, start, end, engineer_id } = req.query || {};
+      if (start && end) {
+        const jobs = await service.getJobsInRange?.(start, end, engineer_id) ?? [];
+        return res.status(200).json(jobs);
+      }
       if (date) {
         const jobs = await service.getJobsForDate?.(date) ?? [];
         return res.status(200).json(jobs);

--- a/pages/office/scheduling/index.js
+++ b/pages/office/scheduling/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import OfficeLayout from '../../../components/OfficeLayout';
+import SchedulingCalendar from '../../../components/SchedulingCalendar.jsx';
 
 const SchedulingPage = () => (
   <OfficeLayout>
     <h1 className="text-xl font-semibold">Scheduling</h1>
-    {/* TODO: Calendar component */}
+    <SchedulingCalendar />
   </OfficeLayout>
 );
 


### PR DESCRIPTION
## Summary
- install `react-big-calendar` and friends
- expose `fetchJobsInRange` and `assignJob` helpers
- extend `/api/jobs` for date range queries
- implement `SchedulingCalendar` with drag & drop
- show calendar on the scheduling page
- test scheduling page behaviour

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686dbba1624c8333a188b34c76985cc2