### PR TITLE
Add API secret check to standards endpoints

### DIFF
--- a/__tests__/standards-api.test.js
+++ b/__tests__/standards-api.test.js
@@ -1,14 +1,19 @@
 import { jest } from '@jest/globals';
 
-afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  delete process.env.API_SECRET;
+});
 
 test('POST /api/standards/ingest starts ingestion', async () => {
+  process.env.API_SECRET = 'shhh';
   const ingestMock = jest.fn().mockResolvedValue();
   jest.unstable_mockModule('../services/standardIngestService.js', () => ({
     ingestStandards: ingestMock,
   }));
   const { default: handler } = await import('../pages/api/standards/ingest.js');
-  const req = { method: 'POST', headers: {} };
+  const req = { method: 'POST', headers: {}, query: { secret: 'shhh' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
   await handler(req, res);
   expect(res.status).toHaveBeenCalledWith(202);
@@ -16,14 +21,45 @@ test('POST /api/standards/ingest starts ingestion', async () => {
 });
 
 test('GET /api/standards/status returns status', async () => {
+  process.env.API_SECRET = 'shhh';
   const statusMock = jest.fn().mockReturnValue(true);
   jest.unstable_mockModule('../services/standardIngestService.js', () => ({
     getIngestStatus: statusMock,
   }));
   const { default: handler } = await import('../pages/api/standards/status.js');
-  const req = { method: 'GET', headers: {} };
+  const req = { method: 'GET', headers: {}, query: { secret: 'shhh' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
   await handler(req, res);
   expect(res.status).toHaveBeenCalledWith(200);
   expect(res.json).toHaveBeenCalledWith({ running: true });
+});
+
+test('POST /api/standards/ingest rejects invalid secret', async () => {
+  process.env.API_SECRET = 'shhh';
+  const ingestMock = jest.fn();
+  jest.unstable_mockModule('../services/standardIngestService.js', () => ({
+    ingestStandards: ingestMock,
+  }));
+  const { default: handler } = await import('../pages/api/standards/ingest.js');
+  const req = { method: 'POST', headers: {}, query: { secret: 'nope' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+  expect(ingestMock).not.toHaveBeenCalled();
+});
+
+test('GET /api/standards/status rejects invalid secret', async () => {
+  process.env.API_SECRET = 'shhh';
+  const statusMock = jest.fn();
+  jest.unstable_mockModule('../services/standardIngestService.js', () => ({
+    getIngestStatus: statusMock,
+  }));
+  const { default: handler } = await import('../pages/api/standards/status.js');
+  const req = { method: 'GET', headers: {}, query: { secret: 'wrong' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
+  expect(statusMock).not.toHaveBeenCalled();
 });

--- a/pages/api/standards/ingest.js
+++ b/pages/api/standards/ingest.js
@@ -2,6 +2,10 @@ import apiHandler from '../../../lib/apiHandler.js';
 import { ingestStandards } from '../../../services/standardIngestService.js';
 
 async function handler(req, res) {
+  const secret = req.query.secret || req.headers['x-api-secret'];
+  if (secret !== process.env.API_SECRET) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
     return res.status(405).end(`Method ${req.method} Not Allowed`);

--- a/pages/api/standards/status.js
+++ b/pages/api/standards/status.js
@@ -2,6 +2,10 @@ import apiHandler from '../../../lib/apiHandler.js';
 import { getIngestStatus } from '../../../services/standardIngestService.js';
 
 async function handler(req, res) {
+  const secret = req.query.secret || req.headers['x-api-secret'];
+  if (secret !== process.env.API_SECRET) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
   if (req.method !== 'GET') {
     res.setHeader('Allow', ['GET']);
     return res.status(405).end(`Method ${req.method} Not Allowed`);


### PR DESCRIPTION
## Summary
- enforce `API_SECRET` on standards ingestion endpoints
- extend tests for secret enforcement

## Testing
- `npm test --silent` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872ce063554833387d88d9e86350e73