### PR TITLE
Show all active jobs and allow null schedule

### DIFF
--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -92,8 +92,15 @@ export async function updateJob(id, data = {}) {
 
   for (const key of allowed) {
     if (Object.prototype.hasOwnProperty.call(data, key)) {
+      let value = data[key];
+      if (
+        (key === 'scheduled_start' || key === 'scheduled_end') &&
+        (value === '' || value === undefined)
+      ) {
+        value = null;
+      }
       fields.push(`${key}=?`);
-      params.push(data[key] ?? null);
+      params.push(value ?? null);
     }
   }
 


### PR DESCRIPTION
## Summary
- show all non-completed jobs in Job Management
- keep jobs in list when assigning or marking awaiting parts
- update jobs after parts arrival
- allow empty scheduled start/end values when updating a job

## Testing
- `npm test` *(fails: cannot read properties, Jest configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_6878253bb9bc83339a764025a65e5f80