### PR TITLE
Fix locale import path

### DIFF
--- a/components/SchedulingCalendar.jsx
+++ b/components/SchedulingCalendar.jsx
@@ -4,7 +4,7 @@ import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop/index.js'
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { parse, format, startOfWeek, getDay } from 'date-fns';
-import enUS from 'date-fns/locale/en-US/index.js';
+import enUS from 'date-fns/locale/en-US';
 import { fetchJobsInRange, assignJob } from '../lib/jobs.js';
 
 const locales = { 'en-US': enUS };


### PR DESCRIPTION
## Summary
- simplify enUS locale import in `SchedulingCalendar.jsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dcb1b4e9483339847d8342212b72e