### PR TITLE
Display make and model on job management page

### DIFF
--- a/__tests__/job-management-form.test.js
+++ b/__tests__/job-management-form.test.js
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('job management form submits without scheduled end', async () => {
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobs: jest.fn().mockResolvedValue([{ id: 9 }]),
+    fetchJob: jest.fn().mockResolvedValue({
+      id: 9,
+      vehicle: { licence_plate: 'XYZ', make: 'Ford', model: 'Focus' },
+      quote: {},
+    }),
+  }));
+  jest.unstable_mockModule('../lib/engineers', () => ({
+    fetchEngineers: jest.fn().mockResolvedValue([{ id: 2, username: 'E' }]),
+  }));
+
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+
+  const { default: Page } = await import('../pages/office/job-management/index.js');
+  render(<Page />);
+
+  await screen.findByText('Job #9');
+  fireEvent.change(screen.getByLabelText('Engineer'), { target: { value: '2' } });
+  fireEvent.change(screen.getByLabelText('Scheduled Start'), { target: { value: '2024-01-02T10:00' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+  expect(global.fetch.mock.calls[0][0]).toBe('/api/jobs/9/assign');
+  const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+  expect(body.scheduled_start).toBe('2024-01-02T10:00');
+  expect(body.scheduled_end).toBeUndefined();
+});

--- a/__tests__/office-pages.test.js
+++ b/__tests__/office-pages.test.js
@@ -79,7 +79,7 @@ test('job management shows vehicle plate and defect', async () => {
       ok: true,
       json: async () => ({
         id: 1,
-        vehicle: { licence_plate: 'XYZ' },
+        vehicle: { licence_plate: 'XYZ', make: 'Ford', model: 'Focus' },
         quote: {
           defect_description: 'broken',
           items: [{ id: 5, partNumber: 'P1', description: 'part', qty: 2 }]
@@ -90,6 +90,8 @@ test('job management shows vehicle plate and defect', async () => {
   render(<JobManagementPage />);
   await screen.findByText('Job #1');
   expect(screen.getByText('XYZ')).toBeInTheDocument();
+  expect(screen.getByText('Ford')).toBeInTheDocument();
+  expect(screen.getByText('Focus')).toBeInTheDocument();
   expect(screen.getByText('broken')).toBeInTheDocument();
   expect(screen.getByText('part')).toBeInTheDocument();
 });

--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -95,7 +95,12 @@ export default function JobManagementPage() {
               >
                 <p className="font-semibold">Job #{job.id}</p>
                 {job.vehicle && (
-                  <p className="text-sm">{job.vehicle.licence_plate}</p>
+                  <>
+                    <p className="text-sm">{job.vehicle.licence_plate}</p>
+                    <p className="text-sm">
+                      {job.vehicle.make} {job.vehicle.model}
+                    </p>
+                  </>
                 )}
                 {job.quote?.defect_description && (
                   <p className="text-sm">{job.quote.defect_description}</p>
@@ -153,7 +158,6 @@ export default function JobManagementPage() {
                     value={f.scheduled_end || ''}
                     onChange={e => change(job.id, 'scheduled_end', e.target.value)}
                     className="input w-full"
-                    required
                   />
                 </div>
                 <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- show vehicle make and model on the Job Management page
- make scheduled end optional
- test for make/model display and submitting the form without a scheduled end

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_687183d8fd0c8333a1738d2167a0097e