### PR TITLE
Add error log link on dev dashboard

### DIFF
--- a/pages/dev/dashboard.js
+++ b/pages/dev/dashboard.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
 import { Sidebar } from '../../components/Sidebar';
 import { Header } from '../../components/Header';
 import { Card } from '../../components/Card';
@@ -68,36 +69,45 @@ export default function DevDashboard() {
             </div>
           </section>
 
-          <section>
-            <h2 className="text-2xl font-semibold mb-4 text-[var(--color-text-primary)]">Important Announcements</h2>
-            {!announcements.length ? (
-              <p className="text-[var(--color-text-secondary)]">No announcements.</p>
-            ) : (
-              <div className="space-y-4">
-                {announcements.map(a => (
-                  <Card key={a.id}>
-                    <div>
-                      <span className="font-semibold mr-2" style={{ color: userColor(a.user) }}>
-                        {a.user}:
-                      </span>
-                      <span>{highlightMentions(a.body)}</span>
-                      {a.s3_key && (
-                        a.content_type && a.content_type.startsWith('image/') ? (
-                          <img src={`${S3_BASE_URL}/${a.s3_key}`} alt="attachment" className="mt-2 max-w-xs" />
-                        ) : (
-                          <a href={`${S3_BASE_URL}/${a.s3_key}`} target="_blank" rel="noopener noreferrer" className="block mt-2 text-blue-500 underline" download>
-                            {a.file_name || a.s3_key.split('/').pop()}
-                          </a>
-                        )
-                      )}
-                    </div>
-                  </Card>
-                ))}
-              </div>
-            )}
-          </section>
-        </main>
+            <section>
+              <h2 className="text-2xl font-semibold mb-4 text-[var(--color-text-primary)]">Important Announcements</h2>
+              {!announcements.length ? (
+                <p className="text-[var(--color-text-secondary)]">No announcements.</p>
+              ) : (
+                <div className="space-y-4">
+                  {announcements.map(a => (
+                    <Card key={a.id}>
+                      <div>
+                        <span className="font-semibold mr-2" style={{ color: userColor(a.user) }}>
+                          {a.user}:
+                        </span>
+                        <span>{highlightMentions(a.body)}</span>
+                        {a.s3_key && (
+                          a.content_type && a.content_type.startsWith('image/') ? (
+                            <img src={`${S3_BASE_URL}/${a.s3_key}`} alt="attachment" className="mt-2 max-w-xs" />
+                          ) : (
+                            <a href={`${S3_BASE_URL}/${a.s3_key}`} target="_blank" rel="noopener noreferrer" className="block mt-2 text-blue-500 underline" download>
+                              {a.file_name || a.s3_key.split('/').pop()}
+                            </a>
+                          )
+                        )}
+                      </div>
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section>
+              <h2 className="text-2xl font-semibold mb-4 text-[var(--color-text-primary)]">Tools</h2>
+              <Card>
+                <Link href="/dev/error-log" className="text-blue-500 underline">
+                  View Error Log
+                </Link>
+              </Card>
+            </section>
+          </main>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }


### PR DESCRIPTION
## Summary
- import Link on dev dashboard page
- add a new Tools section containing a link to `/dev/error-log`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c4579f488333a15dcc903802a2b6