### PR TITLE
Remove scheduled end fields

### DIFF
--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -50,7 +50,6 @@ export default function JobManagementPage() {
         body: JSON.stringify({
           engineer_id: data.engineer_id,
           scheduled_start: data.scheduled_start,
-          scheduled_end: data.scheduled_end,
         }),
       });
       if (!res.ok) throw new Error();
@@ -155,15 +154,6 @@ export default function JobManagementPage() {
                     onChange={e => change(job.id, 'scheduled_start', e.target.value)}
                     className="input w-full"
                     required
-                  />
-                </div>
-                <div>
-                  <label className="block mb-1">Scheduled End</label>
-                  <input
-                    type="datetime-local"
-                    value={f.scheduled_end || ''}
-                    onChange={e => change(job.id, 'scheduled_end', e.target.value)}
-                    className="input w-full"
                   />
                 </div>
                 <div className="flex gap-2">

--- a/pages/office/jobs/[id].js
+++ b/pages/office/jobs/[id].js
@@ -21,7 +21,6 @@ export default function JobViewPage() {
     status: '',
     engineer_id: '',
     scheduled_start: '',
-    scheduled_end: '',
     notes: '',
   });
 
@@ -56,7 +55,6 @@ export default function JobViewPage() {
           scheduled_start: j.scheduled_start
             ? j.scheduled_start.slice(0, 16)
             : '',
-          scheduled_end: j.scheduled_end ? j.scheduled_end.slice(0, 16) : '',
           notes: j.notes || '',
         });
         if (j.customer_id) {
@@ -93,7 +91,6 @@ export default function JobViewPage() {
           body: JSON.stringify({
             engineer_id: form.engineer_id,
             scheduled_start: form.scheduled_start,
-            ...(form.scheduled_end ? { scheduled_end: form.scheduled_end } : {}),
           }),
         });
         if (!res.ok) throw new Error();
@@ -252,16 +249,6 @@ export default function JobViewPage() {
                 type="datetime-local"
                 name="scheduled_start"
                 value={form.scheduled_start}
-                onChange={change}
-                className="input w-full"
-              />
-            </div>
-            <div>
-              <label className="block mb-1">Scheduled End</label>
-              <input
-                type="datetime-local"
-                name="scheduled_end"
-                value={form.scheduled_end}
                 onChange={change}
                 className="input w-full"
               />

--- a/pages/office/jobs/assign.js
+++ b/pages/office/jobs/assign.js
@@ -9,7 +9,7 @@ export default function AssignJobPage() {
   const router = useRouter();
   const { id } = router.query;
   const [engineers, setEngineers] = useState([]);
-  const [form, setForm] = useState({ engineer_id: '', scheduled_start: '', scheduled_end: '' });
+  const [form, setForm] = useState({ engineer_id: '', scheduled_start: '' });
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -32,7 +32,6 @@ export default function AssignJobPage() {
           scheduled_start: job.scheduled_start
             ? job.scheduled_start.slice(0, 16)
             : '',
-          scheduled_end: job.scheduled_end ? job.scheduled_end.slice(0, 16) : '',
         });
       } catch {
         // ignore
@@ -51,7 +50,6 @@ export default function AssignJobPage() {
         engineer_id: form.engineer_id,
         scheduled_start: form.scheduled_start,
       };
-      if (form.scheduled_end) data.scheduled_end = form.scheduled_end;
       const res = await fetch(`/api/jobs/${id}/assign`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -93,16 +91,6 @@ export default function AssignJobPage() {
             type="datetime-local"
             name="scheduled_start"
             value={form.scheduled_start}
-            onChange={change}
-            className="input w-full"
-          />
-        </div>
-        <div>
-          <label className="block mb-1">Scheduled End</label>
-          <input
-            type="datetime-local"
-            name="scheduled_end"
-            value={form.scheduled_end}
             onChange={change}
             className="input w-full"
           />


### PR DESCRIPTION
## Summary
- drop scheduled end fields from assign forms and job management list
- update job view page accordingly

## Testing
- `npm install` *(fails: network access blocked)*
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687574119d7c83338e19a76bb7d1db5c