### PR TITLE
Set cache-control header for standards API

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,5 @@ Two endpoints expose the ingested standards and their quiz questions.
 Both endpoints require the secret defined in the `API_SECRET` environment
 variable. Supply it as either a `secret` query parameter or an `X-API-SECRET`
 header when making requests.
+
+Both responses include `Cache-Control: no-store` to prevent caching.

--- a/pages/api/standards/[id].js
+++ b/pages/api/standards/[id].js
@@ -20,6 +20,7 @@ async function handler(req, res) {
     [id]
   );
 
+  res.setHeader('Cache-Control', 'no-store');
   res.status(200).json({ questions: rows });
 }
 

--- a/pages/api/standards/status.js
+++ b/pages/api/standards/status.js
@@ -31,6 +31,7 @@ async function handler(req, res) {
     return res.status(500).json({ error: 'internal_error' });
   }
 
+  res.setHeader('Cache-Control', 'no-store');
   return res.status(200).json({
     running: getIngestStatus(),
     standards: rows


### PR DESCRIPTION
## Summary
- add `Cache-Control: no-store` to standards API responses
- document cache header in README

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872fa5efaec8333a81ed3f5a11882b3