### PR TITLE
Add apprentice management and standards ingest

### DIFF
--- a/.github/workflows/ingest-standards.yml
+++ b/.github/workflows/ingest-standards.yml
@@ -1,0 +1,19 @@
+name: Ingest Standards
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      - run: node scripts/ingestStandards.js
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/__tests__/apprentices-api.test.js
+++ b/__tests__/apprentices-api.test.js
@@ -1,0 +1,37 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('GET /api/apprentices returns list', async () => {
+  const data = [{ id: 1 }];
+  const getMock = jest.fn().mockResolvedValue(data);
+  jest.unstable_mockModule('../services/apprenticesService.js', () => ({
+    getAllApprentices: getMock,
+    createApprentice: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/apprentices/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(data);
+});
+
+test('POST /api/apprentices creates apprentice', async () => {
+  const created = { id: 2 };
+  const createMock = jest.fn().mockResolvedValue(created);
+  jest.unstable_mockModule('../services/apprenticesService.js', () => ({
+    getAllApprentices: jest.fn(),
+    createApprentice: createMock,
+  }));
+  jest.unstable_mockModule('../lib/schemas.js', () => ({
+    CreateApprenticeSchema: { parse: x => x },
+  }));
+  const { default: handler } = await import('../pages/api/apprentices/index.js');
+  const req = { method: 'POST', body: { first_name: 'A' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(created);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+});

--- a/__tests__/office-layout-navigation.test.js
+++ b/__tests__/office-layout-navigation.test.js
@@ -28,3 +28,25 @@ test('OfficeLayout includes link to new invoice', async () => {
   const link = screen.getByRole('link', { name: 'New Invoice' });
   expect(link).toHaveAttribute('href', '/office/invoices/new');
 });
+
+test('OfficeLayout includes link to apprentices', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ push: jest.fn() })
+  }));
+  jest.unstable_mockModule('../lib/search.js', () => ({
+    fetchSearch: jest.fn().mockResolvedValue(null)
+  }));
+  jest.unstable_mockModule('../lib/logout.js', () => ({
+    default: jest.fn().mockResolvedValue()
+  }));
+
+  const { default: OfficeLayout } = await import('../components/OfficeLayout.jsx');
+  render(
+    <OfficeLayout>
+      <div>content</div>
+    </OfficeLayout>
+  );
+
+  const link = screen.getByRole('link', { name: 'Apprentices' });
+  expect(link).toHaveAttribute('href', '/office/apprentices');
+});

--- a/__tests__/standardIngestService.test.js
+++ b/__tests__/standardIngestService.test.js
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('ingestStandards spawns child process', async () => {
+  let exit;
+  const spawnMock = jest.fn(() => ({
+    on: (ev, cb) => { if (ev === 'exit') exit = cb; }
+  }));
+  jest.unstable_mockModule('child_process', () => ({ spawn: spawnMock }));
+  const { ingestStandards } = await import('../services/standardIngestService.js');
+  const p = ingestStandards();
+  exit(0);
+  await expect(p).resolves.toBeUndefined();
+  expect(spawnMock).toHaveBeenCalledWith('node', ['scripts/ingestStandards.js'], expect.any(Object));
+});
+
+test('getIngestStatus reflects running state', async () => {
+  let exit;
+  const spawnMock = jest.fn(() => ({
+    on: (ev, cb) => { if (ev === 'exit') exit = cb; }
+  }));
+  jest.unstable_mockModule('child_process', () => ({ spawn: spawnMock }));
+  const mod = await import('../services/standardIngestService.js');
+  const p = mod.ingestStandards();
+  expect(mod.getIngestStatus()).toBe(true);
+  exit(0);
+  await p;
+  expect(mod.getIngestStatus()).toBe(false);
+});

