### PR TITLE
Add error handling tests

### DIFF
--- a/__tests__/apiHandler.test.js
+++ b/__tests__/apiHandler.test.js
@@ -34,13 +34,20 @@ test('catches errors and responds with 500', async () => {
       requestLogger: jest.fn(() => log),
     };
   });
+  const oldEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
   const { default: withApiHandler } = await import('../lib/apiHandler.js');
   const err = new Error('fail');
-  const fn = jest.fn(() => { throw err; });
+  const fn = jest.fn(() => {
+    throw err;
+  });
   const wrapped = withApiHandler(fn);
   const req = { method: 'GET', url: '/foo', headers: {} };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), headersSent: false, setHeader: jest.fn() };
   await wrapped(req, res);
   expect(res.status).toHaveBeenCalledWith(500);
-  expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'internal_error' }));
+  expect(res.json).toHaveBeenCalledWith(
+    expect.objectContaining({ error: 'internal_error', message: 'fail' })
+  );
+  process.env.NODE_ENV = oldEnv;
 });

--- a/__tests__/clients-api.test.js
+++ b/__tests__/clients-api.test.js
@@ -46,6 +46,30 @@ test('clients index creates client', async () => {
   expect(createMock).toHaveBeenCalledWith(req.body);
 });
 
+test('clients index validates input on create', async () => {
+  const createMock = jest.fn();
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getAllClients: jest.fn(),
+    createClient: createMock,
+    searchClients: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/clients/index.js');
+  const req = {
+    method: 'POST',
+    body: { first_name: '' },
+    headers: {},
+  };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(400);
+  expect(res.json).toHaveBeenCalledWith(
+    expect.objectContaining({ error: 'validation_error' })
+  );
+  const [{ details }] = res.json.mock.calls[0];
+  expect(details).toBeDefined();
+  expect(createMock).not.toHaveBeenCalled();
+});
+
 
 test('clients index rejects unsupported method', async () => {
   jest.unstable_mockModule('../services/clientsService.js', () => ({


### PR DESCRIPTION
## Summary
- test that generic errors through apiHandler include error and message
- test POST /api/clients with invalid data returns validation_error

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6872be2bec348333b8cfa4fe91426648