### PR TITLE
Add View Job link

### DIFF
--- a/__tests__/job-management-link.test.js
+++ b/__tests__/job-management-link.test.js
@@ -21,3 +21,18 @@ test('unassigned jobs page links to purchase orders', async () => {
   const link = await screen.findByRole('link', { name: 'Purchase Orders' });
   expect(link).toHaveAttribute('href', '/office/jobs/9/purchase-orders');
 });
+
+test('unassigned jobs page links to job view page', async () => {
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobs: jest.fn().mockResolvedValue([{ id: 9 }])
+  }));
+  jest.unstable_mockModule('../lib/engineers', () => ({
+    fetchEngineers: jest.fn().mockResolvedValue([])
+  }));
+
+  const { default: Page } = await import('../pages/office/job-management/index.js');
+  render(<Page />);
+
+  const link = await screen.findByRole('link', { name: 'View Job' });
+  expect(link).toHaveAttribute('href', '/office/jobs/9');
+});

--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -123,6 +123,12 @@ export default function JobManagementPage() {
                     Awaiting Parts
                   </button>
                   <Link
+                    href={`/office/jobs/${job.id}`}
+                    className="button-secondary px-4"
+                  >
+                    View Job
+                  </Link>
+                  <Link
                     href={`/office/jobs/${job.id}/purchase-orders`}
                     className="button-secondary px-4"
                   >


### PR DESCRIPTION
## Summary
- show a link to view the job in job management page
- test the new link rendering

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686e99dc8e14833398746f9a14ad9957