### PR TITLE
Add env loading for tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,29 @@
+# Sample environment for running tests
+# Database connection string
+DATABASE_URL="mysql://user:pass@localhost:3306/garage"
+# Secret key for JWT tokens
+JWT_SECRET="change-me"
+
+# AWS S3 configuration
+S3_BUCKET="your-bucket-name"
+AWS_REGION="us-east-1"
+AWS_ACCESS_KEY_ID="your-access-key"
+AWS_SECRET_ACCESS_KEY="your-secret-key"
+
+# Expose bucket info to the client
+NEXT_PUBLIC_S3_BUCKET="your-bucket-name"
+NEXT_PUBLIC_AWS_REGION="us-east-1"
+
+# Expose API secret to the client
+NEXT_PUBLIC_API_SECRET="your-api-secret"
+
+
+# SMTP configuration
+SMTP_HOST="smtp.example.com"
+SMTP_PORT="587"
+SMTP_USER="user@example.com"
+SMTP_PASS="password"
+SMTP_SECURE="false"
+SMTP_FROM_NAME="Garage"
+SMTP_FROM_EMAIL="noreply@example.com"
+

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ For a local installation, ensure the MySQL service is running and a database nam
    - This command executes every `.sql` file in the `migrations/` directory in
      order and records which have been run.
    - Running the script again safely skips already-applied migrations.
-7. Run tests and lint checks: `npm test` and `npm run lint`. The test suite
-   requires Node and all npm packages to be installed, so ensure the previous
-   step succeeded or use a Docker image with these dependencies preinstalled.
+7. Run tests and lint checks: `npm test` and `npm run lint`.
+   The test suite expects environment variables such as `JWT_SECRET`
+   (and the other variables in `.env.example`) to be defined.
+   Copy `.env.example` to `.env.test` or create those variables in your environment before running Jest.
+   The tests will automatically load variables from `.env.test` if it exists.
 8. Start dev server: `npm run dev`
 
 ## Code Style

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,14 @@
+import { config } from 'dotenv';
+import fs from 'fs';
+
+const envFile = fs.existsSync('.env.test')
+  ? '.env.test'
+  : fs.existsSync('.env.example')
+  ? '.env.example'
+  : null;
+
+if (envFile) config({ path: envFile });
+
 export default {
   testEnvironment: 'node',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       "devDependencies": {
         "@testing-library/react": "^16.3.0",
         "autoprefixer": "^10.4.14",
+        "dotenv": "^17.2.0",
         "eslint": "^8.57.0",
         "eslint-config-next": "15.3.4",
         "jest": "^30.0.0",
@@ -6420,6 +6421,19 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
     "autoprefixer": "^10.4.14",
+    "dotenv": "^17.2.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "15.3.4",
     "jest": "^30.0.0",


### PR DESCRIPTION
## Summary
- document environment variables needed when running tests
- load `.env.test` or `.env.example` from `jest.config.js`
- add sample `.env.test`
- include `dotenv` as a dev dependency

## Testing
- `npm ci`
- `npm test` *(fails: vehicles-api.test.js, clients-api.test.js, reporting-api.test.js, engineers-api.test.js, office-pages.test.js, jobRequests-api.test.js, dev-projects.test.js, fleet-request-quotation-page.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_687844eedbf08333825ef164f75234be