### PR TITLE
Add shift management enhancements

### DIFF
--- a/components/EmployeeAutocomplete.jsx
+++ b/components/EmployeeAutocomplete.jsx
@@ -1,0 +1,86 @@
+import { useState, useEffect } from 'react';
+
+export default function EmployeeAutocomplete({ value, onChange, onSelect }) {
+  const [term, setTerm] = useState(value || '');
+  const [results, setResults] = useState([]);
+
+  useEffect(() => {
+    if (value !== undefined) setTerm(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (!term) {
+      setResults([]);
+      return;
+    }
+    let cancel = false;
+    const load = async () => {
+      try {
+        const [engRes, appRes] = await Promise.all([
+          fetch('/api/engineers'),
+          fetch('/api/apprentices'),
+        ]);
+        const [engData, appData] = await Promise.all([
+          engRes.ok ? engRes.json() : [],
+          appRes.ok ? appRes.json() : [],
+        ]);
+        if (cancel) return;
+        const q = term.toLowerCase();
+        const eng = engData.filter(e =>
+          e.username.toLowerCase().includes(q) ||
+          (e.email || '').toLowerCase().includes(q)
+        ).map(e => ({ id: e.id, label: e.username }));
+        const app = appData.filter(a => {
+          const name = `${a.first_name || ''} ${a.last_name || ''}`.trim();
+          return (
+            name.toLowerCase().includes(q) ||
+            (a.email || '').toLowerCase().includes(q)
+          );
+        }).map(a => ({ id: a.id, label: `${a.first_name || ''} ${a.last_name || ''}`.trim() }));
+        setResults([...eng, ...app]);
+      } catch {
+        if (cancel) return;
+        setResults([]);
+      }
+    };
+    load();
+    return () => {
+      cancel = true;
+    };
+  }, [term]);
+
+  return (
+    <div className="relative">
+      <input
+        className="input w-full"
+        value={term}
+        onChange={e => {
+          setTerm(e.target.value);
+          onChange && onChange(e.target.value);
+        }}
+        placeholder="Employee name or email"
+      />
+      {term && results.length > 0 && (
+        <div className="absolute z-10 bg-white shadow rounded w-full text-black">
+          {results.map(r => (
+            <div
+              key={r.id}
+              className="px-2 py-1 cursor-pointer hover:bg-gray-200"
+              onClick={() => {
+                onSelect && onSelect(r);
+                if (value === undefined) {
+                  setTerm('');
+                } else {
+                  setTerm(r.label);
+                }
+                setResults([]);
+              }}
+            >
+              {r.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/HrShiftForm.jsx
+++ b/components/HrShiftForm.jsx
@@ -1,7 +1,12 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import EmployeeAutocomplete from './EmployeeAutocomplete.jsx';
 
-export default function HrShiftForm({ onSubmit }) {
+export default function HrShiftForm({ onSubmit, initialData }) {
   const [form, setForm] = useState({ employee_id: '', start_time: '', end_time: '' });
+
+  useEffect(() => {
+    if (initialData) setForm(initialData);
+  }, [initialData]);
 
   const change = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
 
@@ -14,8 +19,10 @@ export default function HrShiftForm({ onSubmit }) {
   return (
     <form onSubmit={submit} className="space-y-2 max-w-md mb-4">
       <div>
-        <label className="block mb-1">Employee ID</label>
-        <input name="employee_id" value={form.employee_id} onChange={change} className="input w-full" />
+        <label className="block mb-1">Employee</label>
+        <EmployeeAutocomplete
+          onSelect={e => setForm(f => ({ ...f, employee_id: e.id }))}
+        />
       </div>
       <div>
         <label className="block mb-1">Start Time</label>

--- a/components/HrShiftTable.jsx
+++ b/components/HrShiftTable.jsx
@@ -1,4 +1,4 @@
-export default function HrShiftTable({ shifts = [] }) {
+export default function HrShiftTable({ shifts = [], onEdit, onDelete, onCopy }) {
   return (
     <table className="mb-4 table-auto w-full">
       <thead>
@@ -6,6 +6,7 @@ export default function HrShiftTable({ shifts = [] }) {
           <th className="px-2 py-1">Employee</th>
           <th className="px-2 py-1">Start</th>
           <th className="px-2 py-1">End</th>
+          <th className="px-2 py-1"></th>
         </tr>
       </thead>
       <tbody>
@@ -14,6 +15,32 @@ export default function HrShiftTable({ shifts = [] }) {
             <td className="px-2 py-1">{s.employee_id}</td>
             <td className="px-2 py-1">{s.start_time}</td>
             <td className="px-2 py-1">{s.end_time}</td>
+            <td className="px-2 py-1 space-x-1">
+              {onEdit && (
+                <button
+                  className="button px-2 text-sm"
+                  onClick={() => onEdit(s)}
+                >
+                  Edit
+                </button>
+              )}
+              {onCopy && (
+                <button
+                  className="button px-2 text-sm"
+                  onClick={() => onCopy(s)}
+                >
+                  Copy
+                </button>
+              )}
+              {onDelete && (
+                <button
+                  className="button px-2 text-sm bg-red-600 hover:bg-red-700"
+                  onClick={() => onDelete(s)}
+                >
+                  Delete
+                </button>
+              )}
+            </td>
           </tr>
         ))}
       </tbody>

--- a/pages/api/hr/shifts/index.js
+++ b/pages/api/hr/shifts/index.js
@@ -10,7 +10,17 @@ async function handler(req, res) {
     const created = await service.createShift(req.body || {});
     return res.status(201).json(created);
   }
-  res.setHeader('Allow', ['GET','POST']);
+  if (req.method === 'PUT') {
+    const { id, ...data } = req.body || {};
+    const updated = await service.updateShift(id, data);
+    return res.status(200).json(updated);
+  }
+  if (req.method === 'DELETE') {
+    const { id } = req.body || {};
+    await service.deleteShift(id);
+    return res.status(204).end();
+  }
+  res.setHeader('Allow', ['GET','POST','PUT','DELETE']);
   res.status(405).end(`Method ${req.method} Not Allowed`);
 }
 

--- a/pages/office/hr/shift-scheduling.js
+++ b/pages/office/hr/shift-scheduling.js
@@ -2,10 +2,13 @@ import { useEffect, useState } from 'react';
 import OfficeLayout from '../../../components/OfficeLayout.jsx';
 import HrShiftForm from '../../../components/HrShiftForm.jsx';
 import HrShiftTable from '../../../components/HrShiftTable.jsx';
+import EmployeeAutocomplete from '../../../components/EmployeeAutocomplete.jsx';
 
 export default function ShiftSchedulingPage() {
   const [shifts, setShifts] = useState([]);
   const [error, setError] = useState('');
+  const [filterId, setFilterId] = useState('');
+  const [editing, setEditing] = useState(null);
 
   const load = () => {
     fetch('/api/hr/shifts')
@@ -29,12 +32,74 @@ export default function ShiftSchedulingPage() {
     }
   };
 
+  const updateShift = async data => {
+    try {
+      await fetch('/api/hr/shifts', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      setEditing(null);
+      load();
+    } catch {
+      setError('Failed to update shift');
+    }
+  };
+
+  const removeShift = async id => {
+    if (!confirm('Delete this shift?')) return;
+    await fetch('/api/hr/shifts', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    });
+    load();
+  };
+
+  const copyShift = async s => {
+    const countStr = prompt('Copy for how many additional days?');
+    const count = parseInt(countStr, 10);
+    if (!count || count < 1) return;
+    const start = new Date(s.start_time);
+    const end = new Date(s.end_time);
+    for (let i = 1; i <= count; i++) {
+      const newStart = new Date(start.getTime() + 86400000 * i);
+      const newEnd = new Date(end.getTime() + 86400000 * i);
+      await fetch('/api/hr/shifts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          employee_id: s.employee_id,
+          start_time: newStart.toISOString().slice(0, 16),
+          end_time: newEnd.toISOString().slice(0, 16),
+        }),
+      });
+    }
+    load();
+  };
+
   return (
     <OfficeLayout>
       <h1 className="text-2xl font-semibold mb-4">Shift Scheduling</h1>
       {error && <p className="text-red-500">{error}</p>}
-      <HrShiftForm onSubmit={addShift} />
-      <HrShiftTable shifts={shifts} />
+      <div className="mb-4">
+        <EmployeeAutocomplete onSelect={e => setFilterId(e.id)} />
+      </div>
+      <HrShiftForm
+        onSubmit={editing ? updateShift : addShift}
+        initialData={editing || undefined}
+      />
+      {editing && (
+        <button className="button mb-4" onClick={() => setEditing(null)}>
+          Cancel Edit
+        </button>
+      )}
+      <HrShiftTable
+        shifts={filterId ? shifts.filter(s => String(s.employee_id) === String(filterId)) : shifts}
+        onEdit={s => setEditing(s)}
+        onDelete={s => removeShift(s.id)}
+        onCopy={copyShift}
+      />
     </OfficeLayout>
   );
 }

--- a/services/shiftsService.js
+++ b/services/shiftsService.js
@@ -14,3 +14,25 @@ export async function createShift({ employee_id, start_time, end_time }) {
   );
   return { id: insertId, employee_id, start_time, end_time };
 }
+
+export async function updateShift(id, data = {}) {
+  const fields = [];
+  const params = [];
+  for (const key of ['employee_id', 'start_time', 'end_time']) {
+    if (Object.prototype.hasOwnProperty.call(data, key)) {
+      fields.push(`${key}=?`);
+      params.push(data[key] ?? null);
+    }
+  }
+  if (fields.length) {
+    const sql = `UPDATE shifts SET ${fields.join(', ')} WHERE id=?`;
+    params.push(id);
+    await pool.query(sql, params);
+  }
+  return { ok: true };
+}
+
+export async function deleteShift(id) {
+  await pool.query('DELETE FROM shifts WHERE id=?', [id]);
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- add `EmployeeAutocomplete` to search engineers/apprentices
- integrate `EmployeeAutocomplete` into `HrShiftForm`
- allow editing, copying and filtering shifts in scheduling page
- support updating and deleting shifts API-side

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68757cbc7ed48333b599eec02f6253a3