### PR TITLE
Add part categories

### DIFF
--- a/__tests__/categoriesService.test.js
+++ b/__tests__/categoriesService.test.js
@@ -1,0 +1,15 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('createCategory inserts row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([{ insertId: 4 }]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { createCategory } = await import('../services/categoriesService.js');
+  const result = await createCategory({ name: 'Cat' });
+  expect(queryMock).toHaveBeenCalledWith('INSERT INTO part_categories (name) VALUES (?)', ['Cat']);
+  expect(result).toEqual({ id: 4, name: 'Cat' });
+});

--- a/__tests__/parts-api.test.js
+++ b/__tests__/parts-api.test.js
@@ -13,7 +13,7 @@ test('parts index creates part', async () => {
     createPart: createMock,
   }));
   const { default: handler } = await import('../pages/api/parts/index.js');
-  const req = { method: 'POST', body: { part_number: 'P1', supplier_id: 2 }, headers: {} };
+  const req = { method: 'POST', body: { part_number: 'P1', supplier_id: 2, category_id: 3 }, headers: {} };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
   await handler(req, res);
   expect(res.status).toHaveBeenCalledWith(201);
@@ -23,6 +23,7 @@ test('parts index creates part', async () => {
     description: undefined,
     unit_cost: undefined,
     supplier_id: 2,
+    category_id: 3,
   });
 });
 

--- a/__tests__/partsService.test.js
+++ b/__tests__/partsService.test.js
@@ -9,11 +9,11 @@ test('createPart inserts row', async () => {
   const queryMock = jest.fn().mockResolvedValue([{ insertId: 3 }]);
   jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
   const { createPart } = await import('../services/partsService.js');
-  const data = { part_number: 'A', description: 'B', unit_cost: 1.2, supplier_id: 4 };
+  const data = { part_number: 'A', description: 'B', unit_cost: 1.2, supplier_id: 4, category_id: 7 };
   const result = await createPart(data);
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/INSERT INTO parts/),
-    ['A', 'B', 1.2, 4]
+    ['A', 'B', 1.2, 4, 7]
   );
   expect(result).toEqual({ id: 3, ...data });
 });
@@ -22,10 +22,10 @@ test('updatePart updates row', async () => {
   const queryMock = jest.fn().mockResolvedValue([]);
   jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
   const { updatePart } = await import('../services/partsService.js');
-  const result = await updatePart(1, { part_number: 'X', supplier_id: 5 });
+  const result = await updatePart(1, { part_number: 'X', supplier_id: 5, category_id: 9 });
   expect(queryMock).toHaveBeenCalledWith(
     expect.stringMatching(/UPDATE parts/),
-    ['X', null, null, 5, 1]
+    ['X', null, null, 5, 9, 1]
   );
   expect(result).toEqual({ ok: true });
 });

--- a/migrations/20260720_create_part_categories.sql
+++ b/migrations/20260720_create_part_categories.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS part_categories (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(100) NOT NULL UNIQUE
+);
+ALTER TABLE parts ADD COLUMN category_id INT;
+ALTER TABLE parts ADD CONSTRAINT fk_parts_category FOREIGN KEY (category_id) REFERENCES part_categories(id);

