### PR TITLE
Remove unused parameter from simpleXlsx

### DIFF
--- a/lib/simpleXlsx.js
+++ b/lib/simpleXlsx.js
@@ -10,7 +10,7 @@ export const utils = {
     const rows = [headers, ...data.map(row => headers.map(h => row[h] ?? ''))];
     return { rows };
   },
-  book_append_sheet(wb, sheet, name) {
+  book_append_sheet(wb, sheet) {
     wb.rows = sheet.rows;
   },
 };

--- a/pages/api/company/export-clients.js
+++ b/pages/api/company/export-clients.js
@@ -10,7 +10,7 @@ async function handler(req, res) {
   const data = await getClientsWithVehicles();
   const wb = utils.book_new();
   const ws = utils.json_to_sheet(data);
-  utils.book_append_sheet(wb, ws, 'Clients');
+  utils.book_append_sheet(wb, ws);
   const buffer = write(wb, { type: 'buffer', bookType: 'xlsx' });
   res.setHeader(
     'Content-Type',


### PR DESCRIPTION
## Summary
- drop unused `name` arg from `book_append_sheet`
- update export clients route accordingly

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_686dcc31e82483339c18a977323063cb