### PR TITLE
Add quotes job filter

### DIFF
--- a/__tests__/quotes-api.test.js
+++ b/__tests__/quotes-api.test.js
@@ -23,6 +23,23 @@ test('quotes index returns list of quotes', async () => {
   expect(getAllMock).toHaveBeenCalledTimes(1);
 });
 
+test('quotes index returns quotes for job when job_id query provided', async () => {
+  const rows = [{ id: 10 }];
+  const jobMock = jest.fn().mockResolvedValue(rows);
+  jest.unstable_mockModule('../services/quotesService.js', () => ({
+    getQuotesByJob: jobMock,
+    getAllQuotes: jest.fn(),
+    createQuote: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/quotes/index.js');
+  const req = { method: 'GET', query: { job_id: '7' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(jobMock).toHaveBeenCalledWith('7');
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(rows);
+});
+
 test('quotes index creates quote', async () => {
   const newQuote = { id: 2 };
   const createMock = jest.fn().mockResolvedValue(newQuote);

--- a/__tests__/quotesService.test.js
+++ b/__tests__/quotesService.test.js
@@ -30,6 +30,21 @@ test('getQuoteById fetches single quote', async () => {
   expect(result).toEqual(row);
 });
 
+test('getQuotesByJob fetches quotes for job', async () => {
+  const rows = [{ id: 4 }];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  const { getQuotesByJob } = await import('../services/quotesService.js');
+  const result = await getQuotesByJob(5);
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/WHERE job_id=\?/),
+    [5]
+  );
+  expect(result).toEqual(rows);
+});
+
 test('createQuote inserts quote', async () => {
   const queryMock = jest
     .fn()

--- a/pages/api/quotes/index.js
+++ b/pages/api/quotes/index.js
@@ -3,7 +3,7 @@ import apiHandler from '../../../lib/apiHandler.js';
 
 async function handler(req, res) {
     if (req.method === 'GET') {
-      const { fleet_id, customer_id, vehicle_id } = req.query || {};
+      const { fleet_id, customer_id, vehicle_id, job_id } = req.query || {};
       if (fleet_id) {
         const rows = await service.getQuotesByFleet?.(fleet_id) ?? [];
         return res.status(200).json(rows);
@@ -14,6 +14,10 @@ async function handler(req, res) {
       }
       if (vehicle_id) {
         const rows = await service.getQuotesByVehicle?.(vehicle_id) ?? [];
+        return res.status(200).json(rows);
+      }
+      if (job_id) {
+        const rows = await service.getQuotesByJob?.(job_id) ?? [];
         return res.status(200).json(rows);
       }
       const quotes = await service.getAllQuotes();

--- a/services/quotesService.js
+++ b/services/quotesService.js
@@ -35,6 +35,15 @@ export async function getQuotesByVehicle(vehicle_id) {
   return rows;
 }
 
+export async function getQuotesByJob(job_id) {
+  const [rows] = await pool.query(
+    `SELECT id, customer_id, fleet_id, job_id, vehicle_id, fleet_vehicle_id, customer_reference, po_number, defect_description, total_amount, status, terms, created_ts
+       FROM quotes WHERE job_id=? ORDER BY id`,
+    [job_id]
+  );
+  return rows;
+}
+
 export async function getQuoteById(id) {
   const [[row]] = await pool.query(
     `SELECT id, customer_id, fleet_id, job_id, vehicle_id, fleet_vehicle_id, customer_reference, po_number, defect_description, total_amount, status, terms, created_ts


### PR DESCRIPTION
## Summary
- support querying quotes by `job_id`
- expose new `getQuotesByJob` service helper
- test job-based quote lookup in API and service layers

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_686e9cbcfcf883339b7532e0f9ac9996