### PR TITLE
Add scheduled_end input for job assignment

### DIFF
--- a/__tests__/job-assign-page.test.js
+++ b/__tests__/job-assign-page.test.js
@@ -8,7 +8,7 @@ import { jest } from '@jest/globals';
 afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
 
 
-test('assign job form submits without scheduled end', async () => {
+test('assign job form submits with scheduled end', async () => {
   const push = jest.fn();
   jest.unstable_mockModule('next/router', () => ({
     useRouter: () => ({ query: { id: '5' }, push })
@@ -27,12 +27,17 @@ test('assign job form submits without scheduled end', async () => {
 
   await screen.findByText('Assign Engineer');
   fireEvent.change(screen.getByLabelText('Engineer'), { target: { value: '2' } });
-  fireEvent.change(screen.getByLabelText('Scheduled Start'), { target: { value: '2024-01-01T09:00' } });
+  fireEvent.change(screen.getByLabelText('Scheduled Start'), {
+    target: { value: '2024-01-01T09:00' },
+  });
+  fireEvent.change(screen.getByLabelText('Scheduled End'), {
+    target: { value: '2024-01-01T10:30' },
+  });
   fireEvent.click(screen.getByRole('button', { name: 'Assign' }));
 
   await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
   const body = JSON.parse(global.fetch.mock.calls[0][1].body);
   expect(body.scheduled_start).toBe('2024-01-01T09:00');
-  expect(body.scheduled_end).toBeUndefined();
+  expect(body.scheduled_end).toBe('2024-01-01T10:30');
   expect(push).toHaveBeenCalledWith('/office/jobs/5');
 });

--- a/__tests__/job-management-form.test.js
+++ b/__tests__/job-management-form.test.js
@@ -7,7 +7,7 @@ import { jest } from '@jest/globals';
 
 afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
 
-test('job management form submits without scheduled end', async () => {
+test('job management form submits with scheduled end', async () => {
   jest.unstable_mockModule('../lib/jobs', () => ({
     fetchJobs: jest.fn().mockResolvedValue([{ id: 9 }]),
     fetchJob: jest.fn().mockResolvedValue({
@@ -27,12 +27,17 @@ test('job management form submits without scheduled end', async () => {
 
   await screen.findByText('Job #9');
   fireEvent.change(screen.getByLabelText('Engineer'), { target: { value: '2' } });
-  fireEvent.change(screen.getByLabelText('Scheduled Start'), { target: { value: '2024-01-02T10:00' } });
+  fireEvent.change(screen.getByLabelText('Scheduled Start'), {
+    target: { value: '2024-01-02T10:00' },
+  });
+  fireEvent.change(screen.getByLabelText('Scheduled End'), {
+    target: { value: '2024-01-02T11:00' },
+  });
   fireEvent.click(screen.getByRole('button', { name: 'Schedule' }));
 
   await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
   expect(global.fetch.mock.calls[0][0]).toBe('/api/jobs/9/assign');
   const body = JSON.parse(global.fetch.mock.calls[0][1].body);
   expect(body.scheduled_start).toBe('2024-01-02T10:00');
-  expect(body.scheduled_end).toBeUndefined();
+  expect(body.scheduled_end).toBe('2024-01-02T11:00');
 });

--- a/__tests__/scheduling-page.test.js
+++ b/__tests__/scheduling-page.test.js
@@ -60,7 +60,15 @@ test('dragging unassigned job calls assign endpoint', async () => {
   fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'in progress' } });
   fireEvent.click(screen.getByRole('button', { name: 'Assign' }));
   await act(() => Promise.resolve());
-  expect(assignMock).toHaveBeenCalledWith(3, expect.objectContaining({ engineer_id: 1, status: 'in progress' }));
+  expect(assignMock).toHaveBeenCalledWith(
+    3,
+    expect.objectContaining({
+      engineer_id: 1,
+      status: 'in progress',
+      scheduled_start: '2024-05-02T09:00:00.000Z',
+      scheduled_end: '2024-05-02T10:00:00.000Z',
+    })
+  );
 });
 
 test('dragging cancelled does not assign job', async () => {

--- a/pages/office/jobs/assign.js
+++ b/pages/office/jobs/assign.js
@@ -9,7 +9,11 @@ export default function AssignJobPage() {
   const router = useRouter();
   const { id } = router.query;
   const [engineers, setEngineers] = useState([]);
-  const [form, setForm] = useState({ engineer_id: '', scheduled_start: '' });
+  const [form, setForm] = useState({
+    engineer_id: '',
+    scheduled_start: '',
+    scheduled_end: '',
+  });
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -32,6 +36,7 @@ export default function AssignJobPage() {
           scheduled_start: job.scheduled_start
             ? job.scheduled_start.slice(0, 16)
             : '',
+          scheduled_end: job.scheduled_end ? job.scheduled_end.slice(0, 16) : '',
         });
       } catch {
         // ignore
@@ -49,6 +54,7 @@ export default function AssignJobPage() {
       const data = {
         engineer_id: form.engineer_id,
         scheduled_start: form.scheduled_start,
+        scheduled_end: form.scheduled_end,
       };
       const res = await fetch(`/api/jobs/${id}/assign`, {
         method: 'POST',
@@ -91,6 +97,16 @@ export default function AssignJobPage() {
             type="datetime-local"
             name="scheduled_start"
             value={form.scheduled_start}
+            onChange={change}
+            className="input w-full"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Scheduled End</label>
+          <input
+            type="datetime-local"
+            name="scheduled_end"
+            value={form.scheduled_end}
             onChange={change}
             className="input w-full"
           />


### PR DESCRIPTION
## Summary
- extend job assign form to capture `scheduled_end`
- adjust job assignment submission to send `scheduled_end`
- update relevant tests for the new field

## Testing
- `npm ci`
- `npm test` *(fails: Jest unable to run due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68781d532bbc8333b65bf49cbd24a3df