### PR TITLE
Add fetchJSON helper

### DIFF
--- a/components/office/CurriculumDashboard.jsx
+++ b/components/office/CurriculumDashboard.jsx
@@ -3,7 +3,7 @@ import Table from '../ui/Table.jsx';
 import Modal from '../ui/Modal.jsx';
 import Button from '../ui/Button.jsx';
 import { Card } from '../Card.js';
-import fetchJSON from '../../lib/fetchJSON.js';
+import { fetchJSON } from '@/lib/api';
 
 export default function CurriculumDashboard() {
   const [standards, setStandards] = useState([]);

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,5 @@
+export async function fetchJSON(url, options) {
+  const res = await fetch(url, options);
+  if (!res.ok) throw new Error('Request failed');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add `lib/api.js` for shared API helpers
- import `fetchJSON` from this new module

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872eb22c768833397745e2ca6e552d3