### PR TITLE
Add cache header checks in standards API tests

### DIFF
--- a/__tests__/standards-api.test.js
+++ b/__tests__/standards-api.test.js
@@ -45,6 +45,7 @@ test('GET /api/standards/status returns status and standards', async () => {
   expect(queryMock).toHaveBeenCalledWith(expect.any(String));
   expect(res.status).toHaveBeenCalledWith(200);
   expect(res.json).toHaveBeenCalledWith({ running: true, standards: rows });
+  expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
 });
 
 test('GET /api/standards/status includes fields', async () => {
@@ -119,6 +120,7 @@ test('GET /api/standards/[id] returns questions', async () => {
   expect(queryMock).toHaveBeenCalledWith(expect.any(String), ['1']);
   expect(res.status).toHaveBeenCalledWith(200);
   expect(res.json).toHaveBeenCalledWith({ questions: rows });
+  expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
 });
 
 test('GET /api/standards/[id] rejects invalid secret', async () => {


### PR DESCRIPTION
## Summary
- add assertions that API responses set `Cache-Control: no-store` in `/api/standards/status` and `/api/standards/[id]`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68730c5d37ac8333a2680d7e9ee74b08