### PR TITLE
Update standards questions endpoint

### DIFF
--- a/__tests__/standards-api.test.js
+++ b/__tests__/standards-api.test.js
@@ -104,12 +104,11 @@ test('GET /api/standards/status rejects invalid secret', async () => {
   expect(statusMock).not.toHaveBeenCalled();
 });
 
-test('GET /api/standards/[id] returns grouped sections', async () => {
+test('GET /api/standards/[id] returns questions', async () => {
   process.env.API_SECRET = 'shhh';
   const rows = [
-    { section: 'A', subsection: 'A1' },
-    { section: 'A', subsection: 'A2' },
-    { section: 'B', subsection: 'B1' },
+    { no: 1, text: 'Q1' },
+    { no: 2, text: 'Q2' },
   ];
   const queryMock = jest.fn().mockResolvedValue([rows]);
   jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
@@ -119,12 +118,7 @@ test('GET /api/standards/[id] returns grouped sections', async () => {
   await handler(req, res);
   expect(queryMock).toHaveBeenCalledWith(expect.any(String), ['1']);
   expect(res.status).toHaveBeenCalledWith(200);
-  expect(res.json).toHaveBeenCalledWith({
-    sections: [
-      { section: 'A', subsections: ['A1', 'A2'] },
-      { section: 'B', subsections: ['B1'] },
-    ],
-  });
+  expect(res.json).toHaveBeenCalledWith({ questions: rows });
 });
 
 test('GET /api/standards/[id] rejects invalid secret', async () => {

--- a/pages/api/standards/[id].js
+++ b/pages/api/standards/[id].js
@@ -13,28 +13,14 @@ async function handler(req, res) {
 
   const { id } = req.query;
   const [rows] = await pool.query(
-    `SELECT section, subsection
+    `SELECT question_no AS no, question AS text
        FROM quiz_questions
       WHERE standard_id = ?
-      ORDER BY section, subsection`,
+      ORDER BY question_no`,
     [id]
   );
 
-  const map = new Map();
-  for (const row of rows) {
-    if (!map.has(row.section)) {
-      map.set(row.section, []);
-    }
-    if (row.subsection !== undefined) {
-      map.get(row.section).push(row.subsection);
-    }
-  }
-  const sections = Array.from(map, ([section, subsections]) => ({
-    section,
-    subsections,
-  }));
-
-  res.status(200).json({ sections });
+  res.status(200).json({ questions: rows });
 }
 
 export default apiHandler(handler);


### PR DESCRIPTION
## Summary
- replace `/api/standards/[id]` query with new quiz question query
- return `{ questions: rows }` from that endpoint
- update tests for the new API shape

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872e971c56c833389c9830b673d10e0