### PR TITLE
Display status and modal for awaiting parts

### DIFF
--- a/__tests__/parts-arrived-modal.test.js
+++ b/__tests__/parts-arrived-modal.test.js
@@ -27,6 +27,25 @@ test('schedule later calls parts arrived endpoint', async () => {
   expect(fetchSpy.mock.calls[0][0]).toBe('/api/jobs/1/parts-arrived');
 });
 
+test('parts arrived button shows modal', async () => {
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobs: jest.fn().mockResolvedValue([{ id: 3, status: 'awaiting parts' }]),
+    fetchJob: jest.fn().mockResolvedValue({ id: 3, vehicle: {}, quote: {} }),
+    markPartsArrived: jest.fn(),
+  }));
+  jest.unstable_mockModule('../lib/engineers', () => ({
+    fetchEngineers: jest.fn().mockResolvedValue([]),
+  }));
+  const { default: Page } = await import('../pages/office/job-management/index.js');
+  render(<Page />);
+  await screen.findByText('Job #3');
+  const btn = screen.getByRole('button', { name: 'Parts Arrived' });
+  fireEvent.click(btn);
+  expect(
+    await screen.findByText('Parts have arrived for this job.')
+  ).toBeInTheDocument();
+});
+
 test('schedule now assigns via assign endpoint', async () => {
   jest.unstable_mockModule('../lib/jobs', () => ({
     fetchJobs: jest.fn().mockResolvedValue([{ id: 2, status: 'awaiting parts' }]),

--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -120,6 +120,7 @@ export default function JobManagementPage() {
             return (
               <div key={job.id} className="space-y-2 bg-white text-black p-4 rounded">
                 <p className="font-semibold">Job #{job.id}</p>
+                <p className="text-sm">Status: {job.status}</p>
                 {job.partsHere && (
                   <p className="text-green-600 font-bold">PARTS HERE</p>
                 )}
@@ -147,6 +148,14 @@ export default function JobManagementPage() {
                   >
                     Purchase Orders
                   </Link>
+                  {job.status === 'awaiting parts' && (
+                    <button
+                      onClick={() => setPartsModal(job.id)}
+                      className="button px-4"
+                    >
+                      Parts Arrived
+                    </button>
+                  )}
                 </div>
               </div>
             );


### PR DESCRIPTION
## Summary
- show job status text on the job-management page
- add "Parts Arrived" action when a job is awaiting parts
- test that clicking the new button opens the modal

## Testing
- `npm ci`
- `npm test` *(fails: Jest configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878184d4fd48333bffbc937315878eb