### PR TITLE
Use default terms for quotes/invoices

### DIFF
--- a/__tests__/invoicesService.test.js
+++ b/__tests__/invoicesService.test.js
@@ -37,15 +37,19 @@ test('createInvoice inserts invoice', async () => {
     default: { query: queryMock },
   }));
   jest.unstable_mockModule('../services/invoiceStatusesService.js', () => ({ invoiceStatusExists: existsMock }));
+  const settingsMock = jest.fn().mockResolvedValue({ invoice_terms: 'IT' });
+  jest.unstable_mockModule('../services/companySettingsService.js', () => ({
+    getSettings: settingsMock,
+  }));
   const { createInvoice } = await import('../services/invoicesService.js');
   const data = { job_id: 1, customer_id: 2, amount: 99, due_date: '2024-06-01', status: 'open' };
   const result = await createInvoice(data);
   expect(existsMock).toHaveBeenCalledWith('open');
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/INSERT INTO invoices/),
-    [1, 2, 99, '2024-06-01', 'open', null]
+    [1, 2, 99, '2024-06-01', 'open', 'IT']
   );
-  expect(result).toEqual({ id: 3, ...data });
+  expect(result).toEqual({ id: 3, ...data, terms: 'IT' });
 });
 
 test('createInvoice inserts with provided id', async () => {
@@ -55,14 +59,18 @@ test('createInvoice inserts with provided id', async () => {
     default: { query: queryMock },
   }));
   jest.unstable_mockModule('../services/invoiceStatusesService.js', () => ({ invoiceStatusExists: existsMock }));
+  const settingsMock = jest.fn().mockResolvedValue({ invoice_terms: 'IT' });
+  jest.unstable_mockModule('../services/companySettingsService.js', () => ({
+    getSettings: settingsMock,
+  }));
   const { createInvoice } = await import('../services/invoicesService.js');
   const data = { id: 5, job_id: 3, customer_id: 4, status: 'issued' };
   const result = await createInvoice(data);
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/INSERT INTO invoices/),
-    [5, 3, 4, null, null, 'issued', null]
+    [5, 3, 4, null, null, 'issued', 'IT']
   );
-  expect(result).toEqual(data);
+  expect(result).toEqual({ ...data, terms: 'IT' });
 });
 
 test('updateInvoice updates row', async () => {

--- a/__tests__/quotesService.test.js
+++ b/__tests__/quotesService.test.js
@@ -56,6 +56,10 @@ test("createQuote inserts quote", async () => {
   jest.unstable_mockModule("../lib/db.js", () => ({
     default: { query: queryMock },
   }));
+  const settingsMock = jest.fn().mockResolvedValue({ quote_terms: "QT" });
+  jest.unstable_mockModule("../services/companySettingsService.js", () => ({
+    getSettings: settingsMock,
+  }));
   const { createQuote } = await import("../services/quotesService.js");
   const data = {
     customer_id: 1,
@@ -82,9 +86,15 @@ test("createQuote inserts quote", async () => {
   expect(queryMock).toHaveBeenNthCalledWith(
     3,
     expect.stringMatching(/INSERT INTO quotes/),
-    [1, 2, 3, 3, 4, "F1", "ref", "PO123", "d", 50, "new", null],
+    [1, 2, 3, 3, 4, "F1", "ref", "PO123", "d", 50, "new", "QT"],
   );
-  expect(result).toEqual({ id: 3, ...data, fleet_vehicle_id: "F1", revision: 3 });
+  expect(result).toEqual({
+    id: 3,
+    ...data,
+    fleet_vehicle_id: "F1",
+    revision: 3,
+    terms: "QT",
+  });
 });
 
 test("updateQuote updates row", async () => {

--- a/services/invoicesService.js
+++ b/services/invoicesService.js
@@ -1,5 +1,6 @@
 import pool from '../lib/db.js';
 import { invoiceStatusExists } from './invoiceStatusesService.js';
+import { getSettings } from './companySettingsService.js';
 
 export async function getAllInvoices() {
   const [rows] = await pool.query(
@@ -41,6 +42,10 @@ export async function getInvoiceById(id) {
 export async function createInvoice({ id, job_id, customer_id, amount, due_date, status, terms }) {
   if (status && !(await invoiceStatusExists(status))) {
     throw new Error('Invalid invoice status');
+  }
+  if (terms === undefined) {
+    const settings = await getSettings();
+    terms = settings?.invoice_terms ?? null;
   }
   if (id !== undefined) {
     const [[exists]] = await pool.query('SELECT 1 FROM invoices WHERE id=?', [id]);

--- a/services/quotesService.js
+++ b/services/quotesService.js
@@ -1,4 +1,5 @@
 import pool from "../lib/db.js";
+import { getSettings } from "./companySettingsService.js";
 
 export async function getAllQuotes() {
   const [rows] = await pool.query(
@@ -89,6 +90,11 @@ export async function createQuote({
     } else {
       revision = 1;
     }
+  }
+
+  if (terms === undefined) {
+    const settings = await getSettings();
+    terms = settings?.quote_terms ?? null;
   }
 
   const [{ insertId }] = await pool.query(


### PR DESCRIPTION
## Summary
- fetch default quote terms on `createQuote`
- fetch default invoice terms on `createInvoice`
- adjust service tests for new default terms

## Testing
- `npm install` *(fails: connect ECONNREFUSED)*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_687193ad55348333b948bf64d67adfed