### PR TITLE
Fix Next Image width/height handling

### DIFF
--- a/pages/chat.js
+++ b/pages/chat.js
@@ -201,11 +201,12 @@ export default function Chat() {
                       <Image
                         src={`${S3_BASE_URL}/${m.s3_key}`}
                         alt="uploaded"
-                        width={0}
-                        height={0}
+                        width={1}
+                        height={1}
                         sizes="100vw"
                         style={{ width: '100%', height: 'auto' }}
                         className="mt-2 max-w-xs"
+                        unoptimized
                       />
                     ) : (
                       <a

--- a/pages/dev/dashboard.js
+++ b/pages/dev/dashboard.js
@@ -87,11 +87,12 @@ export default function DevDashboard() {
                           <Image
                             src={`${S3_BASE_URL}/${a.s3_key}`}
                             alt="attachment"
-                            width={0}
-                            height={0}
+                            width={1}
+                            height={1}
                             sizes="100vw"
                             style={{ width: '100%', height: 'auto' }}
                             className="mt-2 max-w-xs"
+                            unoptimized
                           />
                         ) : (
                           <a href={`${S3_BASE_URL}/${a.s3_key}`} target="_blank" rel="noopener noreferrer" className="block mt-2 text-blue-500 underline" download>

--- a/pages/dev/projects/[id].js
+++ b/pages/dev/projects/[id].js
@@ -186,11 +186,12 @@ export default function ProjectDetail() {
                     <Image
                       src={`${S3_BASE_URL}/${f.s3_key}`}
                       alt="attachment"
-                      width={0}
-                      height={0}
+                      width={1}
+                      height={1}
                       sizes="100vw"
                       style={{ width: '100%', height: 'auto' }}
                       className="max-w-xs"
+                      unoptimized
                     />
                   ) : (
                     <a href={`${S3_BASE_URL}/${f.s3_key}`} target="_blank" rel="noopener noreferrer" className="text-blue-500 underline" download>

--- a/pages/dev/tasks/[id].js
+++ b/pages/dev/tasks/[id].js
@@ -119,11 +119,12 @@ export default function TaskDetail() {
                     <Image
                       src={`${S3_BASE_URL}/${f.s3_key}`}
                       alt="attachment"
-                      width={0}
-                      height={0}
+                      width={1}
+                      height={1}
                       sizes="100vw"
                       style={{ width: '100%', height: 'auto' }}
                       className="max-w-xs"
+                      unoptimized
                     />
                   ) : (
                     <a href={`${S3_BASE_URL}/${f.s3_key}`} target="_blank" rel="noopener noreferrer" className="text-blue-500 underline" download>

--- a/pages/index.js
+++ b/pages/index.js
@@ -36,11 +36,12 @@ export default function Landing() {
             <Image
               src="/mechanic-cards.png"
               alt="Mechanic illustration"
-              width={0}
-              height={0}
+              width={1}
+              height={1}
               sizes="100vw"
               style={{ width: '100%', height: 'auto' }}
               className="max-w-md w-full rounded-2xl shadow-xl"
+              unoptimized
             />
           </div>
         </div>
@@ -84,11 +85,12 @@ export default function Landing() {
           <Image
             src="/web-header-image.png"
             alt="App preview"
-            width={0}
-            height={0}
+            width={1}
+            height={1}
             sizes="100vw"
             style={{ width: '100%', height: 'auto' }}
             className="max-w-4xl w-full rounded-2xl shadow-2xl"
+            unoptimized
           />
         </div>
       </section>

--- a/pages/office/company-settings.js
+++ b/pages/office/company-settings.js
@@ -142,11 +142,12 @@ export default function CompanySettingsPage() {
             <Image
               src={form.logo_url}
               alt="Logo"
-              width={0}
-              height={0}
+              width={1}
+              height={1}
               sizes="100vw"
               style={{ width: '100%', height: 'auto' }}
               className="max-h-32 mb-2"
+              unoptimized
             />
           )}
           <input type="file" onChange={handleLogoUpload} disabled={uploading} />

--- a/pages/office/document-templates.js
+++ b/pages/office/document-templates.js
@@ -11,11 +11,12 @@ function TemplateBox({ title, company }) {
           <Image
             src={company.logo_url}
             alt="Logo"
-            width={0}
-            height={0}
+            width={1}
+            height={1}
             sizes="100vw"
             style={{ width: '100%', height: 'auto' }}
             className="h-16"
+            unoptimized
           />
         )}
         {company.company_name && (


### PR DESCRIPTION
## Summary
- ensure `next/image` components set a non-zero width/height
- mark these images `unoptimized`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729763bc508333ad7276d968c8b6f8