### PR TITLE
Fix Next.js script loading

### DIFF
--- a/pages/chat.js
+++ b/pages/chat.js
@@ -136,7 +136,7 @@ export default function Chat() {
         <Header />
         <Script
           src="/api/socket-io/socket.io.js"
-          strategy="beforeInteractive"
+          strategy="afterInteractive"
         />
         <main className="p-8 space-y-4">
           <Head>


### PR DESCRIPTION
## Summary
- follow Next.js rule for `Script` tag in `pages/chat.js`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6871bf3a9c108333ae169bd3bc6b2129