### PR TITLE
Remove job cards links

### DIFF
--- a/components/OfficeDashboard.jsx
+++ b/components/OfficeDashboard.jsx
@@ -99,7 +99,7 @@ export default function OfficeDashboard() {
             {statuses.map(s => (
               <li key={s.id} className="capitalize">
                 {s.name}:{' '}
-                <Link href={`/office/job-cards?status=${encodeURIComponent(s.name)}`}>{jobStatusCounts[s.name] || 0}</Link>
+                <Link href={`/office/job-management?status=${encodeURIComponent(s.name)}`}>{jobStatusCounts[s.name] || 0}</Link>
               </li>
             ))}
           </ul>

--- a/components/OfficeLayout.jsx
+++ b/components/OfficeLayout.jsx
@@ -111,12 +111,14 @@ export default function OfficeLayout({ children }) {
                   Open Quotes
                 </Link>
               </li>
+              {/*
               <li>
                 <Link href="/office/job-cards" className="flex items-center hover:underline">
                   <ArrowIcon />
                   Job Cards
                 </Link>
               </li>
+              */}
               <li>
                 <Link href="/office/scheduling" className="flex items-center hover:underline">
                   <ArrowIcon />


### PR DESCRIPTION
## Summary
- disable the Job Cards nav link in OfficeLayout
- change dashboard job status links to Job Management

## Testing
- `npm test -- -t office-pages.test.js` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6871950f8f5083338601054f2fa9e24f