### PR TITLE
Add pino logger

### DIFF
--- a/__tests__/apiHandler.test.js
+++ b/__tests__/apiHandler.test.js
@@ -6,9 +6,13 @@ afterEach(() => {
 });
 
 test('passes through successful handler', async () => {
-  jest.unstable_mockModule('../lib/logger.js', () => ({
-    default: { info: jest.fn(), error: jest.fn() },
-  }));
+  jest.unstable_mockModule('../lib/logger.js', () => {
+    const log = { info: jest.fn(), error: jest.fn() };
+    return {
+      default: log,
+      requestLogger: jest.fn(() => log),
+    };
+  });
   const { default: withApiHandler } = await import('../lib/apiHandler.js');
   const fn = jest.fn(async (req, res) => {
     res.status(200).json({ ok: true });
@@ -23,9 +27,13 @@ test('passes through successful handler', async () => {
 });
 
 test('catches errors and responds with 500', async () => {
-  jest.unstable_mockModule('../lib/logger.js', () => ({
-    default: { info: jest.fn(), error: jest.fn() },
-  }));
+  jest.unstable_mockModule('../lib/logger.js', () => {
+    const log = { info: jest.fn(), error: jest.fn() };
+    return {
+      default: log,
+      requestLogger: jest.fn(() => log),
+    };
+  });
   const { default: withApiHandler } = await import('../lib/apiHandler.js');
   const err = new Error('fail');
   const fn = jest.fn(() => { throw err; });

--- a/lib/apiHandler.js
+++ b/lib/apiHandler.js
@@ -1,24 +1,23 @@
 import { randomUUID } from 'crypto';
 import { ZodError } from 'zod';
-import logger from './logger.js';
+import { requestLogger } from './logger.js';
 
 export default function withApiHandler(fn) {
   return async function handler(req, res) {
     const requestId = req.headers['x-request-id'] || randomUUID();
     res.setHeader('x-request-id', requestId);
-    logger.info({ method: req.method, url: req.url, requestId });
+    const log = requestLogger({
+      route: req.url,
+      method: req.method,
+      requestId,
+      userId: req.user?.id,
+    });
+    req.log = log;
+    log.info('request_start');
     try {
       await fn(req, res);
     } catch (err) {
-      const payload = {
-        timestamp: new Date().toISOString(),
-        route: req.url,
-        method: req.method,
-        userId: req.user?.id,
-        requestId,
-        err,
-      };
-      logger.error(payload);
+      log.error({ err });
       if (res.headersSent) return;
       if (err.name === 'ValidationError') {
         return res

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,6 +2,21 @@ import pino from 'pino';
 
 const logger = pino({
   level: process.env.LOG_LEVEL || 'info',
+  timestamp: pino.stdTimeFunctions.isoTime,
+  formatters: {
+    level(label) {
+      return { level: label };
+    },
+  },
 });
+
+export function requestLogger({ route, method, requestId, userId }) {
+  return logger.child({
+    route,
+    method,
+    requestId,
+    ...(userId ? { userId } : {}),
+  });
+}
 
 export default logger;

--- a/pages/api/documents/index.js
+++ b/pages/api/documents/index.js
@@ -13,7 +13,7 @@ async function handler(req, res) {
       const docs = await getDocuments(entity_type, entity_id);
       return res.status(200).json(docs);
     } catch (err) {
-      console.error(err);
+      req.log.error({ err });
       return res.status(500).json({ error: 'Internal Server Error' });
     }
   }
@@ -27,7 +27,7 @@ async function handler(req, res) {
       const doc = await createDocument({ entity_type, entity_id, filename, url });
       return res.status(201).json(doc);
     } catch (err) {
-      console.error(err);
+      req.log.error({ err });
       return res.status(500).json({ error: 'Internal Server Error' });
     }
   }

--- a/services/reminderScheduler.js
+++ b/services/reminderScheduler.js
@@ -1,12 +1,13 @@
 import cron from 'node-cron';
 import { scheduleDueReminders } from './followUpRemindersService.js';
+import logger from '../lib/logger.js';
 
 export function startReminderScheduler() {
   cron.schedule('0 3 * * *', async () => {
     try {
       await scheduleDueReminders();
     } catch (err) {
-      console.error('REMINDER_JOB_ERROR:', err);
+      logger.error({ err, msg: 'REMINDER_JOB_ERROR' });
     }
   });
 }


### PR DESCRIPTION
## Summary
- configure pino in `lib/logger.js`
- create request-scoped loggers in `withApiHandler`
- log background job errors with pino
- use request logger in documents API
- update tests for new logger API

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872bbaab9e48333bd6a14cd027f5f15