### PR TITLE
Update job card list to show placeholder

### DIFF
--- a/pages/office/job-cards/index.js
+++ b/pages/office/job-cards/index.js
@@ -111,9 +111,13 @@ const JobCardsPage = () => {
           {filteredJobs.map(j => (
             <div key={j.id} className="item-card">
               <h2 className="font-semibold mb-1">
-                <Link href={`/office/jobs/${j.job_id}`} className="underline">
-                  Job #{j.job_id}
-                </Link>
+                {j.job_id ? (
+                  <Link href={`/office/jobs/${j.job_id}`} className="underline">
+                    Job #{j.job_id}
+                  </Link>
+                ) : (
+                  <span>Job not created</span>
+                )}
               </h2>
               <p className="text-sm">{clientMap[j.customer_id] || ''}</p>
               <p className="text-sm">{vehicleMap[j.vehicle_id]?.licence_plate || ''}</p>


### PR DESCRIPTION
## Summary
- guard job card links with a falsy check for `job_id`
- display `Job not created` in place of the link when a job hasn't been created

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68705fae488c83338806f7615bc9e690