### PR TITLE
Switch UI components to named exports

### DIFF
--- a/components/office/CurriculumDashboard.jsx
+++ b/components/office/CurriculumDashboard.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import Table from '../ui/Table.jsx';
-import Modal from '../ui/Modal.jsx';
-import Button from '../ui/Button.jsx';
+import { Table } from '../ui/Table.jsx';
+import { Modal } from '../ui/Modal.jsx';
+import { Button } from '../ui/Button.jsx';
 import { Card } from '../Card.js';
 import { fetchJSON } from '@/lib/api';
 

--- a/components/ui/Button.jsx
+++ b/components/ui/Button.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function Button({ type = 'button', className = '', children, ...props }) {
+export function Button({ type = 'button', className = '', children, ...props }) {
   return (
     <button type={type} className={`button px-4 ${className}`} {...props}>
       {children}

--- a/components/ui/Modal.jsx
+++ b/components/ui/Modal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function Modal({ children, onClose }) {
+export function Modal({ children, onClose }) {
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div className="bg-white dark:bg-gray-800 text-black dark:text-white rounded-xl p-4 max-h-[80vh] overflow-y-auto">

--- a/components/ui/Table.jsx
+++ b/components/ui/Table.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export default function Table({ children, className = '' }) {
+export function Table({ children, className = '' }) {
   return <table className={`table-auto w-full ${className}`}>{children}</table>;
 }

--- a/pages/office/apprentices/index.js
+++ b/pages/office/apprentices/index.js
@@ -4,7 +4,7 @@ import Spinner from '../../../components/Spinner.jsx';
 import Toast from '../../../components/Toast.jsx';
 import { fetchApprentices } from '../../../lib/apprentices';
 import Tabs from '../../../components/ui/Tabs.jsx';
-import Button from '../../../components/ui/Button.jsx';
+import { Button } from '../../../components/ui/Button.jsx';
 import CurriculumDashboard from '../../../components/office/CurriculumDashboard.jsx';
 
 export default function ApprenticesPage() {


### PR DESCRIPTION
## Summary
- convert Button, Modal and Table to named exports
- update imports that reference these components

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872ebf889248333bd3e7823d807c559