### PR TITLE
Fix socket.io script injection

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,15 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <script src="/api/socket-io/socket.io.js" defer></script>
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/chat.js
+++ b/pages/chat.js
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import Script from 'next/script';
 import Head from 'next/head';
 import Image from 'next/image';
 import Sidebar from '../components/Sidebar';
@@ -134,10 +133,6 @@ export default function Chat() {
       <Sidebar />
       <div className="flex-1 flex flex-col overflow-y-auto">
         <Header />
-        <Script
-          src="/api/socket-io/socket.io.js"
-          strategy="afterInteractive"
-        />
         <main className="p-8 space-y-4">
           <Head>
             <title>Chat</title>


### PR DESCRIPTION
## Summary
- ensure a custom document exists
- move the socket.io script loader from `chat.js` to the document to satisfy Next.js ESLint rule

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68729d79b7388333a753d04298f95587