### PR TITLE
Remove unused imports

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import logout from '../lib/logout.js';
 import Head from 'next/head';


### PR DESCRIPTION
## Summary
- fix ESLint warning by removing an unused React import in dashboard page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871b3bab59c8333876fbfa631824fd8