### PR TITLE
Fix EPOS page markup

### DIFF
--- a/pages/office/epos/index.js
+++ b/pages/office/epos/index.js
@@ -223,6 +223,7 @@ export default function EposPage() {
           </Card>
         </div>
       </div>
+      </div>
     </OfficeLayout>
   );
 }


### PR DESCRIPTION
## Summary
- fix closing tag in `pages/office/epos/index.js`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687871df8b008333ad4bd4778dfbd035