### PR TITLE
Add job status filter tests

### DIFF
--- a/__tests__/office-dashboard.test.js
+++ b/__tests__/office-dashboard.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { jest } from '@jest/globals';
 
 afterEach(() => {
@@ -40,5 +40,29 @@ test('OfficeDashboard lists todays jobs', async () => {
 
   const invoiceLink = screen.getByRole('link', { name: 'Create Invoice' });
   expect(invoiceLink).toHaveAttribute('href', '/office/invoices/new');
+});
+
+test('job status links navigate to job management page', async () => {
+  const push = jest.fn();
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ push })
+  }));
+  jest.unstable_mockModule('../lib/quotes', () => ({ fetchQuotes: jest.fn().mockResolvedValue([]) }));
+  jest.unstable_mockModule('../lib/jobs', () => ({
+    fetchJobs: jest.fn().mockResolvedValue([]),
+    fetchJobsForDate: jest.fn().mockResolvedValue([])
+  }));
+  jest.unstable_mockModule('../lib/invoices', () => ({ fetchInvoices: jest.fn().mockResolvedValue([]) }));
+  jest.unstable_mockModule('../lib/jobStatuses', () => ({
+    fetchJobStatuses: jest.fn().mockResolvedValue([{ id: 1, name: 'awaiting parts' }])
+  }));
+  jest.unstable_mockModule('../lib/vehicles', () => ({ fetchVehicles: jest.fn().mockResolvedValue([]) }));
+
+  const { default: OfficeDashboard } = await import('../components/OfficeDashboard.jsx');
+  const { container } = render(<OfficeDashboard />);
+  const link = container.querySelector('a[href="/office/job-management?status=awaiting%20parts"]');
+  expect(link).toBeTruthy();
+  link && fireEvent.click(link);
+  expect(push).toHaveBeenCalledWith('/office/job-management?status=awaiting%20parts');
 });
 


### PR DESCRIPTION
## Summary
- support filtering JobManagementPage by status query parameter
- expose status filter dropdown for JobManagementPage
- test query param filter behavior
- test navigation from OfficeDashboard to filtered job management page

## Testing
- `npm test` *(fails: vehicles-api.test.js, clients-api.test.js, quotes-api.test.js, quotesService.test.js, invoicesService.test.js, etc.)*
- `node --experimental-vm-modules node_modules/.bin/jest __tests__/job-management-form.test.js __tests__/office-dashboard.test.js` *(fails: JSX transform error)*

------
https://chatgpt.com/codex/tasks/task_e_68783dd6604883339440f657e2a7e0a4