### PR TITLE
Add Part Categories navigation link

### DIFF
--- a/components/OfficeLayout.jsx
+++ b/components/OfficeLayout.jsx
@@ -195,9 +195,21 @@ export default function OfficeLayout({ children }) {
             <h3 className="uppercase text-sm font-semibold mb-2 text-cyan-400">Assets</h3>
             <ul className="space-y-1">
               <li>
-                <Link href="/office/parts" className="flex items-center hover:underline">
+                <Link
+                  href="/office/parts"
+                  className={`flex items-center hover:underline ${router.pathname.startsWith('/office/parts') && !router.pathname.startsWith('/office/parts/categories') ? 'text-yellow-300 font-semibold' : ''}`}
+                >
                   <ArrowIcon />
                   Parts
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/office/parts/categories"
+                  className={`flex items-center hover:underline ${router.pathname.startsWith('/office/parts/categories') ? 'text-yellow-300 font-semibold' : ''}`}
+                >
+                  <ArrowIcon />
+                  Part Categories
                 </Link>
               </li>
               <li>

--- a/pages/office/parts/index.js
+++ b/pages/office/parts/index.js
@@ -42,7 +42,12 @@ export default function PartsPage() {
     <OfficeLayout>
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-semibold">Parts</h1>
-        <Link href="/office/parts/new" className="button">+ New Part</Link>
+        <div className="flex gap-2">
+          <Link href="/office/parts/categories" className="button-secondary">
+            Categories
+          </Link>
+          <Link href="/office/parts/new" className="button">+ New Part</Link>
+        </div>
       </div>
       {error && <p className="text-red-500">{error}</p>}
       {loading ? (


### PR DESCRIPTION
## Summary
- link to part categories from parts index
- include "Part Categories" in OfficeLayout navigation
- highlight Parts and Part Categories links when active

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6878665e9d6c8333937c97b4ade5a474