### PR TITLE
Fix dropdown visibility in PartAutocomplete

### DIFF
--- a/components/PartAutocomplete.js
+++ b/components/PartAutocomplete.js
@@ -58,7 +58,7 @@ export default function PartAutocomplete({
         }}
         placeholder="Part number or description"
       />
-      {term && (
+      {term && (results.length > 0 || showAdd) && (
         <div className="absolute z-10 bg-white shadow rounded w-full text-black">
           {results.map(p => (
             <div


### PR DESCRIPTION
## Summary
- ensure part dropdown only shows when term is entered and there are results or Add Part

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757e5940f48333926e5e13e588a1e5