### PR TITLE
Fix error log table text color

### DIFF
--- a/pages/dev/error-log.js
+++ b/pages/dev/error-log.js
@@ -31,7 +31,7 @@ export default function ErrorLog() {
           <Head><title>Error Log</title></Head>
           <h1 className="text-3xl mb-4">Error Log</h1>
           <div className="overflow-x-auto">
-            <table className="min-w-full bg-[var(--color-surface)] rounded-xl shadow text-sm">
+            <table className="min-w-full bg-[var(--color-surface)] rounded-xl shadow text-sm text-black dark:text-white">
               <thead className="text-left">
                 <tr>
                   <th className="px-3 py-2">Timestamp</th>


### PR DESCRIPTION
## Summary
- ensure text in error log table is readable by using `text-black` on light mode and `text-white` on dark mode

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c5d3b9708333921c81b24f54809e