### PR TITLE
Add role flag columns migration

### DIFF
--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -413,6 +413,11 @@ This table enumerates the valid statuses that a job can be in. The `status` colu
 |--------|------------|
 | `id` | int(11) NOT NULL AUTO_INCREMENT |
 | `name` | varchar(50) NOT NULL |
+| `developer` | tinyint(1) NOT NULL DEFAULT 0 |
+| `office` | tinyint(1) NOT NULL DEFAULT 0 |
+| `engineer` | tinyint(1) NOT NULL DEFAULT 0 |
+| `apprentice` | tinyint(1) NOT NULL DEFAULT 0 |
+| `description` | varchar(255) DEFAULT NULL |
 | `name` | (`name`) |
 
 ## Table: `sessions`

--- a/migrations/202607XX_add_role_flags.sql
+++ b/migrations/202607XX_add_role_flags.sql
@@ -1,0 +1,9 @@
+ALTER TABLE roles
+  ADD COLUMN developer TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN office TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN engineer TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN apprentice TINYINT(1) NOT NULL DEFAULT 0;
+UPDATE roles SET developer=1 WHERE name='developer';
+UPDATE roles SET office=1 WHERE name='office';
+UPDATE roles SET engineer=1 WHERE name='engineer';
+UPDATE roles SET apprentice=1 WHERE name='apprentice';


### PR DESCRIPTION
## Summary
- add migration for role flag columns
- document new role flag columns in db schema

## Testing
- `npm run migrate` *(fails: Cannot find module 'mysql2/promise')*
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6875a13e70e48333ad977b263e0ae8da