--- a/__tests__/standards-api.test.js
+++ b/__tests__/standards-api.test.js
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('POST /api/standards/ingest starts ingestion', async () => {
+  const ingestMock = jest.fn().mockResolvedValue();
+  jest.unstable_mockModule('../services/standardIngestService.js', () => ({
+    ingestStandards: ingestMock,
+  }));
+  const { default: handler } = await import('../pages/api/standards/ingest.js');
+  const req = { method: 'POST', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(202);
+  expect(ingestMock).toHaveBeenCalled();
+});
+
+test('GET /api/standards/status returns status', async () => {
+  const statusMock = jest.fn().mockReturnValue(true);
+  jest.unstable_mockModule('../services/standardIngestService.js', () => ({
+    getIngestStatus: statusMock,
+  }));
+  const { default: handler } = await import('../pages/api/standards/status.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ running: true });
+});

--- a/components/OfficeLayout.jsx
+++ b/components/OfficeLayout.jsx
@@ -155,6 +155,12 @@ export default function OfficeLayout({ children }) {
                 </Link>
               </li>
               <li>
+                <Link href="/office/apprentices" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  Apprentices
+                </Link>
+              </li>
+              <li>
                 <Link href="/office/crm" className="flex items-center hover:underline">
                   <ArrowIcon />
                   CRM

--- a/db/migrations/20250713_create_apprentice_and_standards_tables.sql
+++ b/db/migrations/20250713_create_apprentice_and_standards_tables.sql
@@ -1,0 +1,55 @@
+CREATE TABLE IF NOT EXISTS standards (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  code VARCHAR(100) UNIQUE NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  pdf_url VARCHAR(255),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS apprentices (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) UNIQUE,
+  start_date DATE,
+  end_date DATE,
+  standard_id INT,
+  CONSTRAINT fk_apprentices_standard FOREIGN KEY (standard_id) REFERENCES standards(id)
+);
+
+-- Add columns to quiz_questions if they don't already exist
+SET @col_count := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'quiz_questions'
+     AND COLUMN_NAME = 'standard_id'
+);
+SET @sql := IF(
+  @col_count = 0,
+  'ALTER TABLE quiz_questions ADD COLUMN standard_id INT',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @col_count := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'quiz_questions'
+     AND COLUMN_NAME = 'question_no'
+);
+SET @sql := IF(
+  @col_count = 0,
+  'ALTER TABLE quiz_questions ADD COLUMN question_no INT',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @fk_count := (
+  SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'quiz_questions'
+     AND CONSTRAINT_NAME = 'fk_quiz_question_standard'
+);
+SET @sql := IF(
+  @fk_count = 0,
+  'ALTER TABLE quiz_questions ADD CONSTRAINT fk_quiz_question_standard FOREIGN KEY (standard_id) REFERENCES standards(id)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/lib/apprentices.js
+++ b/lib/apprentices.js
@@ -1,0 +1,5 @@
+export async function fetchApprentices() {
+  const res = await fetch('/api/apprentices');
+  if (!res.ok) throw new Error('Failed to fetch apprentices');
+  return res.json();
+}

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -17,3 +17,14 @@ export const CreateClientSchema = z.object({
 });
 
 export const UpdateClientSchema = CreateClientSchema.partial();
+
+export const CreateApprenticeSchema = z.object({
+  first_name: z.string().min(1),
+  last_name: z.string().min(1),
+  email: z.string().email(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+  standard_id: z.number().optional(),
+});
+
+export const UpdateApprenticeSchema = CreateApprenticeSchema.partial();

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "18.x",
     "socket.io": "^4.7.5",
     "pino": "^8.17.0",
+    "pdf-parse": "^1.1.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/pages/api/apprentices/index.js
+++ b/pages/api/apprentices/index.js
@@ -1,0 +1,19 @@
+import apiHandler from '../../../lib/apiHandler.js';
+import { getAllApprentices, createApprentice } from '../../../services/apprenticesService.js';
+import { CreateApprenticeSchema } from '../../../lib/schemas.js';
+
+async function handler(req, res) {
+  if (req.method === 'GET') {
+    const apprentices = await getAllApprentices();
+    return res.status(200).json(apprentices);
+  }
+  if (req.method === 'POST') {
+    const data = CreateApprenticeSchema.parse(req.body);
+    const apprentice = await createApprentice(data);
+    return res.status(201).json(apprentice);
+  }
+  res.setHeader('Allow', ['GET','POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/api/standards/ingest.js
+++ b/pages/api/standards/ingest.js
@@ -1,0 +1,13 @@
+import apiHandler from '../../../lib/apiHandler.js';
+import { ingestStandards } from '../../../services/standardIngestService.js';
+
+async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+  ingestStandards().catch(() => {});
+  res.status(202).json({ started: true });
+}
+
+export default apiHandler(handler);

--- a/pages/api/standards/status.js
+++ b/pages/api/standards/status.js
@@ -1,0 +1,12 @@
+import apiHandler from '../../../lib/apiHandler.js';
+import { getIngestStatus } from '../../../services/standardIngestService.js';
+
+async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+  res.status(200).json({ running: getIngestStatus() });
+}
+
+export default apiHandler(handler);

--- a/pages/office/apprentices/index.js
+++ b/pages/office/apprentices/index.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import OfficeLayout from '../../../components/OfficeLayout';
+import { fetchApprentices } from '../../../lib/apprentices';
+
+export default function ApprenticesPage() {
+  const [apprentices, setApprentices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = () => {
+    setLoading(true);
+    fetchApprentices()
+      .then(setApprentices)
+      .catch(() => setError('Failed to load apprentices'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  return (
+    <OfficeLayout>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-semibold">Apprentices</h1>
+      </div>
+      {loading && <p>Loading…</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      {!loading && !error && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {apprentices.map(a => (
+            <div key={a.id} className="item-card">
+              <h2 className="font-semibold text-black dark:text-white text-lg mb-1">
+                {a.first_name} {a.last_name}
+              </h2>
+              <p className="text-sm text-black dark:text-white">{a.email || '—'}</p>
+              <p className="text-sm text-black dark:text-white">
+                Standard: {a.standard_id || '—'}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </OfficeLayout>
+  );
+}

--- a/scripts/ingestStandards.js
+++ b/scripts/ingestStandards.js
@@ -1,0 +1,56 @@
+import pdf from 'pdf-parse';
+import pool from '../lib/db.js';
+
+export async function fetchPdf(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch ${url}`);
+  return Buffer.from(await res.arrayBuffer());
+}
+
+export async function parseQuestions(text) {
+  const lines = text.split(/\r?\n/);
+  const questions = [];
+  for (const line of lines) {
+    const m = line.match(/^\d+\.\s*(.+)/);
+    if (m) questions.push(m[1].trim());
+  }
+  return questions;
+}
+
+export async function ingestStandard({ code, url }) {
+  const buffer = await fetchPdf(url);
+  const { text } = await pdf(buffer);
+  const title = text.split(/\n/)[0].trim();
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO standards (code, title, pdf_url)
+     VALUES (?,?,?)
+     ON DUPLICATE KEY UPDATE title=VALUES(title), pdf_url=VALUES(pdf_url)`,
+    [code, title, url]
+  );
+  const [[row]] = await pool.query('SELECT id FROM standards WHERE code=?', [code]);
+  const standardId = row.id || insertId;
+  const questions = await parseQuestions(text);
+  let no = 1;
+  for (const q of questions) {
+    await pool.query(
+      `INSERT INTO quiz_questions (standard_id, question_no, question)
+       VALUES (?,?,?)
+       ON DUPLICATE KEY UPDATE question=VALUES(question)`,
+      [standardId, no++, q]
+    );
+  }
+}
+
+export default async function ingestAll() {
+  const standards = [
+    // example list
+    { code: 'STD001', url: 'https://example.com/std1.pdf' },
+  ];
+  for (const s of standards) {
+    await ingestStandard(s);
+  }
+}
+
+if (import.meta.url === process.argv[1] || import.meta.url === `file://${process.argv[1]}`) {
+  ingestAll().then(() => process.exit(0)).catch(err => { console.error(err); process.exit(1); });
+}

--- a/services/apprenticesService.js
+++ b/services/apprenticesService.js
@@ -1,0 +1,17 @@
+import pool from '../lib/db.js';
+
+export async function getAllApprentices() {
+  const [rows] = await pool.query(
+    'SELECT id, first_name, last_name, email, start_date, end_date, standard_id FROM apprentices ORDER BY id'
+  );
+  return rows;
+}
+
+export async function createApprentice({ first_name, last_name, email, start_date, end_date, standard_id }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO apprentices (first_name, last_name, email, start_date, end_date, standard_id)
+     VALUES (?,?,?,?,?,?)`,
+    [first_name, last_name, email, start_date || null, end_date || null, standard_id || null]
+  );
+  return { id: insertId, first_name, last_name, email, start_date, end_date, standard_id };
+}

--- a/services/standardIngestService.js
+++ b/services/standardIngestService.js
@@ -1,0 +1,26 @@
+import { spawn } from 'child_process';
+
+let current = null;
+
+export function ingestStandards() {
+  if (current) return current;
+  current = new Promise((resolve, reject) => {
+    const child = spawn('node', ['scripts/ingestStandards.js'], {
+      stdio: 'inherit',
+    });
+    child.on('error', err => {
+      current = null;
+      reject(err);
+    });
+    child.on('exit', code => {
+      current = null;
+      if (code === 0) resolve();
+      else reject(new Error('ingest_failed'));
+    });
+  });
+  return current;
+}
+
+export function getIngestStatus() {
+  return !!current;
+}


### PR DESCRIPTION
## Summary
- add apprentices & standards migration
- implement ingestion script and service
- expose standards ingest/status and apprentices API routes
- UI page to list apprentices
- link apprentices in office navigation
- weekly GH workflow to ingest standards
- tests for new routes and service

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872c575cef08333a18c51ab6af2c056