### PR TITLE
Add curriculum dashboard tabs

### DIFF
--- a/components/office/CurriculumDashboard.jsx
+++ b/components/office/CurriculumDashboard.jsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import Table from '../ui/Table.jsx';
+import Modal from '../ui/Modal.jsx';
+import Button from '../ui/Button.jsx';
+import { Card } from '../Card.js';
+
+export default function CurriculumDashboard() {
+  const [standards, setStandards] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/standards/status')
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(d => {
+        setStandards(d.standards || []);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Failed to load standards');
+        setLoading(false);
+      });
+  }, []);
+
+  return (
+    <div>
+      {loading && <p>Loading…</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      {!loading && !error && (
+        <Table>
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Code</th>
+              <th className="px-2 py-1 text-left">Title</th>
+              <th className="px-2 py-1 text-left">Sections</th>
+            </tr>
+          </thead>
+          <tbody>
+            {standards.map(s => (
+              <tr key={s.id || s.code}>
+                <td className="px-2 py-1">{s.code}</td>
+                <td className="px-2 py-1">{s.title}</td>
+                <td className="px-2 py-1">
+                  <Button className="button-secondary" onClick={() => setSelected(s)}>
+                    View
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
+      {selected && (
+        <Modal onClose={() => setSelected(null)}>
+          <Card>
+            <h2 className="text-lg font-semibold mb-2">{selected.title}</h2>
+            <Table>
+              <thead>
+                <tr>
+                  <th className="px-2 py-1 text-left">#</th>
+                  <th className="px-2 py-1 text-left">Title</th>
+                  <th className="px-2 py-1 text-left">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(selected.sections || []).map(sec => (
+                  <tr key={sec.id || sec.number}>
+                    <td className="px-2 py-1">{sec.number}</td>
+                    <td className="px-2 py-1">{sec.title}</td>
+                    <td className="px-2 py-1">{sec.status}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Card>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/components/ui/Button.jsx
+++ b/components/ui/Button.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Button({ type = 'button', className = '', children, ...props }) {
+  return (
+    <button type={type} className={`button px-4 ${className}`} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/components/ui/Modal.jsx
+++ b/components/ui/Modal.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function Modal({ children, onClose }) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 text-black dark:text-white rounded-xl p-4 max-h-[80vh] overflow-y-auto">
+        {children}
+        {onClose && (
+          <div className="mt-4 text-right">
+            <button className="button px-4" onClick={onClose}>Close</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/Table.jsx
+++ b/components/ui/Table.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Table({ children, className = '' }) {
+  return <table className={`table-auto w-full ${className}`}>{children}</table>;
+}

--- a/components/ui/Tabs.jsx
+++ b/components/ui/Tabs.jsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+
+export default function Tabs({ tabs, className = '' }) {
+  const [active, setActive] = useState(tabs[0]?.label);
+  const current = tabs.find(t => t.label === active) || tabs[0];
+  return (
+    <div className={className}>
+      <div className="flex border-b mb-4 gap-2">
+        {tabs.map(t => (
+          <button
+            key={t.label}
+            onClick={() => setActive(t.label)}
+            className={`px-3 py-2 ${active === t.label ? 'border-b-2 border-blue-500 font-semibold' : 'text-gray-500'}`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <div>{current && current.content}</div>
+    </div>
+  );
+}

--- a/pages/office/apprentices/index.js
+++ b/pages/office/apprentices/index.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
 import OfficeLayout from '../../../components/OfficeLayout';
 import Spinner from '../../../components/Spinner.jsx';
 import Toast from '../../../components/Toast.jsx';
 import { fetchApprentices } from '../../../lib/apprentices';
+import Tabs from '../../../components/ui/Tabs.jsx';
+import Button from '../../../components/ui/Button.jsx';
+import CurriculumDashboard from '../../../components/office/CurriculumDashboard.jsx';
 
 export default function ApprenticesPage() {
   const [apprentices, setApprentices] = useState([]);
@@ -52,30 +54,45 @@ export default function ApprenticesPage() {
 
   return (
     <OfficeLayout>
-      <div className="flex justify-between items-center mb-4">
-        <h1 className="text-2xl font-semibold">Apprentices</h1>
-        <button onClick={handleRefresh} className="button flex items-center">
-          {refreshing ? <Spinner /> : 'Refresh Curriculum'}
-        </button>
-      </div>
-      {ingestRunning && <p>Refreshing curriculum…</p>}
-      {loading && <p>Loading…</p>}
-      {error && <p className="text-red-500">{error}</p>}
-      {!loading && !error && (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {apprentices.map(a => (
-            <div key={a.id} className="item-card">
-              <h2 className="font-semibold text-black dark:text-white text-lg mb-1">
-                {a.first_name} {a.last_name}
-              </h2>
-              <p className="text-sm text-black dark:text-white">{a.email || '—'}</p>
-              <p className="text-sm text-black dark:text-white">
-                Standard: {a.standard_id || '—'}
-              </p>
-            </div>
-          ))}
-        </div>
-      )}
+      <Tabs
+        tabs={[
+          {
+            label: 'Apprentices',
+            content: (
+              <>
+                <div className="flex justify-between items-center mb-4">
+                  <h1 className="text-2xl font-semibold">Apprentices</h1>
+                  <Button onClick={handleRefresh} className="flex items-center">
+                    {refreshing ? <Spinner /> : 'Refresh Curriculum'}
+                  </Button>
+                </div>
+                {ingestRunning && <p>Refreshing curriculum…</p>}
+                {loading && <p>Loading…</p>}
+                {error && <p className="text-red-500">{error}</p>}
+                {!loading && !error && (
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    {apprentices.map(a => (
+                      <div key={a.id} className="item-card">
+                        <h2 className="font-semibold text-black dark:text-white text-lg mb-1">
+                          {a.first_name} {a.last_name}
+                        </h2>
+                        <p className="text-sm text-black dark:text-white">{a.email || '—'}</p>
+                        <p className="text-sm text-black dark:text-white">
+                          Standard: {a.standard_id || '—'}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </>
+            ),
+          },
+          {
+            label: 'Curriculum',
+            content: <CurriculumDashboard />,
+          },
+        ]}
+      />
       {toast && (
         <Toast
           message={toast.message}


### PR DESCRIPTION
## Summary
- create basic UI primitives under `components/ui`
- add CurriculumDashboard component with table and modal
- wrap apprentice page in new Tabs layout with Curriculum tab

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872d95bd3e8833386eb10dc04b757aa