### PR TITLE
Improve standards ingestion

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "next": "15.3.4",
     "node-cron": "^3.0.3",
     "nodemailer": "^6.9.8",
+    "pdfjs-dist": "^4.0.269",
     "pdf-parse": "^1.1.1",
     "pdfkit": "^0.13.0",
     "pino": "^8.17.0",


### PR DESCRIPTION
## Summary
- parse PDFs using `pdfjs-dist`
- split document text into numbered sections
- store sections and update `target_questions`
- close the DB connection when done
- add `pdfjs-dist` dependency

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6873195a0e988333abee087a9557612f