### PR TITLE
Fix module path for CurriculumDashboard

### DIFF
--- a/components/office/CurriculumDashboard.jsx
+++ b/components/office/CurriculumDashboard.jsx
@@ -3,7 +3,7 @@ import { Table } from '../ui/Table.jsx';
 import { Modal } from '../ui/Modal.jsx';
 import { Button } from '../ui/Button.jsx';
 import { Card } from '../Card.js';
-import { fetchJSON } from '@/lib/api';
+import { fetchJSON } from '../../lib/api';
 
 export default function CurriculumDashboard() {
   const [standards, setStandards] = useState([]);


### PR DESCRIPTION
## Summary
- correct import path in `CurriculumDashboard.jsx`

## Testing
- `npm test` *(fails: cannot find module 'jest')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872f02e3a4083339343ade142139f21