### PR TITLE
Implement basic EPOS

### DIFF
--- a/__tests__/epos-api.test.js
+++ b/__tests__/epos-api.test.js
@@ -1,0 +1,76 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// start-day GET
+test('get active session', async () => {
+  const sess = { id: 1 };
+  jest.unstable_mockModule('../services/posSessionsService.js', () => ({
+    getActiveSession: jest.fn().mockResolvedValue(sess),
+    startSession: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/epos/start-day.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(sess);
+});
+
+// start-day POST
+test('start session returns new session', async () => {
+  const sess = { id: 2 };
+  const startMock = jest.fn().mockResolvedValue(sess);
+  jest.unstable_mockModule('../services/posSessionsService.js', () => ({
+    getActiveSession: jest.fn(),
+    startSession: startMock,
+  }));
+  const { default: handler } = await import('../pages/api/epos/start-day.js');
+  const req = { method: 'POST', body: { float_amount: 5 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(startMock).toHaveBeenCalledWith(5);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(sess);
+});
+
+// record sale
+test('record sale posts items', async () => {
+  const sale = { id: 3 };
+  const recordMock = jest.fn().mockResolvedValue(sale);
+  const addMock = jest.fn();
+  jest.unstable_mockModule('../services/posSalesService.js', () => ({
+    recordSale: recordMock,
+  }));
+  jest.unstable_mockModule('../services/posSaleItemsService.js', () => ({
+    addSaleItem: addMock,
+  }));
+  const { default: handler } = await import('../pages/api/epos/sales.js');
+  const req = { method: 'POST', body: { session_id: 1, payment_type: 'cash', total_amount: 10, items: [{ part_id: 1, qty: 2, unit_price: 5 }] }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(recordMock).toHaveBeenCalled();
+  expect(addMock).toHaveBeenCalledWith({ sale_id: sale.id, part_id: 1, qty: 2, unit_price: 5 });
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(sale);
+});
+
+// end-day POST
+test('end session closes day', async () => {
+  const session = { id: 4 };
+  const endMock = jest.fn().mockResolvedValue(session);
+  jest.unstable_mockModule('../services/posSessionsService.js', () => ({
+    getActiveSession: jest.fn().mockResolvedValue(session),
+    endSession: endMock,
+  }));
+  const { default: handler } = await import('../pages/api/epos/end-day.js');
+  const req = { method: 'POST', body: { cash_total: 1, card_total: 2 }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(endMock).toHaveBeenCalledWith(session.id, { cash_total: 1, card_total: 2 });
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(session);
+});

--- a/components/OfficeLayout.jsx
+++ b/components/OfficeLayout.jsx
@@ -88,6 +88,12 @@ export default function OfficeLayout({ children }) {
                   Pay Invoice
                 </Link>
               </li>
+              <li>
+                <Link href="/office/epos" className="flex items-center hover:underline">
+                  <ArrowIcon />
+                  EPOS
+                </Link>
+              </li>
             </ul>
           </div>
           <div>

--- a/migrations/20260721_create_pos_tables.sql
+++ b/migrations/20260721_create_pos_tables.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS pos_sessions (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ended_at DATETIME DEFAULT NULL,
+  float_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+  cash_total DECIMAL(10,2) NOT NULL DEFAULT 0,
+  card_total DECIMAL(10,2) NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS pos_sales (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  session_id INT NOT NULL,
+  customer_id INT DEFAULT NULL,
+  vehicle_id INT DEFAULT NULL,
+  payment_type ENUM('cash','card') NOT NULL,
+  total_amount DECIMAL(10,2) NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (session_id) REFERENCES pos_sessions(id)
+);
+
+CREATE TABLE IF NOT EXISTS pos_sale_items (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  sale_id INT NOT NULL,
+  part_id INT NOT NULL,
+  qty INT NOT NULL,
+  unit_price DECIMAL(10,2) NOT NULL,
+  FOREIGN KEY (sale_id) REFERENCES pos_sales(id)
+);

--- a/pages/api/epos/end-day.js
+++ b/pages/api/epos/end-day.js
@@ -1,0 +1,16 @@
+import apiHandler from '../../../lib/apiHandler.js';
+import { endSession, getActiveSession } from '../../../services/posSessionsService.js';
+
+async function handler(req, res) {
+  if (req.method === 'POST') {
+    const session = await getActiveSession();
+    if (!session) return res.status(400).json({ error: 'no_session' });
+    const { cash_total, card_total } = req.body;
+    const closed = await endSession(session.id, { cash_total, card_total });
+    return res.status(200).json(closed);
+  }
+  res.setHeader('Allow', ['POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/api/epos/sales.js
+++ b/pages/api/epos/sales.js
@@ -1,0 +1,20 @@
+import apiHandler from '../../../lib/apiHandler.js';
+import { recordSale } from '../../../services/posSalesService.js';
+import { addSaleItem } from '../../../services/posSaleItemsService.js';
+
+async function handler(req, res) {
+  if (req.method === 'POST') {
+    const { session_id, customer_id, vehicle_id, payment_type, total_amount, items } = req.body;
+    const sale = await recordSale({ session_id, customer_id, vehicle_id, payment_type, total_amount });
+    if (items && Array.isArray(items)) {
+      for (const it of items) {
+        await addSaleItem({ sale_id: sale.id, part_id: it.part_id, qty: it.qty, unit_price: it.unit_price });
+      }
+    }
+    return res.status(201).json(sale);
+  }
+  res.setHeader('Allow', ['POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/api/epos/start-day.js
+++ b/pages/api/epos/start-day.js
@@ -1,0 +1,18 @@
+import apiHandler from '../../../lib/apiHandler.js';
+import { startSession, getActiveSession } from '../../../services/posSessionsService.js';
+
+async function handler(req, res) {
+  if (req.method === 'GET') {
+    const session = await getActiveSession();
+    return res.status(200).json(session);
+  }
+  if (req.method === 'POST') {
+    const { float_amount } = req.body;
+    const session = await startSession(float_amount || 0);
+    return res.status(201).json(session);
+  }
+  res.setHeader('Allow', ['GET','POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}
+
+export default apiHandler(handler);

--- a/pages/office/epos/end-day.js
+++ b/pages/office/epos/end-day.js
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import OfficeLayout from '../../../components/OfficeLayout';
+
+export default function EndDayPage() {
+  const router = useRouter();
+  const [session, setSession] = useState(null);
+  const [cash, setCash] = useState('');
+  const [card, setCard] = useState('');
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/epos/start-day')
+      .then(r => r.json())
+      .then(setSession);
+  }, []);
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/epos/end-day', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cash_total: parseFloat(cash) || 0, card_total: parseFloat(card) || 0 }),
+      });
+      if (!res.ok) throw new Error();
+      router.push('/office/epos');
+    } catch {
+      setError('Failed to close session');
+    }
+  };
+
+  if (!session) return <OfficeLayout><p>Loading...</p></OfficeLayout>;
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">End Day</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-sm">
+        <p>Started at: {new Date(session.started_at).toLocaleString()}</p>
+        <div>
+          <label className="block mb-1">Cash Total</label>
+          <input type="number" value={cash} onChange={e => setCash(e.target.value)} className="input w-full" />
+        </div>
+        <div>
+          <label className="block mb-1">Card Total</label>
+          <input type="number" value={card} onChange={e => setCard(e.target.value)} className="input w-full" />
+        </div>
+        <button type="submit" className="button">Close Session</button>
+      </form>
+    </OfficeLayout>
+  );
+}

--- a/pages/office/epos/index.js
+++ b/pages/office/epos/index.js
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import OfficeLayout from '../../../components/OfficeLayout';
+
+function Keypad({ value, onChange }) {
+  return (
+    <input
+      type="number"
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      className="input w-full mb-2"
+    />
+  );
+}
+
+export default function EposPage() {
+  const [categories, setCategories] = useState([]);
+  const [parts, setParts] = useState([]);
+  const [categoryId, setCategoryId] = useState(null);
+  const [cart, setCart] = useState([]);
+  const [qty, setQty] = useState(1);
+  const [showPay, setShowPay] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/categories')
+      .then(r => r.json())
+      .then(setCategories);
+  }, []);
+
+  useEffect(() => {
+    if (!categoryId) return;
+    fetch(`/api/parts?category_id=${categoryId}`)
+      .then(r => r.json())
+      .then(setParts);
+  }, [categoryId]);
+
+  const add = p => {
+    setCart(c => [...c, { ...p, qty }]);
+    setQty(1);
+  };
+
+  const remove = idx => setCart(c => c.filter((_, i) => i !== idx));
+
+  const pay = async type => {
+    const total = cart.reduce((sum, i) => sum + i.unit_cost * i.qty, 0);
+    await fetch('/api/epos/sales', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: 1, payment_type: type, total_amount: total, items: cart.map(i => ({ part_id: i.id, qty: i.qty, unit_price: i.unit_cost })) }),
+    });
+    setCart([]);
+    setShowPay(false);
+  };
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">EPOS</h1>
+      {!categoryId && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          {categories.map(c => (
+            <button key={c.id} onClick={() => setCategoryId(c.id)} className="button">
+              {c.name}
+            </button>
+          ))}
+        </div>
+      )}
+      {categoryId && (
+        <div className="space-y-2">
+          <button onClick={() => setCategoryId(null)} className="button-secondary mb-2">Back</button>
+          <Keypad value={qty} onChange={setQty} />
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+            {parts.map(p => (
+              <button key={p.id} onClick={() => add(p)} className="button">
+                {p.part_number}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      <h2 className="text-xl font-semibold mt-4 mb-2">Cart</h2>
+      <ul className="space-y-1">
+        {cart.map((item, i) => (
+          <li key={i} className="flex justify-between">
+            <span>
+              {item.qty} x {item.part_number}
+            </span>
+            <button onClick={() => remove(i)} className="text-red-500">Remove</button>
+          </li>
+        ))}
+      </ul>
+      {cart.length > 0 && (
+        <div className="mt-4 space-x-2">
+          <button onClick={() => setShowPay(true)} className="button">Pay</button>
+          <button onClick={() => setCart([])} className="button-secondary">Clear</button>
+        </div>
+      )}
+      {showPay && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-white p-4 rounded space-x-2">
+            <button onClick={() => pay('cash')} className="button">Cash</button>
+            <button onClick={() => pay('card')} className="button">Card</button>
+            <button onClick={() => setShowPay(false)} className="button-secondary">Cancel</button>
+          </div>
+        </div>
+      )}
+    </OfficeLayout>
+  );
+}

--- a/pages/office/epos/start-day.js
+++ b/pages/office/epos/start-day.js
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import OfficeLayout from '../../../components/OfficeLayout';
+
+export default function StartDayPage() {
+  const router = useRouter();
+  const [floatAmount, setFloatAmount] = useState('');
+  const [error, setError] = useState(null);
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/epos/start-day', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ float_amount: parseFloat(floatAmount) || 0 }),
+      });
+      if (!res.ok) throw new Error();
+      router.push('/office/epos');
+    } catch {
+      setError('Failed to start session');
+    }
+  };
+
+  return (
+    <OfficeLayout>
+      <h1 className="text-2xl font-semibold mb-4">Start Day</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={submit} className="space-y-4 max-w-sm">
+        <div>
+          <label className="block mb-1">Float Amount</label>
+          <input
+            type="number"
+            value={floatAmount}
+            onChange={e => setFloatAmount(e.target.value)}
+            className="input w-full"
+          />
+        </div>
+        <button type="submit" className="button">
+          Open Session
+        </button>
+      </form>
+    </OfficeLayout>
+  );
+}

--- a/services/posSaleItemsService.js
+++ b/services/posSaleItemsService.js
@@ -1,0 +1,16 @@
+import pool from '../lib/db.js';
+
+export async function addSaleItem({ sale_id, part_id, qty, unit_price }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO pos_sale_items (sale_id, part_id, qty, unit_price)
+     VALUES (?,?,?,?)`,
+    [sale_id, part_id, qty, unit_price]
+  );
+  const [[row]] = await pool.query('SELECT * FROM pos_sale_items WHERE id=?', [insertId]);
+  return row;
+}
+
+export async function getItemsBySale(sale_id) {
+  const [rows] = await pool.query('SELECT * FROM pos_sale_items WHERE sale_id=?', [sale_id]);
+  return rows;
+}

--- a/services/posSalesService.js
+++ b/services/posSalesService.js
@@ -1,0 +1,16 @@
+import pool from '../lib/db.js';
+
+export async function recordSale({ session_id, customer_id, vehicle_id, payment_type, total_amount }) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO pos_sales (session_id, customer_id, vehicle_id, payment_type, total_amount)
+     VALUES (?,?,?,?,?)`,
+    [session_id, customer_id || null, vehicle_id || null, payment_type, total_amount]
+  );
+  const [[row]] = await pool.query('SELECT * FROM pos_sales WHERE id=?', [insertId]);
+  return row;
+}
+
+export async function getSalesBySession(session_id) {
+  const [rows] = await pool.query('SELECT * FROM pos_sales WHERE session_id=?', [session_id]);
+  return rows;
+}

--- a/services/posSessionsService.js
+++ b/services/posSessionsService.js
@@ -1,0 +1,29 @@
+import pool from '../lib/db.js';
+
+export async function startSession(float_amount) {
+  const [{ insertId }] = await pool.query(
+    `INSERT INTO pos_sessions (float_amount) VALUES (?)`,
+    [float_amount]
+  );
+  const [[row]] = await pool.query(
+    'SELECT * FROM pos_sessions WHERE id=?',
+    [insertId]
+  );
+  return row;
+}
+
+export async function endSession(id, { cash_total, card_total }) {
+  await pool.query(
+    `UPDATE pos_sessions SET ended_at=NOW(), cash_total=?, card_total=? WHERE id=?`,
+    [cash_total, card_total, id]
+  );
+  const [[row]] = await pool.query('SELECT * FROM pos_sessions WHERE id=?', [id]);
+  return row;
+}
+
+export async function getActiveSession() {
+  const [[row]] = await pool.query(
+    'SELECT * FROM pos_sessions WHERE ended_at IS NULL ORDER BY id DESC LIMIT 1'
+  );
+  return row || null;
+}


### PR DESCRIPTION
## Summary
- add pos tables migration
- implement services for sessions, sales and sale items
- expose `/api/epos` endpoints
- create EPOS front‑end pages and manager screens
- link EPOS from Office menu
- test EPOS API behaviour

## Testing
- `npm test` *(fails: vehicles-api.test.js, clients-api.test.js, quotes-api.test.js, invoice-new-page.test.js, chat-history.test.js, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6878532d961c8333ab3c5cf2ae958727