### PR TITLE
Add bank and terms settings fields

### DIFF
--- a/pages/office/company-settings.js
+++ b/pages/office/company-settings.js
@@ -12,6 +12,9 @@ export default function CompanySettingsPage() {
     phone: '',
     website: '',
     social_links: '',
+    bank_details: '',
+    invoice_terms: '',
+    quote_terms: '',
     terms: '',
   });
   const [loading, setLoading] = useState(true);
@@ -108,7 +111,17 @@ export default function CompanySettingsPage() {
     </OfficeLayout>
   );
 
-  const fields = ['company_name', 'address', 'phone', 'website', 'social_links', 'terms'];
+  const fields = [
+    'company_name',
+    'address',
+    'phone',
+    'website',
+    'social_links',
+    'bank_details',
+    'invoice_terms',
+    'quote_terms',
+    'terms',
+  ];
 
   return (
     <OfficeLayout>


### PR DESCRIPTION
## Summary
- extend company settings form state with bank details, invoice terms, and quote terms
- expose the new fields in the settings form

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68719153c3b483338541d4db7e6c063c