### PR TITLE
Add duration when assigning jobs

### DIFF
--- a/pages/api/jobs/[id]/assign.js
+++ b/pages/api/jobs/[id]/assign.js
@@ -22,6 +22,7 @@ async function handler(req, res) {
         engineer_id,
         scheduled_start,
         scheduled_end,
+        duration,
         awaiting_parts,
       } = req.body || {};
       if (awaiting_parts) {
@@ -31,10 +32,18 @@ async function handler(req, res) {
           return res.status(400).json({ error: 'engineer_id required' });
         }
         await assignUser(id, engineer_id);
+        let end = scheduled_end;
+        if (!end && duration && scheduled_start) {
+          const start = new Date(scheduled_start);
+          if (!Number.isNaN(start.getTime())) {
+            const calc = new Date(start.getTime() + Number(duration) * 60000);
+            end = calc.toISOString().slice(0, 16);
+          }
+        }
         await updateJob(id, {
           status: 'awaiting assessment',
           scheduled_start,
-          scheduled_end,
+          scheduled_end: end,
         });
       }
       const job = await getJobDetails(id);

--- a/pages/office/job-management/index.js
+++ b/pages/office/job-management/index.js
@@ -65,6 +65,14 @@ export default function JobManagementPage() {
 
   const assign = async id => {
     const data = forms[id] || {};
+    let scheduled_end = '';
+    if (data.duration && data.scheduled_start) {
+      const start = new Date(data.scheduled_start);
+      if (!Number.isNaN(start.getTime())) {
+        const end = new Date(start.getTime() + Number(data.duration) * 60000);
+        scheduled_end = end.toISOString().slice(0, 16);
+      }
+    }
     try {
       const res = await fetch(`/api/jobs/${id}/assign`, {
         method: 'POST',
@@ -72,6 +80,8 @@ export default function JobManagementPage() {
         body: JSON.stringify({
           engineer_id: data.engineer_id,
           scheduled_start: data.scheduled_start,
+          scheduled_end,
+          duration: data.duration,
         }),
       });
       if (!res.ok) throw new Error();


### PR DESCRIPTION
## Summary
- add duration support on `/office/jobs/assign`
- compute scheduled_end using duration in job management list
- accept duration in job assign API

## Testing
- `npm test` *(fails: `npm` not found)*
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68786ae2064483338a1c6f304679c215