### PR TITLE
Allow explicit job and invoice IDs

### DIFF
--- a/__tests__/invoicesService.test.js
+++ b/__tests__/invoicesService.test.js
@@ -48,6 +48,23 @@ test('createInvoice inserts invoice', async () => {
   expect(result).toEqual({ id: 3, ...data });
 });
 
+test('createInvoice inserts with provided id', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{}]);
+  const existsMock = jest.fn().mockResolvedValue(true);
+  jest.unstable_mockModule('../lib/db.js', () => ({
+    default: { query: queryMock },
+  }));
+  jest.unstable_mockModule('../services/invoiceStatusesService.js', () => ({ invoiceStatusExists: existsMock }));
+  const { createInvoice } = await import('../services/invoicesService.js');
+  const data = { id: 5, job_id: 3, customer_id: 4, status: 'issued' };
+  const result = await createInvoice(data);
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/INSERT INTO invoices/),
+    [5, 3, 4, null, null, 'issued', null]
+  );
+  expect(result).toEqual(data);
+});
+
 test('updateInvoice updates row', async () => {
   const queryMock = jest.fn().mockResolvedValue([]);
   const existsMock = jest.fn().mockResolvedValue(true);

--- a/migrations/20251001_create_jobs.sql
+++ b/migrations/20251001_create_jobs.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS jobs (
-  id INT PRIMARY KEY AUTO_INCREMENT,
+  id INT PRIMARY KEY,
   customer_id INT,
   vehicle_id INT,
   scheduled_start DATETIME,

--- a/migrations/20251103_create_invoices.sql
+++ b/migrations/20251103_create_invoices.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS invoices (
-  id INT PRIMARY KEY AUTO_INCREMENT,
+  id INT PRIMARY KEY,
   job_id INT,
   customer_id INT,
   amount DECIMAL(10,2),


### PR DESCRIPTION
## Summary
- allow explicit `id` when creating jobs and invoices
- guard against duplicate IDs
- update migrations to drop `AUTO_INCREMENT`
- adjust invoice service tests

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6870553ea9ec83339aa9b7d24fd65412