### PR TITLE
Show quiz progress and options

### DIFF
--- a/__tests__/curriculum-dashboard.test.js
+++ b/__tests__/curriculum-dashboard.test.js
@@ -20,11 +20,17 @@ test('CurriculumDashboard displays source names', async () => {
           id: 1,
           code: 'STD1',
           source_name: 'Standard One',
-          source_url: 'http://example.com/std1.pdf'
+          source_url: 'http://example.com/std1.pdf',
+          generated_questions: 1,
+          target_questions: 2
         }
       ]
     })
-    .mockResolvedValueOnce({ questions: [] });
+    .mockResolvedValueOnce({
+      questions: [
+        { no: 1, text: 'Q1', options: ['A', 'B'], answer_index: 1 }
+      ]
+    });
 
   jest.unstable_mockModule('../lib/api', () => ({
     fetchJSON: fetchMock
@@ -39,6 +45,7 @@ test('CurriculumDashboard displays source names', async () => {
   expect(screen.getByText('Standard One')).toBeInTheDocument();
   const link = screen.getByRole('link', { name: 'PDF' });
   expect(link).toHaveAttribute('href', 'http://example.com/std1.pdf');
+  expect(screen.getByText('1 / 2')).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole('button', { name: 'View Questions' }));
   await screen.findByText('Loading…');
@@ -46,5 +53,6 @@ test('CurriculumDashboard displays source names', async () => {
 
   await screen.findByRole('heading', { name: 'Standard One' });
   expect(screen.getByRole('heading', { name: 'Standard One' })).toBeInTheDocument();
-  await screen.findByText('No questions found for this standard.');
+  await screen.findByText('Q1');
+  expect(screen.getByText('✓ B')).toBeInTheDocument();
 });

--- a/components/office/CurriculumDashboard.jsx
+++ b/components/office/CurriculumDashboard.jsx
@@ -60,6 +60,7 @@ export default function CurriculumDashboard({ active }) {
               <th className="px-2 py-1 text-left">Code</th>
               <th className="px-2 py-1 text-left">Title</th>
               <th className="px-2 py-1 text-left">PDF</th>
+              <th className="px-2 py-1 text-left">Generated</th>
               <th className="px-2 py-1 text-left">Questions</th>
             </tr>
           </thead>
@@ -72,6 +73,9 @@ export default function CurriculumDashboard({ active }) {
                   <a href={s.source_url} target="_blank" rel="noopener noreferrer">
                     PDF
                   </a>
+                </td>
+                <td className="px-2 py-1">
+                  {s.generated_questions} / {s.target_questions}
                 </td>
                 <td className="px-2 py-1">
                   <Button className="button-secondary" onClick={() => handleView(s)}>
@@ -97,6 +101,7 @@ export default function CurriculumDashboard({ active }) {
                   <tr>
                     <th className="px-2 py-1 text-left">#</th>
                     <th className="px-2 py-1 text-left">Question</th>
+                    <th className="px-2 py-1 text-left">Options</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -104,6 +109,19 @@ export default function CurriculumDashboard({ active }) {
                     <tr key={q.no}>
                       <td className="px-2 py-1">{q.no}</td>
                       <td className="px-2 py-1">{q.text}</td>
+                      <td className="px-2 py-1">
+                        <ul className="list-disc pl-4">
+                          {q.options.map((opt, idx) => (
+                            <li
+                              key={idx}
+                              className={idx === q.answer_index ? 'font-semibold' : ''}
+                            >
+                              {idx === q.answer_index ? '✓ ' : ''}
+                              {opt}
+                            </li>
+                          ))}
+                        </ul>
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/pages/api/standards/status.js
+++ b/pages/api/standards/status.js
@@ -23,6 +23,7 @@ async function handler(req, res) {
          s.title   AS source_name,
          s.pdf_url AS source_url,
          s.created_at,
+         s.target_questions,
          COUNT(q.id) AS generated_questions
        FROM standards s
        LEFT JOIN quiz_questions q ON q.standard_id = s.id


### PR DESCRIPTION
## Summary
- display target question counts and progress in CurriculumDashboard
- show multiple-choice options with correct answers in modal
- include `target_questions` in standards status API
- update CurriculumDashboard test for new UI

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68731d78ef748333989f0cde13bfe97d