### PR TITLE
Fix completed jobs showing in calendar

### DIFF
--- a/components/SchedulingCalendar.jsx
+++ b/components/SchedulingCalendar.jsx
@@ -63,7 +63,12 @@ export default function SchedulingCalendar() {
       )
       setEvents(
         jobs
-          .filter(j => j.scheduled_start && j.scheduled_end)
+          .filter(
+            j =>
+              j.scheduled_start &&
+              j.scheduled_end &&
+              j.status !== 'completed'
+          )
           .map(j => ({
             id: j.id,
             title: `Job #${j.id}`,


### PR DESCRIPTION
## Summary
- adjust event filtering so completed jobs are not shown on the calendar

## Testing
- `npm test` *(fails: Test Suites: 42 failed, 1 skipped, 34 passed, 76 of 77 total)*

------
https://chatgpt.com/codex/tasks/task_e_68786c71fd7083339aa4c141b49fab04