### PR TITLE
Add status/assignment editing on job page

### DIFF
--- a/__tests__/job-view-page.test.js
+++ b/__tests__/job-view-page.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { jest } from '@jest/globals';
 
 afterEach(() => {
@@ -17,6 +17,8 @@ test('job view page displays data from api', async () => {
 
   global.fetch = jest
     .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 5, username: 'E' }] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 1, name: 'in progress' }] })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1, customer_id: 2, vehicle_id: 3, status: 'in progress', notes: 'x', assignments: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 2, first_name: 'A', last_name: 'B' }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 3, licence_plate: 'XYZ' }) });
@@ -37,6 +39,8 @@ test('job view page shows vehicle and quote details when provided', async () => 
 
   global.fetch = jest
     .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 5, username: 'E' }] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 1, name: 'awaiting assessment' }] })
     .mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -66,4 +70,34 @@ test('job view page shows vehicle and quote details when provided', async () => 
   expect(screen.getByText('Ford')).toBeInTheDocument();
   expect(screen.getByText('broken')).toBeInTheDocument();
   expect(screen.getByText('part')).toBeInTheDocument();
+});
+
+test('job view page updates job status and assignment', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '5' } })
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, username: 'E' }] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 1, name: 'unassigned' }, { id: 2, name: 'in progress' }] })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 5, status: 'unassigned', assignments: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 5, status: 'in progress', assignments: [{ user_id: 2 }] }) });
+
+  const { default: Page } = await import('../pages/office/jobs/[id].js');
+  render(<Page />);
+
+  await screen.findByText('Job #5');
+  fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'in progress' } });
+  fireEvent.change(screen.getByLabelText('Engineer'), { target: { value: '2' } });
+  fireEvent.change(screen.getByLabelText('Scheduled Start'), { target: { value: '2024-01-01T10:00' } });
+  fireEvent.change(screen.getByLabelText('Scheduled End'), { target: { value: '2024-01-01T11:00' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(6));
+  expect(global.fetch.mock.calls[3][0]).toBe('/api/jobs/5/assign');
+  expect(global.fetch.mock.calls[4][0]).toBe('/api/jobs/5');
+  expect(global.fetch.mock.calls[4][1].method).toBe('PUT');
 });


### PR DESCRIPTION
## Summary
- allow editing job status and assignments from the job view page
- fetch engineers and statuses for select boxes
- update status with `PUT /api/jobs/[id]` and assignment with `POST /api/jobs/[id]/assign`
- refresh local job state after updates
- test updated page logic

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_687056823f3c83338c020edccba1b30e