### PR TITLE
Filter live screen jobs by date

### DIFF
--- a/__tests__/office-live-screen.test.js
+++ b/__tests__/office-live-screen.test.js
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+
+test('LiveScreen lists todays jobs only', async () => {
+  const today = new Date().toISOString().slice(0, 10);
+  const jobs = [
+    { id: 1, status: 'in progress', scheduled_start: '2024-01-01T10:00:00Z', scheduled_end: '2024-01-01T11:00:00Z' }
+  ];
+  const fetchJobsForDate = jest.fn().mockResolvedValue(jobs);
+
+  jest.unstable_mockModule('../lib/quotes', () => ({
+    fetchQuotes: jest.fn().mockResolvedValue([])
+  }));
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobsForDate
+  }));
+  jest.unstable_mockModule('../lib/invoices', () => ({
+    fetchInvoices: jest.fn().mockResolvedValue([])
+  }));
+  jest.unstable_mockModule('../lib/jobStatuses.js', () => ({
+    fetchJobStatuses: jest.fn().mockResolvedValue([{ id: 1, name: 'in progress' }])
+  }));
+
+  const { default: Page } = await import('../pages/office/live-screen/index.js');
+  render(<Page />);
+
+  const link = await screen.findByRole('link', { name: 'Job #1 – in progress' });
+  expect(link).toHaveAttribute('href', '/office/jobs/1');
+  expect(fetchJobsForDate).toHaveBeenCalledWith(today);
+});
+

--- a/pages/office/live-screen/index.js
+++ b/pages/office/live-screen/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import Link from 'next/link';
 import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchQuotes } from '../../../lib/quotes';
-import { fetchJobs } from '../../../lib/jobs';
+import { fetchJobsForDate } from '../../../lib/jobs';
 import { fetchInvoices } from '../../../lib/invoices';
 import { fetchJobStatuses } from '../../../lib/jobStatuses.js';
 
@@ -16,7 +16,13 @@ const LiveScreenPage = () => {
 
   const load = () => {
     setLoading(true);
-    Promise.all([fetchQuotes(), fetchJobs(), fetchInvoices(), fetchJobStatuses()])
+    const dateStr = new Date().toISOString().slice(0, 10);
+    Promise.all([
+      fetchQuotes(),
+      fetchJobsForDate(dateStr),
+      fetchInvoices(),
+      fetchJobStatuses(),
+    ])
       .then(([q, j, i, s]) => {
         setQuotes(q);
         setJobs(j);


### PR DESCRIPTION
## Summary
- filter jobs on Live Screen by today's date
- verify Live Screen only shows today's jobs

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6876f87ca55083338785733944382e95