### PR TITLE
Add manager button to EPOS page

### DIFF
--- a/pages/office/epos/index.js
+++ b/pages/office/epos/index.js
@@ -228,11 +228,19 @@ export default function EposPage() {
           </Button>
         </div>
       </div>
-      {error && <p className="text-red-500">{error}</p>}
-      {loading && <p>Loading…</p>}
-      <Link href="/office" className="button inline-block mb-4">
-        Return to Office
-      </Link>
+        {error && <p className="text-red-500">{error}</p>}
+        {loading && <p>Loading…</p>}
+        <div className="flex justify-between items-center mb-4">
+          <Link href="/office" className="button">
+            Return to Office
+          </Link>
+          <Link
+            href={session ? "/office/epos/end-day" : "/office/epos/start-day"}
+            className="button-secondary"
+          >
+            Manager
+          </Link>
+        </div>
       {/* Cart & keypad pane - now full width */}
       <div className="flex flex-col flex-1 justify-between">
         <Card className="flex-1 mb-4">


### PR DESCRIPTION
## Summary
- add a header action for Manager on EPOS home

## Testing
- `npm test` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68787642d3d4833384d3448b01a47f7d