### PR TITLE
Secure password endpoint

### DIFF
--- a/pages/api/clients/[id]/password.js
+++ b/pages/api/clients/[id]/password.js
@@ -1,8 +1,21 @@
 import { resetClientPassword } from '../../../../services/clientsService.js';
 import apiHandler from '../../../../lib/apiHandler.js';
+import { getTokenFromReq } from '../../../../lib/auth.js';
+import pool from '../../../../lib/db.js';
 
 async function handler(req, res) {
   const { id } = req.query;
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const [[roleRow]] = await pool.query(
+    `SELECT r.name FROM user_roles ur
+       JOIN roles r ON ur.role_id = r.id
+     WHERE ur.user_id = ?`,
+    [t.sub]
+  );
+  if (!roleRow || roleRow.name !== 'admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).end(`Method ${req.method} Not Allowed`);


### PR DESCRIPTION
## Summary
- protect client password reset API with token and admin role checks

## Testing
- `npm test` *(fails: cannot find Jest)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc77a66188333a1c372ea440e1669