### PR TITLE
Add additional company settings fields

### DIFF
--- a/services/companySettingsService.js
+++ b/services/companySettingsService.js
@@ -2,7 +2,8 @@ import pool from '../lib/db.js';
 
 export async function getSettings() {
   const [[row]] = await pool.query(
-    `SELECT id, logo_url, company_name, address, phone, website, social_links, terms
+    `SELECT id, logo_url, company_name, address, phone, website, social_links,
+            bank_details, invoice_terms, quote_terms, terms
        FROM company_settings ORDER BY id LIMIT 1`
   );
   return row || null;
@@ -15,13 +16,28 @@ export async function updateSettings({
   phone,
   website,
   social_links,
+  bank_details,
+  invoice_terms,
+  quote_terms,
   terms,
 }) {
   const current = await getSettings();
   if (current) {
     await pool.query(
-      `UPDATE company_settings SET logo_url=?, company_name=?, address=?, phone=?, website=?, social_links=?, terms=? WHERE id=?`,
-      [logo_url || null, company_name || null, address || null, phone || null, website || null, social_links || null, terms || null, current.id]
+      `UPDATE company_settings SET logo_url=?, company_name=?, address=?, phone=?, website=?, social_links=?, bank_details=?, invoice_terms=?, quote_terms=?, terms=? WHERE id=?`,
+      [
+        logo_url || null,
+        company_name || null,
+        address || null,
+        phone || null,
+        website || null,
+        social_links || null,
+        bank_details || null,
+        invoice_terms || null,
+        quote_terms || null,
+        terms || null,
+        current.id,
+      ]
     );
     return {
       id: current.id,
@@ -31,13 +47,27 @@ export async function updateSettings({
       phone,
       website,
       social_links,
+      bank_details,
+      invoice_terms,
+      quote_terms,
       terms,
     };
   }
   const [{ insertId }] = await pool.query(
-    `INSERT INTO company_settings (logo_url, company_name, address, phone, website, social_links, terms)
-     VALUES (?,?,?,?,?,?,?)`,
-    [logo_url || null, company_name || null, address || null, phone || null, website || null, social_links || null, terms || null]
+    `INSERT INTO company_settings (logo_url, company_name, address, phone, website, social_links, bank_details, invoice_terms, quote_terms, terms)
+     VALUES (?,?,?,?,?,?,?,?,?,?)`,
+    [
+      logo_url || null,
+      company_name || null,
+      address || null,
+      phone || null,
+      website || null,
+      social_links || null,
+      bank_details || null,
+      invoice_terms || null,
+      quote_terms || null,
+      terms || null,
+    ]
   );
   return {
     id: insertId,
@@ -47,6 +77,9 @@ export async function updateSettings({
     phone,
     website,
     social_links,
+    bank_details,
+    invoice_terms,
+    quote_terms,
     terms,
   };
 }


### PR DESCRIPTION
## Summary
- include bank and terms fields in `getSettings`
- support extra company settings fields in `updateSettings`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68719059a73c8333a0e054a2f0e708b6