### PR TITLE
Display plate and defect on job tiles

### DIFF
--- a/__tests__/office-pages.test.js
+++ b/__tests__/office-pages.test.js
@@ -70,3 +70,19 @@ test('invoices listing shows client and vehicle info', async () => {
   expect(screen.getByText('Ford')).toBeInTheDocument();
 });
 
+test('job management shows vehicle plate and defect', async () => {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 1, vehicle_id: 2 }] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 1, vehicle: { licence_plate: 'XYZ' }, quote: { defect_description: 'broken' } })
+    });
+  const { default: JobManagementPage } = await import('../pages/office/job-management/index.js');
+  render(<JobManagementPage />);
+  await screen.findByText('Job #1');
+  expect(screen.getByText('XYZ')).toBeInTheDocument();
+  expect(screen.getByText('broken')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- fetch full job info on Job Management page
- show vehicle plate and defect description on unassigned job tiles
- test Job Management page details

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870544ea6408333874d62a89c775a41