### PR TITLE
Fix local date for LiveScreen

### DIFF
--- a/__tests__/office-live-screen.test.js
+++ b/__tests__/office-live-screen.test.js
@@ -12,7 +12,8 @@ afterEach(() => {
 
 
 test('LiveScreen lists todays jobs only', async () => {
-  const today = new Date().toISOString().slice(0, 10);
+  const date = new Date();
+  const today = date.toLocaleDateString('en-CA');
   const jobs = [
     { id: 1, status: 'in progress', scheduled_start: '2024-01-01T10:00:00Z', scheduled_end: '2024-01-01T11:00:00Z' }
   ];

--- a/pages/office/live-screen/index.js
+++ b/pages/office/live-screen/index.js
@@ -16,7 +16,8 @@ const LiveScreenPage = () => {
 
   const load = () => {
     setLoading(true);
-    const dateStr = new Date().toISOString().slice(0, 10);
+    const date = new Date();
+    const dateStr = date.toLocaleDateString('en-CA');
     Promise.all([
       fetchQuotes(),
       fetchJobsForDate(dateStr),


### PR DESCRIPTION
## Summary
- compute today's date using local time in the live screen page
- adjust the LiveScreen test for new date format

## Testing
- `npm test` *(fails: 43 failed, 34 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68788c73e11c8333be86812ba5ec1ae7