### PR TITLE
Implement EPOS reporting

### DIFF
--- a/lib/reporting.js
+++ b/lib/reporting.js
@@ -15,3 +15,9 @@ export async function fetchBusinessPerformance(start, end) {
   if (!res.ok) throw new Error('Failed to fetch business performance');
   return res.json();
 }
+
+export async function fetchEposReport(start, end) {
+  const res = await fetch(`/api/reporting/epos?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}`);
+  if (!res.ok) throw new Error('Failed to fetch epos report');
+  return res.json();
+}

--- a/pages/api/reporting/epos.js
+++ b/pages/api/reporting/epos.js
@@ -1,0 +1,14 @@
+import { getEposReport } from '../../../services/posReportingService.js';
+import apiHandler from '../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+  const { start, end } = req.query;
+  const report = await getEposReport(start, end);
+  return res.status(200).json(report);
+}
+
+export default apiHandler(handler);

--- a/pages/office/reporting/index.js
+++ b/pages/office/reporting/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import OfficeLayout from '../../../components/OfficeLayout';
-import { fetchFinanceReport, fetchEngineerPerformance, fetchBusinessPerformance } from '../../../lib/reporting';
+import { fetchFinanceReport, fetchEngineerPerformance, fetchBusinessPerformance, fetchEposReport } from '../../../lib/reporting';
 
 function formatDate(d) {
   return d.toISOString().substring(0, 10);
@@ -13,6 +13,7 @@ const ReportingPage = () => {
   const [finance, setFinance] = useState(null);
   const [engineers, setEngineers] = useState([]);
   const [business, setBusiness] = useState(null);
+  const [epos, setEpos] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -50,11 +51,13 @@ const ReportingPage = () => {
       fetchFinanceReport(dates.start, dates.end),
       fetchEngineerPerformance(dates.start, dates.end),
       fetchBusinessPerformance(dates.start, dates.end),
+      fetchEposReport(dates.start, dates.end),
     ])
-      .then(([fin, eng, biz]) => {
+      .then(([fin, eng, biz, epos]) => {
         setFinance(fin);
         setEngineers(eng);
         setBusiness(biz);
+        setEpos(epos);
         setError(null);
       })
       .catch(err => {
@@ -136,6 +139,44 @@ const ReportingPage = () => {
                 <tr>
                   <td className="px-2 py-1">{business.jobs_created}</td>
                   <td className="px-2 py-1">{business.jobs_completed}</td>
+                </tr>
+              </tbody>
+            </table>
+          )}
+          <h2 className="text-lg font-semibold mt-4 mb-2">EPOS</h2>
+          {epos && (
+            <table className="mb-4 table-auto">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1">Session</th>
+                  <th className="px-2 py-1">Cash Sales</th>
+                  <th className="px-2 py-1">Declared Cash</th>
+                  <th className="px-2 py-1">Cash Diff</th>
+                  <th className="px-2 py-1">Card Sales</th>
+                  <th className="px-2 py-1">Declared Card</th>
+                  <th className="px-2 py-1">Card Diff</th>
+                </tr>
+              </thead>
+              <tbody>
+                {epos.sessions.map(s => (
+                  <tr key={s.id}>
+                    <td className="px-2 py-1">{s.id}</td>
+                    <td className="px-2 py-1">€{s.sales_cash.toFixed(2)}</td>
+                    <td className="px-2 py-1">€{s.declared_cash.toFixed(2)}</td>
+                    <td className="px-2 py-1">€{s.cash_difference.toFixed(2)}</td>
+                    <td className="px-2 py-1">€{s.sales_card.toFixed(2)}</td>
+                    <td className="px-2 py-1">€{s.declared_card.toFixed(2)}</td>
+                    <td className="px-2 py-1">€{s.card_difference.toFixed(2)}</td>
+                  </tr>
+                ))}
+                <tr className="font-semibold border-t">
+                  <td className="px-2 py-1">Total</td>
+                  <td className="px-2 py-1">€{epos.totals.sales_cash.toFixed(2)}</td>
+                  <td className="px-2 py-1">€{epos.totals.declared_cash.toFixed(2)}</td>
+                  <td className="px-2 py-1">€{epos.totals.cash_difference.toFixed(2)}</td>
+                  <td className="px-2 py-1">€{epos.totals.sales_card.toFixed(2)}</td>
+                  <td className="px-2 py-1">€{epos.totals.declared_card.toFixed(2)}</td>
+                  <td className="px-2 py-1">€{epos.totals.card_difference.toFixed(2)}</td>
                 </tr>
               </tbody>
             </table>

--- a/services/posReportingService.js
+++ b/services/posReportingService.js
@@ -1,0 +1,44 @@
+import pool from '../lib/db.js';
+
+export async function getEposReport(start, end) {
+  const [rows] = await pool.query(
+    `SELECT s.id, s.started_at, s.ended_at,
+            s.cash_total AS declared_cash,
+            s.card_total AS declared_card,
+            COALESCE(SUM(CASE WHEN ps.payment_type='cash' THEN ps.total_amount END),0) AS sales_cash,
+            COALESCE(SUM(CASE WHEN ps.payment_type='card' THEN ps.total_amount END),0) AS sales_card
+       FROM pos_sessions s
+       LEFT JOIN pos_sales ps ON ps.session_id = s.id
+      WHERE s.started_at >= ? AND s.started_at < ?
+   GROUP BY s.id
+   ORDER BY s.started_at`,
+    [start, end]
+  );
+
+  const sessions = rows.map(row => ({
+    id: row.id,
+    started_at: row.started_at,
+    ended_at: row.ended_at,
+    declared_cash: Number(row.declared_cash),
+    declared_card: Number(row.declared_card),
+    sales_cash: Number(row.sales_cash),
+    sales_card: Number(row.sales_card),
+    cash_difference: Number(row.sales_cash) - Number(row.declared_cash),
+    card_difference: Number(row.sales_card) - Number(row.declared_card),
+  }));
+
+  const totals = sessions.reduce(
+    (acc, s) => {
+      acc.sales_cash += s.sales_cash;
+      acc.sales_card += s.sales_card;
+      acc.declared_cash += s.declared_cash;
+      acc.declared_card += s.declared_card;
+      return acc;
+    },
+    { sales_cash: 0, sales_card: 0, declared_cash: 0, declared_card: 0 }
+  );
+  totals.cash_difference = totals.sales_cash - totals.declared_cash;
+  totals.card_difference = totals.sales_card - totals.declared_card;
+
+  return { sessions, totals };
+}


### PR DESCRIPTION
## Summary
- add posReportingService for EPOS totals comparison
- expose `/api/reporting/epos` endpoint
- support `fetchEposReport` on the client
- show EPOS report on the office reporting page

## Testing
- `npm test` *(fails: clients-api.test.js, vehicles-api.test.js, job-view-page.test.js, invoices-api.test.js, quotes-api.test.js, clients-service.test.js, jobs-assign-api.test.js, engineer-holiday-requests-api.test.js, invoicesService.test.js, engineer-time-entries-api.test.js, quotesService.test.js, fleets-api.test.js, engineer-jobs-api.test.js, scheduling-page.test.js, office-pages.test.js, jobRequests-api.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68787877c1d08333ba0dd464c7101223