### PR TITLE
Add Workshop Live menu link

### DIFF
--- a/components/OfficeLayout.jsx
+++ b/components/OfficeLayout.jsx
@@ -123,6 +123,12 @@ export default function OfficeLayout({ children }) {
                   Scheduling
                 </Link>
               </li>
+              <li>
+                <Link href="/office/live-screen" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Workshop Live
+                </Link>
+              </li>
             </ul>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- add Workshop Live page link to the Operations menu

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717fdf9e1883338d1036868d48b297