### PR TITLE
Update standards API endpoints

### DIFF
--- a/__tests__/standards-api.test.js
+++ b/__tests__/standards-api.test.js
@@ -33,6 +33,7 @@ test('GET /api/standards/status returns status and standards', async () => {
       source: 'example',
       version: '1.0',
       last_fetched_at: '2024-01-01',
+      generated_questions: 3,
     },
   ];
   const queryMock = jest.fn().mockResolvedValue([rows]);
@@ -61,6 +62,7 @@ test('GET /api/standards/status includes fields', async () => {
       source: 'src',
       version: 'v2',
       last_fetched_at: '2024-02-02',
+      generated_questions: 1,
     },
   ];
   const queryMock = jest.fn().mockResolvedValue([rows]);
@@ -108,8 +110,8 @@ test('GET /api/standards/status rejects invalid secret', async () => {
 test('GET /api/standards/[id] returns questions', async () => {
   process.env.API_SECRET = 'shhh';
   const rows = [
-    { no: 1, text: 'Q1' },
-    { no: 2, text: 'Q2' },
+    { no: 1, text: 'Q1', options: ['a', 'b'], answer_index: 0 },
+    { no: 2, text: 'Q2', options: ['x', 'y'], answer_index: 1 },
   ];
   const queryMock = jest.fn().mockResolvedValue([rows]);
   jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));

--- a/pages/api/standards/[id].js
+++ b/pages/api/standards/[id].js
@@ -16,13 +16,14 @@ async function handler(req, res) {
 
   // Fetch questions for this standard
   const [rows] = await pool.query(
-    `SELECT question_no AS no, question
+    `SELECT question_no AS no, question AS text, options, answer_index
        FROM quiz_questions
       WHERE standard_id = ?
       ORDER BY question_no`,
     [id]
   );
 
+  res.setHeader('Cache-Control', 'no-store');
   return res.status(200).json({ questions: rows });
 }
 

--- a/pages/api/standards/status.js
+++ b/pages/api/standards/status.js
@@ -18,13 +18,16 @@ async function handler(req, res) {
   try {
     [rows] = await pool.query(
       `SELECT
-         id,
-         code,
-         title   AS source_name,
-         pdf_url AS source_url,
-         created_at
-       FROM standards
-       ORDER BY id`
+         s.id,
+         s.code,
+         s.title   AS source_name,
+         s.pdf_url AS source_url,
+         s.created_at,
+         COUNT(q.id) AS generated_questions
+       FROM standards s
+       LEFT JOIN quiz_questions q ON q.standard_id = s.id
+       GROUP BY s.id
+       ORDER BY s.id`
     );
   } catch (err) {
     console.error('Standards status query failed:', err);


### PR DESCRIPTION
## Summary
- compute `generated_questions` per standard in the status endpoint
- expose question options and answers in the questions endpoint
- adjust API tests for the new fields

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68731bedd108833386111daf263f6164