### PR TITLE
Add New Invoice page and navigation

### DIFF
--- a/__tests__/invoice-new-page.test.js
+++ b/__tests__/invoice-new-page.test.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('new invoice page renders', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ push: jest.fn() })
+  }));
+
+  jest.unstable_mockModule('../lib/invoices', () => ({
+    createInvoice: jest.fn().mockResolvedValue({ id: 1 })
+  }));
+
+  const { default: NewPage } = await import('../pages/office/invoices/new.js');
+  render(<NewPage />);
+
+  expect(screen.getByText('New Invoice')).toBeInTheDocument();
+  expect(screen.getByText('Create Invoice')).toBeInTheDocument();
+});

--- a/__tests__/office-dashboard.test.js
+++ b/__tests__/office-dashboard.test.js
@@ -37,5 +37,8 @@ test('OfficeDashboard lists todays jobs', async () => {
   expect(link).toHaveAttribute('href', '/office/jobs/1');
   expect(link.textContent).toContain('Alice');
   expect(link.textContent).toContain('in progress');
+
+  const invoiceLink = screen.getByRole('link', { name: 'Create Invoice' });
+  expect(invoiceLink).toHaveAttribute('href', '/office/invoices/new');
 });
 

--- a/__tests__/office-layout-navigation.test.js
+++ b/__tests__/office-layout-navigation.test.js
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('OfficeLayout includes link to new invoice', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ push: jest.fn() })
+  }));
+  jest.unstable_mockModule('../lib/search.js', () => ({
+    fetchSearch: jest.fn().mockResolvedValue(null)
+  }));
+  jest.unstable_mockModule('../lib/logout.js', () => ({
+    default: jest.fn().mockResolvedValue()
+  }));
+
+  const { default: OfficeLayout } = await import('../components/OfficeLayout.jsx');
+  render(
+    <OfficeLayout>
+      <div>content</div>
+    </OfficeLayout>
+  );
+
+  const link = screen.getByRole('link', { name: 'New Invoice' });
+  expect(link).toHaveAttribute('href', '/office/invoices/new');
+});

--- a/components/OfficeDashboard.jsx
+++ b/components/OfficeDashboard.jsx
@@ -84,6 +84,7 @@ export default function OfficeDashboard() {
       <div className="flex flex-wrap justify-center gap-4">
         <Link href="/office/quotations/new" className="button px-8 text-lg">Create Quote</Link>
         <Link href="/office/jobs/new" className="button px-8 text-lg">New Job</Link>
+        <Link href="/office/invoices/new" className="button px-8 text-lg">Create Invoice</Link>
         <Link href="/office/invoices?status=unpaid" className="button px-8 text-lg">Pay Invoice</Link>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/components/OfficeLayout.jsx
+++ b/components/OfficeLayout.jsx
@@ -71,6 +71,12 @@ export default function OfficeLayout({ children }) {
                 </Link>
               </li>
               <li>
+                <Link href="/office/invoices/new" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  New Invoice
+                </Link>
+              </li>
+              <li>
                 <Link href="/office/invoices" className="flex items-center hover:underline">
                   <ArrowIcon />
                   Invoices

--- a/pages/office/invoices/new.js
+++ b/pages/office/invoices/new.js
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import OfficeLayout from '../../../components/OfficeLayout';
+import ClientAutocomplete from '../../../components/ClientAutocomplete';
+import { createInvoice } from '../../../lib/invoices';
+
+export default function NewInvoicePage() {
+  const router = useRouter();
+  const [clientName, setClientName] = useState('');
+  const [form, setForm] = useState({
+    customer_id: '',
+    amount: '',
+    due_date: '',
+    status: 'issued',
+    notes: '',
+    terms: ''
+  });
+  const [error, setError] = useState(null);
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      await createInvoice({
+        customer_id: form.customer_id || null,
+        amount: Number(form.amount) || 0,
+        due_date: form.due_date || null,
+        status: form.status || 'issued',
+        notes: form.notes || null,
+        terms: form.terms || null
+      });
+      router.push('/office/invoices');
+    } catch {
+      setError('Failed to create invoice');
+    }
+  };
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">New Invoice</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block mb-1">Client</label>
+          <ClientAutocomplete
+            value={clientName}
+            onChange={v => {
+              setClientName(v);
+              setForm(f => ({ ...f, customer_id: '' }));
+            }}
+            onSelect={c => {
+              setClientName(`${c.first_name || ''} ${c.last_name || ''}`.trim());
+              setForm(f => ({ ...f, customer_id: c.id }));
+            }}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Amount (€)</label>
+          <input
+            type="number"
+            className="input w-full"
+            value={form.amount}
+            onChange={e => setForm(f => ({ ...f, amount: e.target.value }))}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Due Date</label>
+          <input
+            type="date"
+            className="input w-full"
+            value={form.due_date}
+            onChange={e => setForm(f => ({ ...f, due_date: e.target.value }))}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Status</label>
+          <select
+            className="input w-full"
+            value={form.status}
+            onChange={e => setForm(f => ({ ...f, status: e.target.value }))}
+          >
+            <option value="issued">Issued</option>
+            <option value="unpaid">Unpaid</option>
+            <option value="paid">Paid</option>
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Notes</label>
+          <textarea
+            className="input w-full"
+            value={form.notes}
+            onChange={e => setForm(f => ({ ...f, notes: e.target.value }))}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Terms</label>
+          <textarea
+            className="input w-full"
+            value={form.terms}
+            onChange={e => setForm(f => ({ ...f, terms: e.target.value }))}
+          />
+        </div>
+        <div className="flex gap-2">
+          <button type="submit" className="button">Create Invoice</button>
+          <button type="button" onClick={() => router.back()} className="button-secondary">Cancel</button>
+        </div>
+      </form>
+    </OfficeLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add simplified invoice creation page
- link "Create Invoice" from dashboard
- add "New Invoice" link in sidebar nav
- ensure navigation updates covered by tests
- test that invoice form page renders

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871a2411aac8333a7d4e4dc713702d3