--- a/pages/api/categories/[id].js
+++ b/pages/api/categories/[id].js
@@ -1,0 +1,27 @@
+import { getCategoryById, updateCategory, deleteCategory } from '../../../services/categoriesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const cat = await getCategoryById(id);
+      return res.status(200).json(cat);
+    }
+    if (req.method === 'PUT') {
+      const updated = await updateCategory(id, req.body);
+      return res.status(200).json(updated);
+    }
+    if (req.method === 'DELETE') {
+      await deleteCategory(id);
+      return res.status(204).end();
+    }
+    res.setHeader('Allow', ['GET','PUT','DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+export default apiHandler(handler);

--- a/pages/api/categories/index.js
+++ b/pages/api/categories/index.js
@@ -1,0 +1,17 @@
+import { getAllCategories, createCategory } from '../../../services/categoriesService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  if (req.method === 'GET') {
+    const rows = await getAllCategories();
+    return res.status(200).json(rows);
+  }
+  if (req.method === 'POST') {
+    const created = await createCategory(req.body);
+    return res.status(201).json(created);
+  }
+  res.setHeader('Allow', ['GET','POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/api/parts/index.js
+++ b/pages/api/parts/index.js
@@ -8,12 +8,13 @@ async function handler(req, res) {
       return res.status(200).json(parts);
     }
     if (req.method === 'POST') {
-      const { part_number, description, unit_cost, supplier_id } = req.body || {};
+      const { part_number, description, unit_cost, supplier_id, category_id } = req.body || {};
       const newPart = await createPart({
         part_number,
         description,
         unit_cost,
         supplier_id,
+        category_id,
       });
       return res.status(201).json(newPart);
     }

--- a/pages/office/parts/[id].js
+++ b/pages/office/parts/[id].js
@@ -10,8 +10,10 @@ export default function EditPartPage() {
     description: '',
     unit_cost: '',
     supplier_id: '',
+    category_id: '',
   });
   const [suppliers, setSuppliers] = useState([]);
+  const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -21,15 +23,18 @@ export default function EditPartPage() {
     Promise.all([
       fetch(`/api/parts/${id}`).then(r => (r.ok ? r.json() : Promise.reject())),
       fetch('/api/suppliers').then(r => (r.ok ? r.json() : Promise.reject())),
+      fetch('/api/categories').then(r => (r.ok ? r.json() : Promise.reject())),
     ])
-      .then(([p, s]) => {
+      .then(([p, s, c]) => {
         setForm({
           part_number: p.part_number || '',
           description: p.description || '',
           unit_cost: p.unit_cost || '',
           supplier_id: p.supplier_id || '',
+          category_id: p.category_id || '',
         });
         setSuppliers(s);
+        setCategories(c);
       })
       .catch(() => setError('Failed to load part'))
       .finally(() => setLoading(false));
@@ -50,6 +55,7 @@ export default function EditPartPage() {
           description: form.description,
           unit_cost: form.unit_cost,
           supplier_id: form.supplier_id || null,
+          category_id: form.category_id || null,
         }),
       });
       router.push('/office/parts');
@@ -83,6 +89,15 @@ export default function EditPartPage() {
             <option value="">-- None --</option>
             {suppliers.map(s => (
               <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Category</label>
+          <select name="category_id" value={form.category_id} onChange={change} className="input w-full">
+            <option value="">-- None --</option>
+            {categories.map(c => (
+              <option key={c.id} value={c.id}>{c.name}</option>
             ))}
           </select>
         </div>

--- a/pages/office/parts/categories.js
+++ b/pages/office/parts/categories.js
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import OfficeLayout from '../../../components/OfficeLayout';
+
+export default function PartCategoriesPage() {
+  const [categories, setCategories] = useState([]);
+  const [name, setName] = useState('');
+  const [error, setError] = useState(null);
+
+  const load = () => {
+    fetch('/api/categories')
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setCategories)
+      .catch(() => setError('Failed to load categories'));
+  };
+
+  useEffect(load, []);
+
+  const create = async e => {
+    e.preventDefault();
+    try {
+      await fetch('/api/categories', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      setName('');
+      load();
+    } catch {
+      setError('Failed to create category');
+    }
+  };
+
+  const remove = async id => {
+    if (!confirm('Delete this category?')) return;
+    await fetch(`/api/categories/${id}`, { method: 'DELETE' });
+    load();
+  };
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Part Categories</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={create} className="mb-4 flex gap-2">
+        <input value={name} onChange={e => setName(e.target.value)} className="input flex-grow" placeholder="New category" />
+        <button className="button" type="submit">Add</button>
+      </form>
+      <ul className="space-y-2">
+        {categories.map(c => (
+          <li key={c.id} className="flex justify-between items-center border p-2 rounded">
+            <span>{c.name}</span>
+            <button onClick={() => remove(c.id)} className="button bg-red-600 hover:bg-red-700 px-2 py-1 text-sm">Delete</button>
+          </li>
+        ))}
+      </ul>
+    </OfficeLayout>
+  );
+}

--- a/pages/office/parts/new.js
+++ b/pages/office/parts/new.js
@@ -8,16 +8,23 @@ export default function NewPartPage() {
     description: '',
     unit_cost: '',
     supplier_id: '',
+    category_id: '',
   });
   const [suppliers, setSuppliers] = useState([]);
+  const [categories, setCategories] = useState([]);
   const [error, setError] = useState(null);
   const router = useRouter();
   const { query } = router;
 
   useEffect(() => {
-    fetch('/api/suppliers')
-      .then(r => (r.ok ? r.json() : Promise.reject()))
-      .then(setSuppliers)
+    Promise.all([
+      fetch('/api/suppliers').then(r => (r.ok ? r.json() : Promise.reject())),
+      fetch('/api/categories').then(r => (r.ok ? r.json() : Promise.reject())),
+    ])
+      .then(([s, c]) => {
+        setSuppliers(s);
+        setCategories(c);
+      })
       .catch(() => setError('Failed to load suppliers'));
   }, []);
 
@@ -28,6 +35,7 @@ export default function NewPartPage() {
       part_number: query.part_number || f.part_number,
       description: query.description || f.description,
       unit_cost: query.unit_cost || f.unit_cost,
+      category_id: query.category_id || f.category_id,
     }));
   }, [router.isReady]);
 
