### PR TITLE
Fix vehicle_id parsing in job creation

### DIFF
--- a/pages/api/jobs/index.js
+++ b/pages/api/jobs/index.js
@@ -24,7 +24,12 @@ async function handler(req, res) {
       return res.status(200).json(jobs);
     }
     if (req.method === 'POST') {
-      const job = await service.createJob(req.body);
+      const data = { ...req.body };
+      if (data.vehicle_id !== undefined && data.vehicle_id !== null) {
+        const vid = Number(data.vehicle_id);
+        if (!Number.isNaN(vid)) data.vehicle_id = vid;
+      }
+      const job = await service.createJob(data);
       return res.status(201).json(job);
     }
     res.setHeader('Allow', ['GET','POST']);

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -45,6 +45,10 @@ export async function getJobById(id) {
 
 export async function createJob({ id, customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay }) {
   const finalStatus = status || 'unassigned';
+  const parsedVehicleId =
+    vehicle_id !== undefined && vehicle_id !== null && !Number.isNaN(Number(vehicle_id))
+      ? Number(vehicle_id)
+      : null;
   if (!(await jobStatusExists(finalStatus))) {
     throw new Error('Invalid job status');
   }
@@ -56,16 +60,16 @@ export async function createJob({ id, customer_id, vehicle_id, scheduled_start, 
     await pool.query(
       `INSERT INTO jobs (id, customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay)
        VALUES (?,?,?,?,?,?,?)`,
-      [id, customer_id || null, vehicle_id || null, scheduled_start || null, scheduled_end || null, finalStatus, bay || null]
+      [id, customer_id || null, parsedVehicleId, scheduled_start || null, scheduled_end || null, finalStatus, bay || null]
     );
-    return { id, customer_id, vehicle_id, scheduled_start, scheduled_end, status: finalStatus, bay };
+    return { id, customer_id, vehicle_id: parsedVehicleId, scheduled_start, scheduled_end, status: finalStatus, bay };
   }
   const [{ insertId }] = await pool.query(
     `INSERT INTO jobs (customer_id, vehicle_id, scheduled_start, scheduled_end, status, bay)
      VALUES (?,?,?,?,?,?)`,
-    [customer_id || null, vehicle_id || null, scheduled_start || null, scheduled_end || null, finalStatus, bay || null]
+    [customer_id || null, parsedVehicleId, scheduled_start || null, scheduled_end || null, finalStatus, bay || null]
   );
-  return { id: insertId, customer_id, vehicle_id, scheduled_start, scheduled_end, status: finalStatus, bay };
+  return { id: insertId, customer_id, vehicle_id: parsedVehicleId, scheduled_start, scheduled_end, status: finalStatus, bay };
 }
 
 export async function updateJob(


### PR DESCRIPTION
## Summary
- ensure API converts vehicle_id from request body to a number before creating a job
- store parsed vehicle_id in job creation service

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6875729cfc5483338fad0eaa49f2d8fb