### PR TITLE
Fix curriculum dashboard titles

### DIFF
--- a/__tests__/curriculum-dashboard.test.js
+++ b/__tests__/curriculum-dashboard.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('CurriculumDashboard displays source names', async () => {
+  const fetchMock = jest
+    .fn()
+    .mockResolvedValueOnce({
+      running: false,
+      standards: [{ id: 1, code: 'STD1', source_name: 'Standard One' }]
+    })
+    .mockResolvedValueOnce({ questions: [] });
+
+  jest.unstable_mockModule('../lib/api', () => ({
+    fetchJSON: fetchMock
+  }));
+
+  const { default: CurriculumDashboard } = await import(
+    '../components/office/CurriculumDashboard.jsx'
+  );
+  render(<CurriculumDashboard />);
+
+  await screen.findByText('Standard One');
+  expect(screen.getByText('Standard One')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: 'View Questions' }));
+  await screen.findByRole('heading', { name: 'Standard One' });
+  expect(screen.getByRole('heading', { name: 'Standard One' })).toBeInTheDocument();
+});

--- a/components/office/CurriculumDashboard.jsx
+++ b/components/office/CurriculumDashboard.jsx
@@ -53,7 +53,7 @@ export default function CurriculumDashboard() {
             {standards.map(s => (
               <tr key={s.id || s.code}>
                 <td className="px-2 py-1">{s.code}</td>
-                <td className="px-2 py-1">{s.title}</td>
+                <td className="px-2 py-1">{s.source_name}</td>
                 <td className="px-2 py-1">
                   <Button className="button-secondary" onClick={() => handleView(s)}>
                     View Questions
@@ -67,7 +67,7 @@ export default function CurriculumDashboard() {
       {selected && (
         <Modal onClose={() => setSelected(null)}>
           <Card>
-            <h2 className="text-lg font-semibold mb-2">{selected.title}</h2>
+            <h2 className="text-lg font-semibold mb-2">{selected.source_name}</h2>
             <Table>
               <thead>
                 <tr>


### PR DESCRIPTION
## Summary
- show `source_name` fields on Curriculum dashboard
- update modal header to use `source_name`
- test CurriculumDashboard shows the proper title

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6872f2ce9f0c8333ac9f5e2b744fe817