### PR TITLE
Add PDF column to Curriculum dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Once the dev server is running, open
 `http://localhost:3000/office/apprentices` or click **Apprentices** in the
 Office sidebar to view the list of apprentices.
 
+The page includes a **Curriculum** tab that lists all training standards. Each
+row shows the standard code, title, a **PDF** link to the original document and
+a button to view any quiz questions.
+
 ### Standards API
 
 Two endpoints expose the ingested standards and their quiz questions.

--- a/__tests__/curriculum-dashboard.test.js
+++ b/__tests__/curriculum-dashboard.test.js
@@ -15,7 +15,14 @@ test('CurriculumDashboard displays source names', async () => {
     .fn()
     .mockResolvedValueOnce({
       running: false,
-      standards: [{ id: 1, code: 'STD1', source_name: 'Standard One' }]
+      standards: [
+        {
+          id: 1,
+          code: 'STD1',
+          source_name: 'Standard One',
+          source_url: 'http://example.com/std1.pdf'
+        }
+      ]
     })
     .mockResolvedValueOnce({ questions: [] });
 
@@ -30,6 +37,8 @@ test('CurriculumDashboard displays source names', async () => {
 
   await screen.findByText('Standard One');
   expect(screen.getByText('Standard One')).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: 'PDF' });
+  expect(link).toHaveAttribute('href', 'http://example.com/std1.pdf');
 
   fireEvent.click(screen.getByRole('button', { name: 'View Questions' }));
   await screen.findByText('Loading…');

--- a/components/office/CurriculumDashboard.jsx
+++ b/components/office/CurriculumDashboard.jsx
@@ -59,6 +59,7 @@ export default function CurriculumDashboard({ active }) {
             <tr>
               <th className="px-2 py-1 text-left">Code</th>
               <th className="px-2 py-1 text-left">Title</th>
+              <th className="px-2 py-1 text-left">PDF</th>
               <th className="px-2 py-1 text-left">Questions</th>
             </tr>
           </thead>
@@ -67,6 +68,11 @@ export default function CurriculumDashboard({ active }) {
               <tr key={s.id || s.code}>
                 <td className="px-2 py-1">{s.code}</td>
                 <td className="px-2 py-1">{s.source_name}</td>
+                <td className="px-2 py-1">
+                  <a href={s.source_url} target="_blank" rel="noopener noreferrer">
+                    PDF
+                  </a>
+                </td>
                 <td className="px-2 py-1">
                   <Button className="button-secondary" onClick={() => handleView(s)}>
                     View Questions


### PR DESCRIPTION
## Summary
- show a PDF link for each training standard
- update curriculum dashboard test for the PDF link
- document the Curriculum tab in the Apprentice Manager section

## Testing
- `npm ci` *(fails: Could not reach registry)*
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6873117162b083338f5b0e87f5db3552