### PR TITLE
Add loading state for curriculum questions

### DIFF
--- a/__tests__/curriculum-dashboard.test.js
+++ b/__tests__/curriculum-dashboard.test.js
@@ -32,6 +32,10 @@ test('CurriculumDashboard displays source names', async () => {
   expect(screen.getByText('Standard One')).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole('button', { name: 'View Questions' }));
+  await screen.findByText('Loading…');
+  expect(screen.getByText('Loading…')).toBeInTheDocument();
+
   await screen.findByRole('heading', { name: 'Standard One' });
   expect(screen.getByRole('heading', { name: 'Standard One' })).toBeInTheDocument();
+  await screen.findByText('No questions found for this standard.');
 });

--- a/components/office/CurriculumDashboard.jsx
+++ b/components/office/CurriculumDashboard.jsx
@@ -11,6 +11,7 @@ export default function CurriculumDashboard({ active }) {
   const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null);
   const [questions, setQuestions] = useState([]);
+  const [questionsLoading, setQuestionsLoading] = useState(false);
 
   const load = () => {
     setLoading(true);
@@ -34,11 +35,18 @@ export default function CurriculumDashboard({ active }) {
   const handleView = std => {
     setSelected(std);
     setQuestions([]);
+    setQuestionsLoading(true);
     fetchJSON(
       `/api/standards/${std.id}?secret=${process.env.NEXT_PUBLIC_API_SECRET}`
     )
-      .then(d => setQuestions(d.questions || []))
-      .catch(() => setQuestions([]));
+      .then(d => {
+        setQuestions(d.questions || []);
+        setQuestionsLoading(false);
+      })
+      .catch(() => {
+        setQuestions([]);
+        setQuestionsLoading(false);
+      });
   };
 
   return (
@@ -73,22 +81,28 @@ export default function CurriculumDashboard({ active }) {
         <Modal onClose={() => setSelected(null)}>
           <Card>
             <h2 className="text-lg font-semibold mb-2">{selected.source_name}</h2>
-            <Table>
-              <thead>
-                <tr>
-                  <th className="px-2 py-1 text-left">#</th>
-                  <th className="px-2 py-1 text-left">Question</th>
-                </tr>
-              </thead>
-              <tbody>
-                {questions.map(q => (
-                  <tr key={q.no}>
-                    <td className="px-2 py-1">{q.no}</td>
-                    <td className="px-2 py-1">{q.text}</td>
+            {questionsLoading ? (
+              <p>Loading…</p>
+            ) : questions.length === 0 ? (
+              <em>No questions found for this standard.</em>
+            ) : (
+              <Table>
+                <thead>
+                  <tr>
+                    <th className="px-2 py-1 text-left">#</th>
+                    <th className="px-2 py-1 text-left">Question</th>
                   </tr>
-                ))}
-              </tbody>
-            </Table>
+                </thead>
+                <tbody>
+                  {questions.map(q => (
+                    <tr key={q.no}>
+                      <td className="px-2 py-1">{q.no}</td>
+                      <td className="px-2 py-1">{q.text}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            )}
           </Card>
         </Modal>
       )}


### PR DESCRIPTION
## Summary
- show a loading indicator when fetching standard questions
- display empty state when no questions are found
- update CurriculumDashboard test to cover loading and empty results

## Testing
- `npm ci` *(fails: Cannot download dependencies without internet)*
- `npm test` *(not run due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68730b84c8888333be8872ee96dac26a