### PR TITLE
Add setup script and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,17 @@
    - `NEXT_PUBLIC_AWS_REGION`
    
    The S3 bucket must already exist and permit uploads.
-3. Select the Node.js version defined in `.nvmrc`: `nvm use`
-4. Install dependencies: `npm install`
-5. Make the bootstrap script executable and run it to scaffold the portal:
+3. Run `./setup.sh` to install Node.js and all JavaScript and Python
+   dependencies. This script installs `nvm` if necessary, uses Node.js `22` and
+   runs `npm ci` and `pip install -r requirements.txt`.
+4. Make the bootstrap script executable and run it to scaffold the portal:
    `chmod +x bootstrap_dev_portal.sh && ./bootstrap_dev_portal.sh`
-6. Run migrations: `npm run migrate`
+5. Run migrations: `npm run migrate`
    - This command executes every `.sql` file in the `migrations/` directory in
      order and records which have been run.
    - Running the script again safely skips already-applied migrations.
-7. Run tests and lint checks: `npm test` and `npm run lint`
-8. Start dev server: `npm run dev`
+6. Run tests and lint checks: `npm test` and `npm run lint`
+7. Start dev server: `npm run dev`
 
 ## Database
 
@@ -44,7 +45,7 @@ script `generate_invoice.py` to render this template with data in JSON format
 and produce a PDF invoice. Example usage:
 
 ```bash
-pip install docxtpl python-docx2pdf
+pip install -r requirements.txt  # or run ./setup.sh beforehand
 python generate_invoice.py invoice_data.json
 ```
 
@@ -58,7 +59,7 @@ Use the helper script `generate_quote.py` to fill this template with JSON data
 and produce a PDF quote. Example usage:
 
 ```bash
-pip install docxtpl docx2pdf
+pip install -r requirements.txt  # or run ./setup.sh beforehand
 python generate_quote.py quote_data.json
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# Python dependencies for the invoice and quote generators
+
+docxtpl>=0.16
+# docx2pdf is optional but used for PDF conversion
+# It requires Microsoft Word on Windows or uses macOS printing; on Linux it relies on LibreOffice
+# We include it here for convenience
+# unoconv can be used as a fallback and may need system packages
+# The scripts handle its absence gracefully
+# Pin a recent version
+
+docx2pdf>=0.1

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# Load nvm if installed, otherwise install it
+if ! command -v nvm >/dev/null 2>&1; then
+  echo "nvm not found, installing..."
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+  export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "$HOME/.nvm" || printf %s "$XDG_CONFIG_HOME/nvm")"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+else
+  # shellcheck source=/dev/null
+  export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "$HOME/.nvm" || printf %s "$XDG_CONFIG_HOME/nvm")"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+fi
+
+# Ensure Node.js 22 is installed and active
+nvm install 22
+nvm use 22
+
+# Install JS dependencies
+npm ci
+
+# Install Python dependencies
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi
+


### PR DESCRIPTION
## Summary
- automate environment setup with `setup.sh`
- add Python dependencies in `requirements.txt`
- update setup docs to use the new script and requirements file

## Testing
- `npm ci` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm test` *(fails: Cannot find module 'node_modules/.bin/jest')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686dc1a030308333a90f343de587c44a