### PR TITLE
Add error log dev page

### DIFF
--- a/components/NavLink.js
+++ b/components/NavLink.js
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export function NavLink({ href, children, onClick }) {
+  return (
+    <Link
+      href={href}
+      onClick={onClick}
+      className="bg-gray-200 text-black rounded-full px-4 py-2 shadow hover:bg-gray-300 block text-center w-full"
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { NavLink } from "./NavLink.js";
 
 export function Sidebar() {
   const [userRole, setUserRole] = useState(null);
@@ -89,6 +90,11 @@ export function Sidebar() {
             <a href="/admin/users" {...linkProps}>
               Users
             </a>
+            {process.env.NODE_ENV === 'development' && (
+              <NavLink href="/dev/error-log" onClick={() => setOpen(false)}>
+                Error Log
+              </NavLink>
+            )}
           </>
         )}
       </nav>

--- a/pages/dev/error-log.js
+++ b/pages/dev/error-log.js
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import { Sidebar } from '../../components/Sidebar';
+import { Header } from '../../components/Header';
+
+export default function ErrorLog() {
+  const [entries, setEntries] = useState([]);
+  const router = useRouter();
+  const { level, route } = router.query;
+
+  useEffect(() => {
+    fetch('/error-log.json')
+      .then(r => r.ok ? r.json() : [])
+      .then(setEntries)
+      .catch(() => setEntries([]));
+  }, []);
+
+  const filtered = entries.filter(e => {
+    if (level && e.level !== level) return false;
+    if (route && e.route !== route) return false;
+    return true;
+  });
+
+  return (
+    <div className="min-h-screen flex flex-col sm:flex-row">
+      <Sidebar />
+      <div className="flex-1 flex flex-col overflow-y-auto">
+        <Header />
+        <main className="p-8">
+          <Head><title>Error Log</title></Head>
+          <h1 className="text-3xl mb-4">Error Log</h1>
+          <div className="overflow-x-auto">
+            <table className="min-w-full bg-[var(--color-surface)] rounded-xl shadow text-sm">
+              <thead className="text-left">
+                <tr>
+                  <th className="px-3 py-2">Timestamp</th>
+                  <th className="px-3 py-2">Level</th>
+                  <th className="px-3 py-2">Route</th>
+                  <th className="px-3 py-2">Error Type</th>
+                  <th className="px-3 py-2">Summary</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((e, i) => (
+                  <tr key={i} className="border-t border-gray-300">
+                    <td className="px-3 py-2">{e.timestamp}</td>
+                    <td className="px-3 py-2">{e.level}</td>
+                    <td className="px-3 py-2">{e.route}</td>
+                    <td className="px-3 py-2">{e.errorType || '—'}</td>
+                    <td className="px-3 py-2">{e.summary}</td>
+                  </tr>
+                ))}
+                {!filtered.length && (
+                  <tr>
+                    <td colSpan="5" className="px-3 py-2 text-center">No log entries</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/public/error-log.json
+++ b/public/error-log.json
@@ -1,0 +1,37 @@
+[
+  {
+    "timestamp": "2024-05-01T12:00:00Z",
+    "level": "error",
+    "route": "/api/login",
+    "errorType": "ValidationError",
+    "summary": "Missing username"
+  },
+  {
+    "timestamp": "2024-05-02T08:30:00Z",
+    "level": "warn",
+    "route": "/api/jobs/42",
+    "errorType": "DeprecatedRoute",
+    "summary": "Old job endpoint used"
+  },
+  {
+    "timestamp": "2024-05-03T17:15:00Z",
+    "level": "error",
+    "route": "/dev/projects",
+    "errorType": "DatabaseError",
+    "summary": "Connection timeout"
+  },
+  {
+    "timestamp": "2024-05-04T10:05:00Z",
+    "level": "info",
+    "route": "/api/auth/me",
+    "errorType": "",
+    "summary": "Successful login"
+  },
+  {
+    "timestamp": "2024-05-05T14:45:00Z",
+    "level": "error",
+    "route": "/office/invoices",
+    "errorType": "ServerError",
+    "summary": "Unhandled exception"
+  }
+]


### PR DESCRIPTION
## Summary
- show development error log table
- link to error log from Sidebar (development only)
- add NavLink helper component
- store mock error-log.json in public

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872bd247d808333ac4f10741d153b4e