### PR TITLE
Fix default imports

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Sidebar } from './Sidebar';
-import { Header } from './Header';
+import Sidebar from './Sidebar';
+import Header from './Header';
 
 export function Layout({ children }) {
   return (

--- a/components/PortalDashboard.js
+++ b/components/PortalDashboard.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { Card } from './Card';
+import Card from './Card';
 import { updateQuote } from '../lib/quotes';
 import { fetchJobStatuses } from '../lib/jobStatuses.js';
 import { fetchInvoiceStatuses } from '../lib/invoiceStatuses.js';

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -2,9 +2,9 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
-import { Sidebar } from '../../components/Sidebar';
-import { Header } from '../../components/Header';
-import { Card } from '../../components/Card';
+import Sidebar from '../../components/Sidebar';
+import Header from '../../components/Header';
+import Card from '../../components/Card';
 
 export default function Users() {
   const router = useRouter();

--- a/pages/chat.js
+++ b/pages/chat.js
@@ -2,8 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import Script from 'next/script';
 import Head from 'next/head';
 import Image from 'next/image';
-import { Sidebar } from '../components/Sidebar';
-import { Header } from '../components/Header';
+import Sidebar from '../components/Sidebar';
+import Header from '../components/Header';
 
 import { highlightMentions } from '../lib/highlightMentions.js';
 

--- a/pages/dev/dashboard.js
+++ b/pages/dev/dashboard.js
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
-import { Sidebar } from '../../components/Sidebar';
-import { Header } from '../../components/Header';
+import Sidebar from '../../components/Sidebar';
+import Header from '../../components/Header';
 import Image from 'next/image';
-import { Card } from '../../components/Card';
+import Card from '../../components/Card';
 import { highlightMentions } from '../../lib/highlightMentions.js';
 
 const S3_BASE_URL = `https://${process.env.NEXT_PUBLIC_S3_BUCKET}.s3.${process.env.NEXT_PUBLIC_AWS_REGION}.amazonaws.com`;

--- a/pages/dev/projects/[id].js
+++ b/pages/dev/projects/[id].js
@@ -4,9 +4,9 @@ import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Sidebar } from '../../../components/Sidebar';
-import { Header } from '../../../components/Header';
-import { Card } from '../../../components/Card';
+import Sidebar from '../../../components/Sidebar';
+import Header from '../../../components/Header';
+import Card from '../../../components/Card';
 import Image from 'next/image';
 
 const S3_BASE_URL = `https://${process.env.NEXT_PUBLIC_S3_BUCKET}.s3.${process.env.NEXT_PUBLIC_AWS_REGION}.amazonaws.com`;

--- a/pages/dev/projects/[id]/edit.js
+++ b/pages/dev/projects/[id]/edit.js
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Sidebar } from '../../../../components/Sidebar';
-import { Header } from '../../../../components/Header';
-import { Card } from '../../../../components/Card';
+import Sidebar from '../../../../components/Sidebar';
+import Header from '../../../../components/Header';
+import Card from '../../../../components/Card';
 
 export default function EditProject() {
   const router = useRouter();

--- a/pages/dev/projects/[id]/tasks/new.js
+++ b/pages/dev/projects/[id]/tasks/new.js
@@ -4,9 +4,9 @@ import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Sidebar } from '../../../../../components/Sidebar';
-import { Header } from '../../../../../components/Header';
-import { Card } from '../../../../../components/Card';
+import Sidebar from '../../../../../components/Sidebar';
+import Header from '../../../../../components/Header';
+import Card from '../../../../../components/Card';
 
 export default function NewTask() {
   const router = useRouter();

--- a/pages/dev/projects/new.js
+++ b/pages/dev/projects/new.js
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Sidebar } from '../../../components/Sidebar';
-import { Header } from '../../../components/Header';
-import { Card } from '../../../components/Card';
+import Sidebar from '../../../components/Sidebar';
+import Header from '../../../components/Header';
+import Card from '../../../components/Card';
 
 export default function NewProject() {
   const router = useRouter();

--- a/pages/dev/tasks/[id].js
+++ b/pages/dev/tasks/[id].js
@@ -2,9 +2,9 @@ import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Sidebar } from '../../../components/Sidebar';
-import { Header } from '../../../components/Header';
-import { Card } from '../../../components/Card';
+import Sidebar from '../../../components/Sidebar';
+import Header from '../../../components/Header';
+import Card from '../../../components/Card';
 import Image from 'next/image';
 
 const S3_BASE_URL = `https://${process.env.NEXT_PUBLIC_S3_BUCKET}.s3.${process.env.NEXT_PUBLIC_AWS_REGION}.amazonaws.com`;

--- a/pages/dev/tasks/[id]/edit.js
+++ b/pages/dev/tasks/[id]/edit.js
@@ -2,9 +2,9 @@ import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Sidebar } from '../../../../components/Sidebar';
-import { Header } from '../../../../components/Header';
-import { Card } from '../../../../components/Card';
+import Sidebar from '../../../../components/Sidebar';
+import Header from '../../../../components/Header';
+import Card from '../../../../components/Card';
 
 export default function EditTask() {
   const router = useRouter();

--- a/pages/engineer/index.js
+++ b/pages/engineer/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Layout } from '../../components/Layout';
-import { Card } from '../../components/Card';
+import Card from '../../components/Card';
 
 export default function EngineerHome() {
   const [jobs, setJobs] = useState([]);

--- a/pages/engineer/wiki.js
+++ b/pages/engineer/wiki.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Layout } from '../../components/Layout';
-import { Card } from '../../components/Card';
+import Card from '../../components/Card';
 
 function daysInMonth(year, month) {
   return new Date(year, month + 1, 0).getDate();

--- a/pages/office/clients/view/[id].js
+++ b/pages/office/clients/view/[id].js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import OfficeLayout from '../../../../components/OfficeLayout';
-import { Card } from '../../../../components/Card';
+import Card from '../../../../components/Card';
 import { fetchVehicles } from '../../../../lib/vehicles';
 import { fetchDocuments } from '../../../../lib/documents';
 

--- a/pages/office/engineers/view/[id].js
+++ b/pages/office/engineers/view/[id].js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import OfficeLayout from '../../../../components/OfficeLayout';
-import { Card } from '../../../../components/Card';
+import Card from '../../../../components/Card';
 
 export default function EngineerViewPage() {
   const router = useRouter();

--- a/pages/office/jobs/[id].js
+++ b/pages/office/jobs/[id].js
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import OfficeLayout from '../../../components/OfficeLayout';
-import { Card } from '../../../components/Card';
+import Card from '../../../components/Card';
 import { fetchEngineers } from '../../../lib/engineers';
 import { fetchJobStatuses } from '../../../lib/jobStatuses.js';
 

--- a/pages/office/vehicles/view/[id].js
+++ b/pages/office/vehicles/view/[id].js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import OfficeLayout from '../../../../components/OfficeLayout';
-import { Card } from '../../../../components/Card';
+import Card from '../../../../components/Card';
 import { fetchDocuments } from '../../../../lib/documents';
 
 export default function VehicleViewPage() {


### PR DESCRIPTION
## Summary
- refactor Sidebar, Header, and Card imports to use default import syntax

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871d55c6f1883339e3e6bb9a5f36011