### PR TITLE
Limit scheduling to work week hours

### DIFF
--- a/components/SchedulingCalendar.jsx
+++ b/components/SchedulingCalendar.jsx
@@ -11,6 +11,8 @@ const locales = { 'en-US': enUS };
 const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
 const DnDCalendar = withDragAndDrop(Calendar);
 const COLORS = ['#2563eb', '#d97706', '#047857', '#b91c1c', '#6d28d9', '#be185d'];
+const MIN_TIME = new Date(1970, 0, 1, 7, 0, 0);
+const MAX_TIME = new Date(1970, 0, 1, 21, 0, 0);
 
 export default function SchedulingCalendar() {
   const [events, setEvents] = useState([]);
@@ -94,9 +96,12 @@ export default function SchedulingCalendar() {
           <DnDCalendar
             localizer={localizer}
             events={events}
-            defaultView={Views.WEEK}
-            views={[Views.DAY, Views.WEEK, Views.MONTH]}
+            defaultView={Views.WORK_WEEK}
+            views={[Views.WORK_WEEK, Views.DAY]}
             style={{ height: 600 }}
+            min={MIN_TIME}
+            max={MAX_TIME}
+            scrollToTime={MIN_TIME}
             eventPropGetter={eventPropGetter}
             onDropFromOutside={onDropFromOutside}
             dragFromOutsideItem={() => dragFromOutsideItem}


### PR DESCRIPTION
## Summary
- show scheduling calendar using `WORK_WEEK` view
- restrict displayed hours to 7am–9pm

## Testing
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686dce7a761083339368b58dfbf59d60