### PR TITLE
Add auth checks to user role APIs

### DIFF
--- a/pages/api/user-roles/[id].js
+++ b/pages/api/user-roles/[id].js
@@ -1,8 +1,22 @@
 import { updateRole, deleteRole } from '../../../services/userRolesService.js';
 import apiHandler from '../../../lib/apiHandler.js';
+import pool from '../../../lib/db';
+import { getTokenFromReq } from '../../../lib/auth';
 
 async function handler(req, res) {
   const { id } = req.query;
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const [[roleRow]] = await pool.query(
+    `SELECT r.name FROM user_roles ur
+       JOIN roles r ON ur.role_id = r.id
+     WHERE ur.user_id = ?`,
+    [t.sub]
+  );
+  if (!roleRow || !['admin', 'developer'].includes(roleRow.name)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
   if (req.method === 'PUT') {
     const role = await updateRole(id, req.body);
     return res.status(200).json(role);

--- a/pages/api/user-roles/index.js
+++ b/pages/api/user-roles/index.js
@@ -1,11 +1,26 @@
 import * as service from '../../../services/userRolesService.js';
 import apiHandler from '../../../lib/apiHandler.js';
+import pool from '../../../lib/db';
+import { getTokenFromReq } from '../../../lib/auth';
 
 async function handler(req, res) {
   if (req.method === 'GET') {
     const roles = await service.getRoles();
     return res.status(200).json(roles);
   }
+
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const [[roleRow]] = await pool.query(
+    `SELECT r.name FROM user_roles ur
+       JOIN roles r ON ur.role_id = r.id
+     WHERE ur.user_id = ?`,
+    [t.sub]
+  );
+  if (!roleRow || !['admin', 'developer'].includes(roleRow.name)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
   if (req.method === 'POST') {
     const role = await service.createRole(req.body);
     return res.status(201).json(role);


### PR DESCRIPTION
## Summary
- secure the user roles API endpoints
- verify admin or developer role for modifications

## Testing
- `npm test` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6875a775a0648333b39db340609f04e8