### PR TITLE
Document ESLint rules in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ For a local installation, ensure the MySQL service is running and a database nam
    step succeeded or use a Docker image with these dependencies preinstalled.
 8. Start dev server: `npm run dev`
 
+## Code Style
+
+ESLint is configured using the Next.js base rules. Custom settings warn on
+unused variables, enforce single quotes and require semicolons. Run
+`npm run lint` or enable an editor integration before committing. See
+`.eslintrc.json` or the [Next.js ESLint guide](https://nextjs.org/docs/pages/building-your-application/configuring/eslint)
+for the full rule set.
+
 ## Database
 
 All database schema changes are stored as `.sql` files in the `migrations/`


### PR DESCRIPTION
## Summary
- note that ESLint uses Next.js rules
- mention custom formatting rules and lint script

## Testing
- `npm test` *(fails: cannot find module jest)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870495050308333bd35266a5339bdbb