### PR TITLE
Switch to curriculum tab after refreshing standards

### DIFF
--- a/__tests__/apprentices-page.test.js
+++ b/__tests__/apprentices-page.test.js
@@ -27,7 +27,9 @@ test('refresh button posts ingest and shows toast', async () => {
     .fn()
     .mockResolvedValueOnce({ ok: true, json: async () => [] })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ running: false }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ started: true }) });
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ started: true }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ running: false }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ standards: [] }) });
   const { default: Page } = await import('../pages/office/apprentices/index.js');
   render(<Page />);
   const btn = await screen.findByRole('button', { name: 'Refresh Curriculum' });
@@ -41,4 +43,9 @@ test('refresh button posts ingest and shows toast', async () => {
   );
   await screen.findByRole('alert');
   expect(screen.getByRole('alert').textContent).toMatch('Curriculum refresh started');
+  expect(
+    global.fetch.mock.calls.filter(c =>
+      c[0].startsWith('/api/standards/status')
+    ).length
+  ).toBeGreaterThan(1);
 });

--- a/components/office/CurriculumDashboard.jsx
+++ b/components/office/CurriculumDashboard.jsx
@@ -5,14 +5,15 @@ import { Button } from '../ui/Button.jsx';
 import { Card } from '../Card.js';
 import { fetchJSON } from '../../lib/api';
 
-export default function CurriculumDashboard() {
+export default function CurriculumDashboard({ active }) {
   const [standards, setStandards] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null);
   const [questions, setQuestions] = useState([]);
 
-  useEffect(() => {
+  const load = () => {
+    setLoading(true);
     fetchJSON(
       `/api/standards/status?secret=${process.env.NEXT_PUBLIC_API_SECRET}`
     )
@@ -24,7 +25,11 @@ export default function CurriculumDashboard() {
         setError('Failed to load standards');
         setLoading(false);
       });
-  }, []);
+  };
+
+  useEffect(() => {
+    if (active) load();
+  }, [active]);
 
   const handleView = std => {
     setSelected(std);

--- a/components/ui/Tabs.jsx
+++ b/components/ui/Tabs.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 
-export default function Tabs({ tabs, className = '' }) {
-  const [active, setActive] = useState(tabs[0]?.label);
+export default function Tabs({ tabs, className = '', selected, onChange }) {
+  const [internal, setInternal] = useState(tabs[0]?.label);
+  const active = selected ?? internal;
+  const setActive = onChange ?? setInternal;
   const current = tabs.find(t => t.label === active) || tabs[0];
   return (
     <div className={className}>

--- a/pages/office/apprentices/index.js
+++ b/pages/office/apprentices/index.js
@@ -14,6 +14,7 @@ export default function ApprenticesPage() {
   const [ingestRunning, setIngestRunning] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [toast, setToast] = useState(null);
+  const [tab, setTab] = useState('Apprentices');
 
   const load = () => {
     setLoading(true);
@@ -39,6 +40,7 @@ export default function ApprenticesPage() {
       );
       if (!res.ok) throw new Error('failed');
       setToast({ type: 'success', message: 'Curriculum refresh started' });
+      setTab('Curriculum');
     } catch {
       setToast({ type: 'error', message: 'Failed to refresh curriculum' });
     } finally {
@@ -55,6 +57,8 @@ export default function ApprenticesPage() {
   return (
     <OfficeLayout>
       <Tabs
+        selected={tab}
+        onChange={setTab}
         tabs={[
           {
             label: 'Apprentices',
@@ -89,7 +93,7 @@ export default function ApprenticesPage() {
           },
           {
             label: 'Curriculum',
-            content: <CurriculumDashboard />,
+            content: <CurriculumDashboard active={tab === 'Curriculum'} />,
           },
         ]}
       />


### PR DESCRIPTION
## Summary
- add controlled tab state to apprentices page
- switch to Curriculum tab after curriculum refresh is triggered
- refetch curriculum when Curriculum tab becomes active
- allow Tabs component to be controlled from parent
- update unit test for new tab-switch behaviour

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872f8fbdb88833385b2fceb39a24173