### PR TITLE
Show quote items in job management

### DIFF
--- a/__tests__/job-management-link.test.js
+++ b/__tests__/job-management-link.test.js
@@ -9,7 +9,12 @@ afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
 
 test('unassigned jobs page links to purchase orders', async () => {
   jest.unstable_mockModule('../lib/jobs', () => ({
-    fetchJobs: jest.fn().mockResolvedValue([{ id: 9 }])
+    fetchJobs: jest.fn().mockResolvedValue([{ id: 9 }]),
+    fetchJob: jest.fn().mockResolvedValue({
+      id: 9,
+      vehicle: { licence_plate: 'XYZ' },
+      quote: { defect_description: 'broken', items: [{ id: 1, description: 'part', qty: 1, partNumber: 'P1' }] }
+    })
   }));
   jest.unstable_mockModule('../lib/engineers', () => ({
     fetchEngineers: jest.fn().mockResolvedValue([])
@@ -20,11 +25,17 @@ test('unassigned jobs page links to purchase orders', async () => {
 
   const link = await screen.findByRole('link', { name: 'Purchase Orders' });
   expect(link).toHaveAttribute('href', '/office/jobs/9/purchase-orders');
+  expect(screen.getByText('part')).toBeInTheDocument();
 });
 
 test('unassigned jobs page links to job view page', async () => {
   jest.unstable_mockModule('../lib/jobs', () => ({
-    fetchJobs: jest.fn().mockResolvedValue([{ id: 9 }])
+    fetchJobs: jest.fn().mockResolvedValue([{ id: 9 }]),
+    fetchJob: jest.fn().mockResolvedValue({
+      id: 9,
+      vehicle: { licence_plate: 'XYZ' },
+      quote: { defect_description: 'broken', items: [{ id: 1, description: 'part', qty: 1 }] }
+    })
   }));
   jest.unstable_mockModule('../lib/engineers', () => ({
     fetchEngineers: jest.fn().mockResolvedValue([])
@@ -35,4 +46,5 @@ test('unassigned jobs page links to job view page', async () => {
 
   const link = await screen.findByRole('link', { name: 'View Job' });
   expect(link).toHaveAttribute('href', '/office/jobs/9');
+  expect(screen.getByText('XYZ')).toBeInTheDocument();
 });

--- a/__tests__/office-pages.test.js
+++ b/__tests__/office-pages.test.js
@@ -77,12 +77,20 @@ test('job management shows vehicle plate and defect', async () => {
     .mockResolvedValueOnce({ ok: true, json: async () => [] })
     .mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ id: 1, vehicle: { licence_plate: 'XYZ' }, quote: { defect_description: 'broken' } })
+      json: async () => ({
+        id: 1,
+        vehicle: { licence_plate: 'XYZ' },
+        quote: {
+          defect_description: 'broken',
+          items: [{ id: 5, partNumber: 'P1', description: 'part', qty: 2 }]
+        }
+      })
     });
   const { default: JobManagementPage } = await import('../pages/office/job-management/index.js');
   render(<JobManagementPage />);
   await screen.findByText('Job #1');
   expect(screen.getByText('XYZ')).toBeInTheDocument();
   expect(screen.getByText('broken')).toBeInTheDocument();
+  expect(screen.getByText('part')).toBeInTheDocument();
 });
 

--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -100,6 +100,26 @@ export default function JobManagementPage() {
                 {job.quote?.defect_description && (
                   <p className="text-sm">{job.quote.defect_description}</p>
                 )}
+                {job.quote && Array.isArray(job.quote.items) && job.quote.items.length > 0 && (
+                  <table className="text-sm w-full mb-2">
+                    <thead>
+                      <tr>
+                        <th className="text-left">Part #</th>
+                        <th className="text-left">Description</th>
+                        <th className="text-right">Qty</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {job.quote.items.map(it => (
+                        <tr key={it.id}>
+                          <td>{it.partNumber || ''}</td>
+                          <td>{it.description}</td>
+                          <td className="text-right">{it.qty}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
                 <div>
                   <label className="block mb-1">Engineer</label>
                   <select


### PR DESCRIPTION
## Summary
- get job details for unassigned jobs
- display quote items below each unassigned job
- expect quote item text in job management tests

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6870589eb53c8333852945a6aa8795ce