### PR TITLE
Enable part creation flow & quote draft persistence

### DIFF
--- a/components/PartAutocomplete.js
+++ b/components/PartAutocomplete.js
@@ -1,9 +1,17 @@
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 
-export default function PartAutocomplete({ value, onChange, onSelect }) {
+export default function PartAutocomplete({
+  value,
+  onChange,
+  onSelect,
+  description,
+  unit_cost,
+}) {
   const [term, setTerm] = useState(value || '');
   const [results, setResults] = useState([]);
   const [showAdd, setShowAdd] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     if (value !== undefined) setTerm(value);
@@ -29,19 +37,14 @@ export default function PartAutocomplete({ value, onChange, onSelect }) {
     };
   }, [term]);
 
-  const addPart = async () => {
-    try {
-      const res = await fetch('/api/parts', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ part_number: term, description: term }),
-      });
-      const created = await res.json();
-      setResults([created]);
-      setShowAdd(false);
-    } catch {
-      // ignore
-    }
+  const addPart = () => {
+    const params = new URLSearchParams();
+    params.append('part_number', term);
+    if (description) params.append('description', description);
+    if (unit_cost !== undefined && unit_cost !== '')
+      params.append('unit_cost', unit_cost);
+    params.append('redirect', '/office/quotations/new');
+    router.push(`/office/parts/new?${params.toString()}`);
   };
 
   return (

--- a/pages/office/parts/new.js
+++ b/pages/office/parts/new.js
@@ -12,6 +12,7 @@ export default function NewPartPage() {
   const [suppliers, setSuppliers] = useState([]);
   const [error, setError] = useState(null);
   const router = useRouter();
+  const { query } = router;
 
   useEffect(() => {
     fetch('/api/suppliers')
@@ -19,6 +20,16 @@ export default function NewPartPage() {
       .then(setSuppliers)
       .catch(() => setError('Failed to load suppliers'));
   }, []);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    setForm(f => ({
+      ...f,
+      part_number: query.part_number || f.part_number,
+      description: query.description || f.description,
+      unit_cost: query.unit_cost || f.unit_cost,
+    }));
+  }, [router.isReady]);
 
   const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
 
@@ -36,7 +47,8 @@ export default function NewPartPage() {
         }),
       });
       if (!res.ok) throw new Error();
-      router.push('/office/parts');
+      const dest = query.redirect || '/office/parts';
+      router.push(dest);
     } catch {
       setError('Failed to create part');
     }

--- a/pages/office/quotations/[id]/edit.js
+++ b/pages/office/quotations/[id]/edit.js
@@ -352,6 +352,8 @@ export default function EditQuotationPage() {
             <div key={i} className="grid grid-cols-10 gap-2 mb-2">
               <PartAutocomplete
                 value={it.part_number}
+                description={it.description}
+                unit_cost={it.unit_cost}
                 onChange={v => changeItem(i, 'part_number', v)}
                 onSelect={p => {
                   changeItem(i, 'part_number', p.part_number);

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -35,6 +35,24 @@ export default function NewQuotationPage() {
   const [items, setItems] = useState([emptyItem]);
   const [error, setError] = useState(null);
   const [vehicleError, setVehicleError] = useState(null);
+  const SAVE_KEY = 'quote_draft';
+
+  // load draft from localStorage
+  useEffect(() => {
+    if (!router.isReady) return;
+    const saved = localStorage.getItem(SAVE_KEY);
+    if (saved) {
+      try {
+        const data = JSON.parse(saved);
+        if (data.mode) setMode(data.mode);
+        if (data.clientName) setClientName(data.clientName);
+        if (data.form) setForm(f => ({ ...f, ...data.form }));
+        if (data.items && data.items.length) setItems(data.items);
+      } catch {
+        /* ignore parse errors */
+      }
+    }
+  }, [router.isReady]);
 
   useEffect(() => {
     setForm(f => ({ ...f, customer_id: '', fleet_id: '', vehicle_id: '' }));
@@ -156,6 +174,17 @@ export default function NewQuotationPage() {
       n || 0
     );
 
+  // persist draft to localStorage
+  useEffect(() => {
+    const data = {
+      mode,
+      clientName,
+      form,
+      items,
+    };
+    localStorage.setItem(SAVE_KEY, JSON.stringify(data));
+  }, [mode, clientName, form, items]);
+
   const submit = async e => {
     e.preventDefault();
     try {
@@ -185,6 +214,7 @@ export default function NewQuotationPage() {
           }),
         });
       }
+      localStorage.removeItem(SAVE_KEY);
       router.push('/office/quotations');
     } catch {
       setError('Failed to create quote');
@@ -313,6 +343,8 @@ export default function NewQuotationPage() {
             <div key={i} className="grid grid-cols-10 gap-2 mb-2">
               <PartAutocomplete
                 value={it.part_number}
+                description={it.description}
+                unit_cost={it.unit_cost}
                 onChange={v => changeItem(i, 'part_number', v)}
                 onSelect={p => {
                   changeItem(i, 'part_number', p.part_number);


### PR DESCRIPTION
## Summary
- allow passing description & cost through `PartAutocomplete`
- pre-fill new part form from query params and redirect after save
- persist new quote form/items in localStorage

## Testing
- `npm test` *(fails: Cannot find module 'node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6870604f402c8333a0fd1a3f7bf7bbf6