### PR TITLE
Fix updateJob dynamic update

### DIFF
--- a/__tests__/jobsService.test.js
+++ b/__tests__/jobsService.test.js
@@ -20,7 +20,7 @@ test('updateJob creates invoice when notifying client for collection', async () 
 
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/UPDATE jobs/),
-    [4, null, null, null, 'notified client for collection', null, 2]
+    [4, 'notified client for collection', 2]
   );
   expect(createInvoiceMock).toHaveBeenCalledWith({ job_id: 2, customer_id: 4, status: 'awaiting collection' });
   expect(result).toEqual({ ok: true });
@@ -68,12 +68,12 @@ test('engineer completes job then office notifies client for collection', async 
   expect(queryMock).toHaveBeenNthCalledWith(
     1,
     expect.stringMatching(/UPDATE jobs/),
-    [null, null, null, null, 'engineer completed', null, 5]
+    ['engineer completed', 5]
   );
   expect(queryMock).toHaveBeenNthCalledWith(
     2,
     expect.stringMatching(/UPDATE jobs/),
-    [8, null, null, null, 'notified client for collection', null, 5]
+    [8, 'notified client for collection', 5]
   );
   expect(createInvoiceMock).toHaveBeenCalledWith({ job_id: 5, customer_id: 8, status: 'awaiting collection' });
 });
@@ -90,7 +90,7 @@ test('updateJob updates notes', async () => {
 
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/UPDATE jobs/),
-    [null, null, null, null, null, null, 'hello', 7]
+    ['hello', 7]
   );
 });
 

--- a/pages/api/jobs/[id].js
+++ b/pages/api/jobs/[id].js
@@ -16,24 +16,7 @@ async function handler(req, res) {
       return res.status(200).json(job);
     }
     if (req.method === 'PUT') {
-      const {
-        customer_id,
-        vehicle_id,
-        scheduled_start,
-        scheduled_end,
-        status,
-        bay,
-        notes,
-      } = req.body;
-      const updated = await service.updateJob(id, {
-        customer_id,
-        vehicle_id,
-        scheduled_start,
-        scheduled_end,
-        status,
-        bay,
-        notes,
-      });
+      const updated = await service.updateJob(id, req.body);
       return res.status(200).json(updated);
     }
     if (req.method === 'DELETE') {


### PR DESCRIPTION
## Summary
- dynamically build the SQL `SET` clause in `updateJob`
- simplify jobs API by passing request body directly
- adjust jobs service tests for new parameter handling

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_687576ad474483338a2bbdc806cb455b