@@ -44,6 +52,7 @@ export default function NewPartPage() {
           description: form.description,
           unit_cost: form.unit_cost,
           supplier_id: form.supplier_id || null,
+          category_id: form.category_id || null,
         }),
       });
       if (!res.ok) throw new Error();
@@ -77,6 +86,15 @@ export default function NewPartPage() {
             <option value="">-- None --</option>
             {suppliers.map(s => (
               <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Category</label>
+          <select name="category_id" value={form.category_id} onChange={change} className="input w-full">
+            <option value="">-- None --</option>
+            {categories.map(c => (
+              <option key={c.id} value={c.id}>{c.name}</option>
             ))}
           </select>
         </div>

--- a/services/categoriesService.js
+++ b/services/categoriesService.js
@@ -1,0 +1,37 @@
+import pool from '../lib/db.js';
+
+export async function getAllCategories() {
+  const [rows] = await pool.query(
+    'SELECT id, name FROM part_categories ORDER BY name'
+  );
+  return rows;
+}
+
+export async function getCategoryById(id) {
+  const [[row]] = await pool.query(
+    'SELECT id, name FROM part_categories WHERE id=?',
+    [id]
+  );
+  return row || null;
+}
+
+export async function createCategory({ name }) {
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO part_categories (name) VALUES (?)',
+    [name]
+  );
+  return { id: insertId, name };
+}
+
+export async function updateCategory(id, { name }) {
+  await pool.query(
+    'UPDATE part_categories SET name=? WHERE id=?',
+    [name, id]
+  );
+  return { ok: true };
+}
+
+export async function deleteCategory(id) {
+  await pool.query('DELETE FROM part_categories WHERE id=?', [id]);
+  return { ok: true };
+}

--- a/services/partsService.js
+++ b/services/partsService.js
@@ -4,7 +4,7 @@ export async function searchParts(query) {
   const q = `%${query}%`;
   const [rows] = query
     ? await pool.query(
-        `SELECT id, part_number, description, unit_cost, supplier_id
+        `SELECT id, part_number, description, unit_cost, supplier_id, category_id
            FROM parts
           WHERE part_number LIKE ? OR description LIKE ?
           ORDER BY part_number
@@ -12,7 +12,7 @@ export async function searchParts(query) {
         [q, q]
       )
     : await pool.query(
-        `SELECT id, part_number, description, unit_cost, supplier_id
+        `SELECT id, part_number, description, unit_cost, supplier_id, category_id
            FROM parts
           ORDER BY part_number
           LIMIT 20`
@@ -25,27 +25,28 @@ export async function createPart({
   description,
   unit_cost,
   supplier_id,
+  category_id,
 }) {
   const [{ insertId }] = await pool.query(
-    `INSERT INTO parts (part_number, description, unit_cost, supplier_id)
-     VALUES (?,?,?,?)`,
-    [part_number, description || null, unit_cost || null, supplier_id || null]
+    `INSERT INTO parts (part_number, description, unit_cost, supplier_id, category_id)
+     VALUES (?,?,?,?,?)`,
+    [part_number, description || null, unit_cost || null, supplier_id || null, category_id || null]
   );
-  return { id: insertId, part_number, description, unit_cost, supplier_id };
+  return { id: insertId, part_number, description, unit_cost, supplier_id, category_id };
 }
 
 export async function getPartById(id) {
   const [[row]] = await pool.query(
-    `SELECT id, part_number, description, unit_cost, supplier_id FROM parts WHERE id=?`,
+    `SELECT id, part_number, description, unit_cost, supplier_id, category_id FROM parts WHERE id=?`,
     [id]
   );
   return row || null;
 }
 
-export async function updatePart(id, { part_number, description, unit_cost, supplier_id }) {
+export async function updatePart(id, { part_number, description, unit_cost, supplier_id, category_id }) {
   await pool.query(
-    `UPDATE parts SET part_number=?, description=?, unit_cost=?, supplier_id=? WHERE id=?`,
-    [part_number, description || null, unit_cost || null, supplier_id || null, id]
+    `UPDATE parts SET part_number=?, description=?, unit_cost=?, supplier_id=?, category_id=? WHERE id=?`,
+    [part_number, description || null, unit_cost || null, supplier_id || null, category_id || null, id]
   );
   return { ok: true };
 }


### PR DESCRIPTION
## Summary
- create `part_categories` table and FK on `parts`
- add service and API routes to manage categories
- extend part service and API for optional `category_id`
- show a category dropdown in part forms
- provide office page for managing part categories
- update tests for new field and add basic category test

## Testing
- `npm install`
- `npm test` *(fails: SyntaxError during jest transforms)*

------
https://chatgpt.com/codex/tasks/task_e_68785065e3b88333a532722c172ececb