### PR TITLE
Add Zod validation

### DIFF
--- a/lib/apiHandler.js
+++ b/lib/apiHandler.js
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { ZodError } from 'zod';
 import logger from './logger.js';
 
 export default function withApiHandler(fn) {
@@ -23,6 +24,11 @@ export default function withApiHandler(fn) {
         return res
           .status(400)
           .json({ error: 'validation_error', details: err.details });
+      }
+      if (err instanceof ZodError) {
+        return res
+          .status(400)
+          .json({ error: 'validation_error', details: err.flatten() });
       }
       if (err.name === 'NotFoundError') {
         return res.status(404).json({ error: 'not_found' });

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const CreateClientSchema = z.object({
+  first_name: z.string().min(1),
+  last_name: z.string().min(1),
+  email: z.string().email(),
+  garage_name: z.string().optional(),
+  vehicle_reg: z.string().optional(),
+  mobile: z.string().optional(),
+  landline: z.string().optional(),
+  nie_number: z.string().optional(),
+  street_address: z.string().optional(),
+  town: z.string().optional(),
+  province: z.string().optional(),
+  post_code: z.string().optional(),
+  password: z.string().optional(),
+});
+
+export const UpdateClientSchema = CreateClientSchema.partial();

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "18.x",
-        "socket.io": "^4.7.5"
+        "socket.io": "^4.7.5",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "18.x",
-    "socket.io": "^4.7.5"
-    ,
-    "pino": "^8.17.0"
+    "socket.io": "^4.7.5",
+    "pino": "^8.17.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/pages/api/clients/[id].js
+++ b/pages/api/clients/[id].js
@@ -1,6 +1,7 @@
 import apiHandler from '../../../lib/apiHandler.js';
 // pages/api/clients/[id].js
 import { getClientById, updateClient, deleteClient } from '../../../services/clientsService';
+import { UpdateClientSchema } from '../../../lib/schemas.js';
 
 async function handler(req, res) {
   const { id } = req.query;
@@ -10,7 +11,8 @@ async function handler(req, res) {
       return res.status(200).json(client);
     }
     if (req.method === 'PUT') {
-      const updated = await updateClient(id, req.body);
+      const data = UpdateClientSchema.parse(req.body);
+      const updated = await updateClient(id, data);
       return res.status(200).json(updated);
     }
     if (req.method === 'DELETE') {

--- a/pages/api/clients/index.js
+++ b/pages/api/clients/index.js
@@ -5,6 +5,7 @@ import {
   createClient,
   searchClients,
 } from '../../../services/clientsService';
+import { CreateClientSchema } from '../../../lib/schemas.js';
 
 async function handler(req, res) {
     if (req.method === 'GET') {
@@ -13,7 +14,8 @@ async function handler(req, res) {
       return res.status(200).json(clients);
     }
     if (req.method === 'POST') {
-      const newClient = await createClient(req.body);
+      const data = CreateClientSchema.parse(req.body);
+      const newClient = await createClient(data);
       return res.status(201).json(newClient);
     }
     res.setHeader('Allow', ['GET','POST']);


### PR DESCRIPTION
## Summary
- install `zod` and add simple client schemas
- validate POST/PUT client payloads with `CreateClientSchema` and `UpdateClientSchema`
- catch Zod errors in `withApiHandler`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872ba9abe20833398306a1f9d31eab7