### PR TITLE
Add user roles management

### DIFF
--- a/pages/api/user-roles/[id].js
+++ b/pages/api/user-roles/[id].js
@@ -1,0 +1,18 @@
+import { updateRole, deleteRole } from '../../../services/userRolesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  const { id } = req.query;
+  if (req.method === 'PUT') {
+    const role = await updateRole(id, req.body);
+    return res.status(200).json(role);
+  }
+  if (req.method === 'DELETE') {
+    await deleteRole(id);
+    return res.status(204).end();
+  }
+  res.setHeader('Allow', ['PUT','DELETE']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/api/user-roles/index.js
+++ b/pages/api/user-roles/index.js
@@ -1,0 +1,17 @@
+import * as service from '../../../services/userRolesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  if (req.method === 'GET') {
+    const roles = await service.getRoles();
+    return res.status(200).json(roles);
+  }
+  if (req.method === 'POST') {
+    const role = await service.createRole(req.body);
+    return res.status(201).json(role);
+  }
+  res.setHeader('Allow', ['GET','POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/office/company-settings.js
+++ b/pages/office/company-settings.js
@@ -129,6 +129,9 @@ export default function CompanySettingsPage() {
       <Link href="/office/document-templates" className="text-blue-600 underline mb-4 inline-block">
         View Document Templates
       </Link>
+      <Link href="/office/user-roles" className="text-blue-600 underline mb-4 ml-4 inline-block">
+        Manage User Roles
+      </Link>
       <a href="/api/company/export-clients" className="text-blue-600 underline mb-4 ml-4 inline-block">
         Export Clients
       </a>

--- a/pages/office/user-roles/index.js
+++ b/pages/office/user-roles/index.js
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react';
+import OfficeLayout from '../../../components/OfficeLayout';
+import Link from 'next/link';
+
+export default function UserRolesPage() {
+  const emptyForm = { name: '', description: '', developer: false, office: false, engineer: false, apprentice: false };
+  const [roles, setRoles] = useState([]);
+  const [form, setForm] = useState(emptyForm);
+  const [editingId, setEditingId] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = () => {
+    setLoading(true);
+    fetch('/api/user-roles')
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setRoles)
+      .catch(() => setError('Failed to load roles'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const change = e => {
+    const { name, type, checked, value } = e.target;
+    setForm(f => ({ ...f, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const startEdit = role => {
+    setEditingId(role.id);
+    setForm({
+      name: role.name || '',
+      description: role.description || '',
+      developer: !!role.developer,
+      office: !!role.office,
+      engineer: !!role.engineer,
+      apprentice: !!role.apprentice,
+    });
+  };
+
+  const cancel = () => {
+    setEditingId(null);
+    setForm(emptyForm);
+  };
+
+  const submit = async e => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch(
+        editingId ? `/api/user-roles/${editingId}` : '/api/user-roles',
+        {
+          method: editingId ? 'PUT' : 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(form),
+        }
+      );
+      if (!res.ok) throw new Error();
+      cancel();
+      load();
+    } catch {
+      setError('Failed to save role');
+    }
+  };
+
+  const handleDelete = async id => {
+    if (!confirm('Delete this role?')) return;
+    await fetch(`/api/user-roles/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <OfficeLayout>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-semibold">User Roles</h1>
+        <Link href="/office/company-settings" className="button">
+          Back to Settings
+        </Link>
+      </div>
+      {error && <p className="text-red-500">{error}</p>}
+      {loading ? (
+        <p>Loading…</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 mb-8">
+          {roles.map(r => (
+            <div key={r.id} className="item-card text-black dark:text-white">
+              <h2 className="font-semibold mb-1">{r.name}</h2>
+              <p className="text-sm mb-2">{r.description || '—'}</p>
+              <div className="flex gap-4 mb-2">
+                <label className="flex items-center gap-1">
+                  <input type="checkbox" checked={!!r.developer} readOnly /> developer
+                </label>
+                <label className="flex items-center gap-1">
+                  <input type="checkbox" checked={!!r.office} readOnly /> office
+                </label>
+                <label className="flex items-center gap-1">
+                  <input type="checkbox" checked={!!r.engineer} readOnly /> engineer
+                </label>
+                <label className="flex items-center gap-1">
+                  <input type="checkbox" checked={!!r.apprentice} readOnly /> apprentice
+                </label>
+              </div>
+              <div className="flex gap-2">
+                <button onClick={() => startEdit(r)} className="button px-4 text-sm">Edit</button>
+                <button onClick={() => handleDelete(r.id)} className="button px-4 text-sm bg-red-600 hover:bg-red-700">Delete</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <h2 className="text-xl font-semibold mb-2">{editingId ? 'Edit Role' : 'New Role'}</h2>
+      <form onSubmit={submit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block mb-1">Name</label>
+          <input name="name" value={form.name} onChange={change} className="input w-full" required />
+        </div>
+        <div>
+          <label className="block mb-1">Description</label>
+          <textarea name="description" value={form.description} onChange={change} className="input w-full" rows={2} />
+        </div>
+        <div className="flex gap-4">
+          <label className="flex items-center gap-1">
+            <input type="checkbox" name="developer" checked={form.developer} onChange={change} /> developer
+          </label>
+          <label className="flex items-center gap-1">
+            <input type="checkbox" name="office" checked={form.office} onChange={change} /> office
+          </label>
+          <label className="flex items-center gap-1">
+            <input type="checkbox" name="engineer" checked={form.engineer} onChange={change} /> engineer
+          </label>
+          <label className="flex items-center gap-1">
+            <input type="checkbox" name="apprentice" checked={form.apprentice} onChange={change} /> apprentice
+          </label>
+        </div>
+        <div className="flex gap-2">
+          <button type="submit" className="button">
+            {editingId ? 'Update Role' : 'Create Role'}
+          </button>
+          {editingId && (
+            <button type="button" onClick={cancel} className="button-secondary">
+              Cancel
+            </button>
+          )}
+        </div>
+      </form>
+    </OfficeLayout>
+  );
+}

--- a/services/userRolesService.js
+++ b/services/userRolesService.js
@@ -1,0 +1,29 @@
+import pool from '../lib/db.js';
+
+export async function getRoles() {
+  const [rows] = await pool.query(
+    'SELECT id, name, description, developer, office, engineer, apprentice FROM roles ORDER BY id'
+  );
+  return rows;
+}
+
+export async function createRole({ name, description, developer, office, engineer, apprentice }) {
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO roles (name, description, developer, office, engineer, apprentice) VALUES (?,?,?,?,?,?)',
+    [name, description || null, developer ? 1 : 0, office ? 1 : 0, engineer ? 1 : 0, apprentice ? 1 : 0]
+  );
+  return { id: insertId, name, description, developer: !!developer, office: !!office, engineer: !!engineer, apprentice: !!apprentice };
+}
+
+export async function updateRole(id, { name, description, developer, office, engineer, apprentice }) {
+  await pool.query(
+    'UPDATE roles SET name=?, description=?, developer=?, office=?, engineer=?, apprentice=? WHERE id=?',
+    [name, description || null, developer ? 1 : 0, office ? 1 : 0, engineer ? 1 : 0, apprentice ? 1 : 0, id]
+  );
+  return { id: Number(id), name, description, developer: !!developer, office: !!office, engineer: !!engineer, apprentice: !!apprentice };
+}
+
+export async function deleteRole(id) {
+  await pool.query('DELETE FROM roles WHERE id=?', [id]);
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- add `userRolesService` for CRUD on `roles`
- expose new API routes under `/api/user-roles`
- create `/office/user-roles` page to manage roles
- link to the new page from Company Settings

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875822b44d08333aadb0f98b8d8a97f