### PR TITLE
Add quiz question seeding utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,13 @@ variable. Supply it as either a `secret` query parameter or an `X-API-SECRET`
 header when making requests.
 
 Both responses include `Cache-Control: no-store` to prevent caching.
+
+### Seeding quiz questions
+
+Sample quiz questions live in `data/questionBank.json`. Use `scripts/seedQuestions.js` to insert or update these rows in the `quiz_questions` table:
+
+```bash
+node scripts/seedQuestions.js
+```
+
+Ensure `DATABASE_URL` is set so the script can connect to the database.

--- a/data/questionBank.json
+++ b/data/questionBank.json
@@ -1,0 +1,22 @@
+[
+  {
+    "standard": "STD001",
+    "no": 1,
+    "text": "What is the first step when diagnosing brake problems?"
+  },
+  {
+    "standard": "STD001",
+    "no": 2,
+    "text": "Which tool measures disc brake rotor thickness?"
+  },
+  {
+    "standard": "STD002",
+    "no": 1,
+    "text": "Name one use for a digital multimeter."
+  },
+  {
+    "standard": "STD002",
+    "no": 2,
+    "text": "What safety equipment should always be worn when welding?"
+  }
+]

--- a/scripts/seedQuestions.js
+++ b/scripts/seedQuestions.js
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import pool from '../lib/db.js';
+
+const dataPath = path.resolve('data/questionBank.json');
+const questions = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+
+for (const q of questions) {
+  const [[standard]] = await pool.query(
+    'SELECT id FROM standards WHERE code = ? LIMIT 1',
+    [q.standard]
+  );
+  if (!standard) {
+    console.warn(`Standard code ${q.standard} not found, skipping question ${q.no}`);
+    continue;
+  }
+
+  await pool.query(
+    `INSERT INTO quiz_questions (standard_id, question_no, question)
+     VALUES (?, ?, ?)
+     ON DUPLICATE KEY UPDATE question = VALUES(question)`,
+    [standard.id, q.no, q.text]
+  );
+}
+
+console.log(`\u2705 Seeded ${questions.length} questions`);
+await pool.end();


### PR DESCRIPTION
## Summary
- create `data/questionBank.json` with sample quiz questions
- add `scripts/seedQuestions.js` to load this JSON and upsert rows in `quiz_questions`
- document how to run the script in the README

## Testing
- `npm test` *(fails: module not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68731ae994ec8333af317cc3de9d31c1