### PR TITLE
Add categories service and API tests

### DIFF
--- a/__tests__/categories-api.test.js
+++ b/__tests__/categories-api.test.js
@@ -1,0 +1,92 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+// GET /categories
+test('categories index returns list of categories', async () => {
+  const cats = [{ id: 1, name: 'A' }];
+  const getAllMock = jest.fn().mockResolvedValue(cats);
+  jest.unstable_mockModule('../services/categoriesService.js', () => ({
+    getAllCategories: getAllMock,
+    createCategory: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/categories/index.js');
+  const req = { method: 'GET', headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(cats);
+  expect(getAllMock).toHaveBeenCalledTimes(1);
+});
+
+// POST /categories
+test('categories index creates category', async () => {
+  const newCat = { id: 2, name: 'B' };
+  const createMock = jest.fn().mockResolvedValue(newCat);
+  jest.unstable_mockModule('../services/categoriesService.js', () => ({
+    getAllCategories: jest.fn(),
+    createCategory: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/categories/index.js');
+  const req = { method: 'POST', body: { name: 'B' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(newCat);
+  expect(createMock).toHaveBeenCalledWith(req.body);
+});
+
+// GET /categories/[id]
+test('category detail returns category by id', async () => {
+  const cat = { id: 3, name: 'C' };
+  const getMock = jest.fn().mockResolvedValue(cat);
+  jest.unstable_mockModule('../services/categoriesService.js', () => ({
+    getCategoryById: getMock,
+    updateCategory: jest.fn(),
+    deleteCategory: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/categories/[id].js');
+  const req = { method: 'GET', query: { id: '3' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(cat);
+  expect(getMock).toHaveBeenCalledWith('3');
+});
+
+// PUT /categories/[id]
+test('category update returns ok', async () => {
+  const updateMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/categoriesService.js', () => ({
+    getCategoryById: jest.fn(),
+    updateCategory: updateMock,
+    deleteCategory: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/categories/[id].js');
+  const req = { method: 'PUT', query: { id: '4' }, body: { name: 'New' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ ok: true });
+  expect(updateMock).toHaveBeenCalledWith('4', req.body);
+});
+
+// DELETE /categories/[id]
+test('category delete succeeds', async () => {
+  const deleteMock = jest.fn().mockResolvedValue({ ok: true });
+  jest.unstable_mockModule('../services/categoriesService.js', () => ({
+    getCategoryById: jest.fn(),
+    updateCategory: jest.fn(),
+    deleteCategory: deleteMock,
+  }));
+  const { default: handler } = await import('../pages/api/categories/[id].js');
+  const req = { method: 'DELETE', query: { id: '5' }, headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.status).toHaveBeenCalledWith(204);
+  expect(res.end).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalledWith('5');
+});

--- a/__tests__/categoriesService.test.js
+++ b/__tests__/categoriesService.test.js
@@ -13,3 +13,21 @@ test('createCategory inserts row', async () => {
   expect(queryMock).toHaveBeenCalledWith('INSERT INTO part_categories (name) VALUES (?)', ['Cat']);
   expect(result).toEqual({ id: 4, name: 'Cat' });
 });
+
+test('updateCategory updates row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { updateCategory } = await import('../services/categoriesService.js');
+  const result = await updateCategory(5, { name: 'Updated' });
+  expect(queryMock).toHaveBeenCalledWith('UPDATE part_categories SET name=? WHERE id=?', ['Updated', 5]);
+  expect(result).toEqual({ ok: true });
+});
+
+test('deleteCategory deletes row', async () => {
+  const queryMock = jest.fn().mockResolvedValue([]);
+  jest.unstable_mockModule('../lib/db.js', () => ({ default: { query: queryMock } }));
+  const { deleteCategory } = await import('../services/categoriesService.js');
+  const result = await deleteCategory(6);
+  expect(queryMock).toHaveBeenCalledWith('DELETE FROM part_categories WHERE id=?', [6]);
+  expect(result).toEqual({ ok: true });
+});


### PR DESCRIPTION
## Summary
- extend categoriesService tests for updateCategory and deleteCategory
- add API tests for categories endpoints

## Testing
- `npm test` *(fails: Test Suites: 42 failed, 1 skipped, 34 passed, 76 of 77 total)*

------
https://chatgpt.com/codex/tasks/task_e_687868e4a9a0833399c7984486b44415