### PR TITLE
Add parts arrival workflow

### DIFF
--- a/__tests__/parts-arrived-modal.test.js
+++ b/__tests__/parts-arrived-modal.test.js
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('schedule later calls parts arrived endpoint', async () => {
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobs: jest.fn().mockResolvedValue([{ id: 1, status: 'awaiting parts' }]),
+    fetchJob: jest.fn().mockResolvedValue({ id: 1, vehicle: {}, quote: {} }),
+    markPartsArrived: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/engineers', () => ({
+    fetchEngineers: jest.fn().mockResolvedValue([]),
+  }));
+  const fetchSpy = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  global.fetch = fetchSpy;
+  const { default: Page } = await import('../pages/office/job-management/index.js');
+  render(<Page />);
+  await screen.findByText('Job #1');
+  fireEvent.click(screen.getByRole('button', { name: 'Parts Arrived' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Schedule later' }));
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+  expect(fetchSpy.mock.calls[0][0]).toBe('/api/jobs/1/parts-arrived');
+});
+
+test('schedule now assigns via assign endpoint', async () => {
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobs: jest.fn().mockResolvedValue([{ id: 2, status: 'awaiting parts' }]),
+    fetchJob: jest.fn().mockResolvedValue({ id: 2, vehicle: {}, quote: {} }),
+    markPartsArrived: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/engineers', () => ({
+    fetchEngineers: jest.fn().mockResolvedValue([{ id: 7, username: 'E' }]),
+  }));
+  const fetchSpy = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  global.fetch = fetchSpy;
+  const { default: Page } = await import('../pages/office/job-management/index.js');
+  render(<Page />);
+  await screen.findByText('Job #2');
+  fireEvent.change(screen.getByLabelText('Engineer'), { target: { value: '7' } });
+  fireEvent.change(screen.getByLabelText('Scheduled Start'), { target: { value: '2024-01-02T10:00' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Parts Arrived' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Schedule now' }));
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+  expect(fetchSpy.mock.calls[0][0]).toBe('/api/jobs/2/assign');
+});

--- a/components/office/PartsArrivedModal.jsx
+++ b/components/office/PartsArrivedModal.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Modal } from '../ui/Modal.jsx';
+
+export default function PartsArrivedModal({ onScheduleNow, onScheduleLater }) {
+  return (
+    <Modal>
+      <p className="mb-4">Parts have arrived for this job.</p>
+      <div className="flex justify-end gap-2">
+        <button onClick={onScheduleNow} className="button px-4">Schedule now</button>
+        <button onClick={onScheduleLater} className="button-secondary px-4">Schedule later</button>
+      </div>
+    </Modal>
+  );
+}

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -43,3 +43,9 @@ export async function assignJob(id, data) {
   return res.json();
 }
 
+export async function markPartsArrived(id) {
+  const res = await fetch(`/api/jobs/${id}/parts-arrived`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to update job');
+  return res.json();
+}
+

--- a/pages/api/jobs/[id]/parts-arrived.js
+++ b/pages/api/jobs/[id]/parts-arrived.js
@@ -1,0 +1,33 @@
+import { updateJob, getJobDetails } from '../../../../services/jobsService.js';
+import apiHandler from '../../../../lib/apiHandler.js';
+import { getTokenFromReq } from '../../../../lib/auth.js';
+import pool from '../../../../lib/db.js';
+
+async function handler(req, res) {
+  const { id } = req.query;
+  const t = getTokenFromReq(req);
+  if (!t) return res.status(401).json({ error: 'Unauthorized' });
+  const [[roleRow]] = await pool.query(
+    `SELECT r.name FROM user_roles ur
+       JOIN roles r ON ur.role_id = r.id
+     WHERE ur.user_id=?`,
+    [t.sub]
+  );
+  if (!roleRow || !['office', 'admin', 'developer'].includes(roleRow.name)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  try {
+    if (req.method === 'POST') {
+      await updateJob(id, { status: 'unassigned' });
+      const job = await getJobDetails(id);
+      return res.status(200).json(job);
+    }
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+export default apiHandler(handler);


### PR DESCRIPTION
## Summary
- fetch awaiting parts jobs
- add PartsArrivedModal component
- allow marking parts arrived through new endpoint
- show PARTS HERE label
- tests for schedule now/later actions

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6875ad98ecf48333856cd750256de879