### PR TITLE
Fix quotation edit form mode switching

### DIFF
--- a/pages/office/quotations/[id]/edit.js
+++ b/pages/office/quotations/[id]/edit.js
@@ -37,11 +37,12 @@ export default function EditQuotationPage() {
   const [items, setItems] = useState([emptyItem]);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    setForm(f => ({ ...f, customer_id: '', fleet_id: '', vehicle_id: '' }));
-    setClientName('');
-    setVehicles([]);
-  }, [mode]);
+useEffect(() => {
+  if (loading) return;
+  setForm(f => ({ ...f, customer_id: '', fleet_id: '', vehicle_id: '' }));
+  setClientName('');
+  setVehicles([]);
+}, [mode]);
 
   useEffect(() => {
     fetchFleets()


### PR DESCRIPTION
## Summary
- ensure quotation edit page doesn't clear data while loading

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6870616fe8c883339d21d8d3de2c2628