### PR TITLE
Add description autocomplete for quote items

### DIFF
--- a/components/DescriptionAutocomplete.js
+++ b/components/DescriptionAutocomplete.js
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react';
+
+export default function DescriptionAutocomplete({ value, onChange, onSelect }) {
+  const [term, setTerm] = useState(value || '');
+  const [results, setResults] = useState([]);
+
+  useEffect(() => {
+    if (value !== undefined) setTerm(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (!term) return setResults([]);
+    let cancel = false;
+    fetch(`/api/parts?q=${encodeURIComponent(term)}`)
+      .then(r => (r.ok ? r.json() : []))
+      .then(data => {
+        if (cancel) return;
+        setResults(data);
+      })
+      .catch(() => {
+        if (cancel) return;
+        setResults([]);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [term]);
+
+  return (
+    <div className="relative">
+      <input
+        className="input w-full"
+        value={term}
+        onChange={e => {
+          setTerm(e.target.value);
+          onChange && onChange(e.target.value);
+        }}
+        placeholder="Description"
+      />
+      {term && results.length > 0 && (
+        <div className="absolute z-10 bg-white shadow rounded w-full text-black">
+          {results.map(p => (
+            <div
+              key={p.id}
+              className="px-2 py-1 cursor-pointer hover:bg-gray-200"
+              onClick={() => {
+                onSelect && onSelect(p);
+                const desc = p.description || '';
+                if (value === undefined) {
+                  setTerm('');
+                } else {
+                  setTerm(desc);
+                  onChange && onChange(desc);
+                }
+                setResults([]);
+              }}
+            >
+              {p.description} - {p.part_number}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/office/quotations/new.js
+++ b/pages/office/quotations/new.js
@@ -16,6 +16,7 @@ const emptyItem = {
   price: 0,
 };
 import PartAutocomplete from '../../../components/PartAutocomplete';
+import DescriptionAutocomplete from '../../../components/DescriptionAutocomplete';
 import ClientAutocomplete from '../../../components/ClientAutocomplete';
 
 export default function NewQuotationPage() {
@@ -357,11 +358,13 @@ export default function NewQuotationPage() {
                   changeItem(i, 'unit_cost', p.unit_cost || 0);
                 }}
               />
-              <input
-                className="input w-full col-span-4"
-                placeholder="Description"
+              <DescriptionAutocomplete
                 value={it.description}
-                onChange={e => changeItem(i, 'description', e.target.value)}
+                onChange={v => changeItem(i, 'description', v)}
+                onSelect={p => {
+                  changeItem(i, 'description', p.description || '');
+                  changeItem(i, 'part_id', p.id);
+                }}
               />
               <input
                 type="number"


### PR DESCRIPTION
## Summary
- create `DescriptionAutocomplete` for finding parts by description
- use the new component in quotation form

## Testing
- `npm test` *(fails: Cannot find module 'node_modules/.bin/jest')*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6875712c5d248333a394dff4414762f9