### PR TITLE
Improve offline setup handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@
    The S3 bucket must already exist and permit uploads.
 3. Install the Python dependencies:
    `pip install -r requirements.txt`
-4. Run `./setup.sh` to install Node.js and all JavaScript dependencies. This
-   script installs `nvm` if necessary, runs `nvm install 22` then `nvm use 22`,
-   and executes `npm ci`. If your environment lacks internet access, make sure
-   Node 22 and the packages listed in `package-lock.json` are already downloaded
-   and available locally or use a prebuilt Docker image that contains them.
+4. Run `./setup.sh` to install Node.js and all JavaScript dependencies.
+   The script installs `nvm` if needed, runs `nvm install 22` then `nvm use 22`,
+   and executes `npm ci`. If the online installation of `nvm` fails it will look
+   for a local copy at `scripts/nvm-install.sh` and use that instead. When
+   preparing an offline environment download Node 22 and all packages listed in
+   `package-lock.json` in advance so `npm ci` can run with the cached files.
 5. Make the bootstrap script executable and run it to scaffold the portal:
    `chmod +x bootstrap_dev_portal.sh && ./bootstrap_dev_portal.sh`
 

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,18 @@ set -e
 # Load nvm if installed, otherwise install it
 if ! command -v nvm >/dev/null 2>&1; then
   echo "nvm not found, installing..."
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+  if curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash; then
+    echo "nvm installed via network"
+  else
+    echo "Failed to download nvm. Checking for local copy..."
+    if [ -f scripts/nvm-install.sh ]; then
+      bash scripts/nvm-install.sh
+    else
+      echo "No local nvm installer found at scripts/nvm-install.sh" >&2
+      echo "Please install nvm manually and re-run this script." >&2
+      exit 1
+    fi
+  fi
   export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "$HOME/.nvm" || printf %s "$XDG_CONFIG_HOME/nvm")"
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 else


### PR DESCRIPTION
## Summary
- handle nvm install failures in `setup.sh`
- explain offline setup requirements in README

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6871a95f5c78833393468a633d5fdd77