### PR TITLE
Fix engineer default on job view

### DIFF
--- a/__tests__/job-view-page.test.js
+++ b/__tests__/job-view-page.test.js
@@ -158,3 +158,21 @@ test('job view page lists quotes and new revision link', async () => {
   const newLink = screen.getByRole('link', { name: 'New Quote for Job' });
   expect(newLink).toHaveAttribute('href', '/office/quotations/new?job_id=12');
 });
+
+test('engineer dropdown defaults to assigned engineer', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '21' } })
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 2, username: 'E' }] })
+    .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 1, name: 'open' }] })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 21, status: 'open', assignments: [{ user_id: 2 }] }) });
+
+  const { default: Page } = await import('../pages/office/jobs/[id].js');
+  render(<Page />);
+
+  await screen.findByText('Job #21');
+  expect(screen.getByLabelText('Engineer').value).toBe('2');
+});

--- a/pages/office/jobs/[id].js
+++ b/pages/office/jobs/[id].js
@@ -46,7 +46,7 @@ export default function JobViewPage() {
 
         setForm({
           status: jobData.status || '',
-          engineer_id: jobData.engineer_id || '',
+          engineer_id: jobData.assignments?.[0]?.user_id || '',
           scheduled_start: jobData.scheduled_start || '',
           notes: jobData.notes || '',
         });


### PR DESCRIPTION
## Summary
- derive engineer field from latest assignment
- ensure job view selects assigned engineer on load
- test default engineer selection

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68788c4fc7c48333a5ea198671795d6d