### PR TITLE
Extend standards status API

### DIFF
--- a/__tests__/standards-api.test.js
+++ b/__tests__/standards-api.test.js
@@ -20,18 +20,58 @@ test('POST /api/standards/ingest starts ingestion', async () => {
   expect(ingestMock).toHaveBeenCalled();
 });
 
-test('GET /api/standards/status returns status', async () => {
+test('GET /api/standards/status returns status and standards', async () => {
   process.env.API_SECRET = 'shhh';
   const statusMock = jest.fn().mockReturnValue(true);
   jest.unstable_mockModule('../services/standardIngestService.js', () => ({
     getIngestStatus: statusMock,
   }));
+  const rows = [
+    {
+      id: 1,
+      code: 'STD',
+      source: 'example',
+      version: '1.0',
+      last_fetched_at: '2024-01-01',
+    },
+  ];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+
   const { default: handler } = await import('../pages/api/standards/status.js');
   const req = { method: 'GET', headers: {}, query: { secret: 'shhh' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
   await handler(req, res);
+  expect(queryMock).toHaveBeenCalledWith(expect.any(String));
   expect(res.status).toHaveBeenCalledWith(200);
-  expect(res.json).toHaveBeenCalledWith({ running: true });
+  expect(res.json).toHaveBeenCalledWith({ running: true, standards: rows });
+});
+
+test('GET /api/standards/status includes fields', async () => {
+  process.env.API_SECRET = 'shhh';
+  const statusMock = jest.fn().mockReturnValue(false);
+  jest.unstable_mockModule('../services/standardIngestService.js', () => ({
+    getIngestStatus: statusMock,
+  }));
+  const rows = [
+    {
+      id: 2,
+      code: 'X',
+      source: 'src',
+      version: 'v2',
+      last_fetched_at: '2024-02-02',
+    },
+  ];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+
+  const { default: handler } = await import('../pages/api/standards/status.js');
+  const req = { method: 'GET', headers: {}, query: { secret: 'shhh' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  const payload = res.json.mock.calls[0][0];
+  expect(payload.standards[0]).toEqual(rows[0]);
+  expect(payload).toHaveProperty('running', false);
 });
 
 test('POST /api/standards/ingest rejects invalid secret', async () => {

--- a/pages/api/standards/status.js
+++ b/pages/api/standards/status.js
@@ -1,4 +1,5 @@
 import apiHandler from '../../../lib/apiHandler.js';
+import pool from '../../../lib/db.js';
 import { getIngestStatus } from '../../../services/standardIngestService.js';
 
 async function handler(req, res) {
@@ -10,7 +11,12 @@ async function handler(req, res) {
     res.setHeader('Allow', ['GET']);
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
-  res.status(200).json({ running: getIngestStatus() });
+
+  const [rows] = await pool.query(
+    'SELECT id, code, source, version, last_fetched_at FROM standards'
+  );
+
+  res.status(200).json({ running: getIngestStatus(), standards: rows });
 }
 
 export default apiHandler(handler);


### PR DESCRIPTION
## Summary
- include standard versions in `/api/standards/status`
- update tests for new response structure

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872dc714fd88333be32d21012f0bc07