### PR TITLE
Fix PDF term defaults

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -44,7 +44,7 @@ export async function buildQuotePdf({ company = {}, quote, client = {}, vehicle 
     renderHeader(doc, company.company_name || 'Quote', { client, vehicle });
     renderItemsTable(doc, items);
     renderFooter(doc, 'Total', quote.total_amount);
-    renderTerms(doc, quote.terms || company.terms);
+    renderTerms(doc, quote.terms || company.quote_terms || company.terms);
 
     doc.end();
   });
@@ -60,7 +60,9 @@ export async function buildInvoicePdf({ company = {}, invoice, client = {}, item
     renderHeader(doc, company.company_name || 'Invoice', { client });
     renderItemsTable(doc, items);
     renderFooter(doc, 'Total', invoice.amount);
-    renderTerms(doc, invoice.terms || company.terms);
+    const base = invoice.terms || company.invoice_terms || company.terms;
+    const text = company.bank_details ? `${base}\n\n${company.bank_details}` : base;
+    renderTerms(doc, text);
 
     doc.end();
   });

--- a/pages/api/quotes/[id]/pdf.js
+++ b/pages/api/quotes/[id]/pdf.js
@@ -58,7 +58,7 @@ export default async function handler(req, res) {
       defect_description: quote.defect_description || '',
       quoteNumber: quote.id,
       title: 'QUOTE',
-      terms: settings.terms                   // also for addTerms
+      terms: quote.terms || settings.quote_terms || settings.terms
     };
 
     // Generate PDF

--- a/services/emailService.js
+++ b/services/emailService.js
@@ -51,7 +51,7 @@ export async function sendQuoteEmail(quoteId, to) {
     vehicle: {},
     items: itemList,
     defect_description: quote.defect_description,
-    terms: quote.terms || company.terms || '',
+    terms: quote.terms || company.quote_terms || company.terms || '',
   });
   const recipient = to || clientInfo.email || clientInfo.email_1 || clientInfo.email_2;
   await transporter.sendMail({


### PR DESCRIPTION
## Summary
- set quote PDF API terms to use quote, quote_terms or fallback
- include company quote_terms and invoice_terms when rendering PDFs
- pass email quote terms with correct precedence

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6871925597b8833396da6c0625c6eb72