### PR TITLE
Return all engineer job assignments

### DIFF
--- a/__tests__/engineer-features.test.js
+++ b/__tests__/engineer-features.test.js
@@ -6,7 +6,10 @@ afterEach(() => {
 });
 
 test('engineer jobs returns active jobs', async () => {
-  const jobs = [{ id: 1 }];
+  const jobs = [
+    { id: 1, status: 'in progress' },
+    { id: 2, status: 'completed' },
+  ];
   const listMock = jest.fn().mockResolvedValue(jobs);
   jest.unstable_mockModule('../services/jobsService.js', () => ({
     listActiveJobsForEngineer: listMock,

--- a/__tests__/engineer-jobs-api.test.js
+++ b/__tests__/engineer-jobs-api.test.js
@@ -8,7 +8,10 @@ afterEach(() => {
 // GET /engineer/jobs success
 
 test('engineer jobs returns active jobs for engineer', async () => {
-  const jobs = [{ id: 1 }];
+  const jobs = [
+    { id: 1, status: 'in progress' },
+    { id: 2, status: 'completed' },
+  ];
   const listMock = jest.fn().mockResolvedValue(jobs);
   jest.unstable_mockModule('../services/jobsService.js', () => ({
     listActiveJobsForEngineer: listMock,

--- a/__tests__/jobsService.test.js
+++ b/__tests__/jobsService.test.js
@@ -125,3 +125,26 @@ test('getJobsInRange returns unscheduled jobs', async () => {
     },
   ]);
 });
+
+test('listActiveJobsForEngineer returns all assignments without status filter', async () => {
+  const rows = [{ id: 1 }, { id: 2 }];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { listActiveJobsForEngineer } = await import('../services/jobsService.js');
+  const result = await listActiveJobsForEngineer(5);
+  expect(queryMock).toHaveBeenCalledWith(expect.stringMatching(/FROM jobs/), [5]);
+  expect(result).toEqual(rows);
+});
+
+test('listActiveJobsForEngineer filters by status when provided', async () => {
+  const rows = [{ id: 3 }];
+  const queryMock = jest.fn().mockResolvedValue([rows]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { listActiveJobsForEngineer } = await import('../services/jobsService.js');
+  const result = await listActiveJobsForEngineer(7, 'completed');
+  expect(queryMock).toHaveBeenCalledWith(
+    expect.stringMatching(/j.status=/),
+    [7, 'completed']
+  );
+  expect(result).toEqual(rows);
+});

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -135,15 +135,21 @@ export async function removeAssignment(id) {
   return { ok: true };
 }
 
-export async function listActiveJobsForEngineer(user_id) {
+export async function listActiveJobsForEngineer(user_id, status) {
+  const params = [user_id];
+  let where = 'ja.user_id=?';
+  if (status) {
+    where += ' AND j.status=?';
+    params.push(status);
+  }
   const [rows] = await pool.query(
     `SELECT j.id, j.customer_id, j.vehicle_id, j.scheduled_start, j.scheduled_end,
             j.status, j.bay, j.created_at
        FROM jobs j
        JOIN job_assignments ja ON j.id = ja.job_id
-      WHERE ja.user_id=? AND j.status='in progress'
+      WHERE ${where}
       ORDER BY j.id`,
-    [user_id]
+    params
   );
   return rows;
 }


### PR DESCRIPTION
## Summary
- list all engineer jobs regardless of status
- adjust related tests
- expand jobsService tests for new optional status filter

## Testing
- `npm test` *(fails: Jest configuration issues and missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6876f57993808333adcf97cdfbd8c07d