### PR TITLE
Add NEXT_PUBLIC_API_SECRET example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ AWS_SECRET_ACCESS_KEY="your-secret-key"
 NEXT_PUBLIC_S3_BUCKET="your-bucket-name"
 NEXT_PUBLIC_AWS_REGION="us-east-1"
 
+# Expose API secret to the client
+NEXT_PUBLIC_API_SECRET="your-api-secret"
+
 
 # SMTP configuration
 SMTP_HOST="smtp.example.com"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-1. Copy `.env.example` to `.env.local` and fill in secrets. The required variables are `DATABASE_URL` and `JWT_SECRET`.
+1. Copy `.env.example` to `.env.local` and fill in secrets. The required variables are `DATABASE_URL`, `JWT_SECRET` and `NEXT_PUBLIC_API_SECRET`.
 2. Configure AWS S3 to enable uploading logos and other files. Add the following environment variables from `.env.example`:
    - `S3_BUCKET`
    - `AWS_REGION`


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_API_SECRET` to `.env.example`
- document the new variable in setup instructions

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/pdf-parse)*

------
https://chatgpt.com/codex/tasks/task_e_6872d10a339c833394b7eb671dd0df5d