### PR TITLE
Fix job cards not linking to jobs and show unscheduled jobs

### DIFF
--- a/__tests__/jobsService.test.js
+++ b/__tests__/jobsService.test.js
@@ -77,3 +77,33 @@ test('engineer completes job then office notifies client for collection', async 
   );
   expect(createInvoiceMock).toHaveBeenCalledWith({ job_id: 5, customer_id: 8, status: 'awaiting collection' });
 });
+
+test('getJobsInRange returns unscheduled jobs', async () => {
+  const rows = [{
+    id: 3,
+    customer_id: 1,
+    vehicle_id: 2,
+    scheduled_start: null,
+    scheduled_end: null,
+    status: 'unassigned',
+    bay: null,
+    engineer_ids: null,
+  }];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { getJobsInRange } = await import('../services/jobsService.js');
+  const result = await getJobsInRange('2024-01-01', '2024-01-31');
+  expect(queryMock).toHaveBeenCalledWith(expect.any(String), ['2024-01-01', '2024-01-31']);
+  expect(result).toEqual([
+    {
+      id: 3,
+      customer_id: 1,
+      vehicle_id: 2,
+      scheduled_start: null,
+      scheduled_end: null,
+      status: 'unassigned',
+      bay: null,
+      assignments: [],
+    },
+  ]);
+});

--- a/__tests__/office-pages.test.js
+++ b/__tests__/office-pages.test.js
@@ -41,6 +41,21 @@ test('job cards listing shows client and vehicle info', async () => {
   expect(screen.getByText('Ford')).toBeInTheDocument();
 });
 
+test('job cards link to associated job', async () => {
+  jest.unstable_mockModule('../components/useCurrentUser.js', () => ({
+    useCurrentUser: () => ({ user: null })
+  }));
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, job_id: 7, customer_id: 1, vehicle_id: 3, total_amount: 50, status: 'job-card' }] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [] });
+  const { default: JobCardsPage } = await import('../pages/office/job-cards/index.js');
+  render(<JobCardsPage />);
+  const link = await screen.findByRole('link', { name: 'Job #7' });
+  expect(link).toHaveAttribute('href', '/office/jobs/7');
+});
+
 test('invoices listing shows client and vehicle info', async () => {
   global.fetch = jest
     .fn()

--- a/pages/office/job-cards/index.js
+++ b/pages/office/job-cards/index.js
@@ -52,7 +52,7 @@ const JobCardsPage = () => {
 
   const invoice = async job => {
     await createInvoice({
-      job_id: job.id,
+      job_id: job.job_id,
       customer_id: job.customer_id,
       amount: job.total_amount,
       due_date: new Date().toISOString().substring(0, 10),
@@ -111,8 +111,8 @@ const JobCardsPage = () => {
           {filteredJobs.map(j => (
             <div key={j.id} className="item-card">
               <h2 className="font-semibold mb-1">
-                <Link href={`/office/jobs/${j.id}`} className="underline">
-                  Job #{j.id}
+                <Link href={`/office/jobs/${j.job_id}`} className="underline">
+                  Job #{j.job_id}
                 </Link>
               </h2>
               <p className="text-sm">{clientMap[j.customer_id] || ''}</p>

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -135,7 +135,9 @@ export async function getJobsInRange(start, end, engineer_id) {
             GROUP_CONCAT(ja.user_id) AS engineer_ids
        FROM jobs j
        ${join}
-      WHERE j.scheduled_start>=? AND j.scheduled_end<=?
+      WHERE (j.scheduled_start>=? AND j.scheduled_end<=?)
+         OR j.scheduled_start IS NULL
+         OR j.scheduled_end IS NULL
    GROUP BY j.id
    ORDER BY j.scheduled_start`,
     params


### PR DESCRIPTION
## Summary
- show job card link using `job_id`
- invoice job card using `job_id`
- include unscheduled jobs in `getJobsInRange`
- add regression tests for job card linking and unscheduled jobs

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686e92ffeb908333be581eef20e2d306