### PR TITLE
Fix scheduling calendar local date range

### DIFF
--- a/__tests__/scheduling-page.test.js
+++ b/__tests__/scheduling-page.test.js
@@ -22,8 +22,9 @@ test('jobs fetch and display in calendar and side panel', async () => {
     },
     { id: 2, status: 'unassigned', assignments: [], licence_plate: 'BBB222' },
   ];
+  const fetchJobsInRange = jest.fn().mockResolvedValue(jobs);
   jest.unstable_mockModule('../lib/jobs', () => ({
-    fetchJobsInRange: jest.fn().mockResolvedValue(jobs),
+    fetchJobsInRange,
     assignJob: jest.fn(),
   }));
   jest.unstable_mockModule('next/router', () => ({
@@ -33,6 +34,16 @@ test('jobs fetch and display in calendar and side panel', async () => {
   render(<Page />);
   await screen.findByText('Job #1');
   expect(screen.getByTestId('side-panel')).toHaveTextContent('Job #2 – BBB222');
+  const start = new Date();
+  start.setDate(start.getDate() - 7);
+  const end = new Date();
+  end.setDate(end.getDate() + 30);
+  expect(fetchJobsInRange).toHaveBeenCalledWith(
+    start.toLocaleDateString('en-CA'),
+    end.toLocaleDateString('en-CA'),
+    '',
+    ''
+  );
 });
 
 test('dragging unassigned job calls assign endpoint', async () => {
@@ -128,7 +139,16 @@ test('changing filters reloads jobs', async () => {
   fireEvent.change(screen.getByLabelText('Engineer Filter'), { target: { value: '1' } });
   fireEvent.change(screen.getByLabelText('Status Filter'), { target: { value: 'done' } });
   await act(() => Promise.resolve());
-  expect(fetchMock).toHaveBeenLastCalledWith(expect.any(String), expect.any(String), '1', 'done');
+  const s = new Date();
+  s.setDate(s.getDate() - 7);
+  const e = new Date();
+  e.setDate(e.getDate() + 30);
+  expect(fetchMock).toHaveBeenLastCalledWith(
+    s.toLocaleDateString('en-CA'),
+    e.toLocaleDateString('en-CA'),
+    '1',
+    'done'
+  );
 });
 
 test('assign with duration computes end time', async () => {

--- a/components/SchedulingCalendar.jsx
+++ b/components/SchedulingCalendar.jsx
@@ -13,6 +13,7 @@ import enUS from 'date-fns/locale/en-US';
 import { fetchJobsInRange, assignJob } from '../lib/jobs';
 import { fetchEngineers } from '../lib/engineers';
 import { fetchJobStatuses } from '../lib/jobStatuses';
+import { formatLocalDate } from '../lib/datetime';
 
 // Note: Global CSS imports for react-big-calendar belong in pages/_app.js
 const locales = { 'en-US': enUS };
@@ -49,8 +50,8 @@ export default function SchedulingCalendar() {
   // Load jobs from API
   const load = (startDate, endDate) => {
     fetchJobsInRange(
-      startDate.toISOString().slice(0, 10),
-      endDate.toISOString().slice(0, 10),
+      formatLocalDate(startDate),
+      formatLocalDate(endDate),
       filters.engineer_id,
       filters.status
     ).then(jobs => {

--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -5,3 +5,10 @@ export function formatDateTime(dateStr) {
   const pad = n => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
+
+export function formatLocalDate(date) {
+  if (!date) return null;
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString('en-CA');
+}


### PR DESCRIPTION
## Summary
- add `formatLocalDate` helper
- use it when querying jobs in range
- update tests to expect local date strings

## Testing
- `npm test` *(fails: Jest encountered unexpected tokens)*

------
https://chatgpt.com/codex/tasks/task_e_68788de61bbc8333b8b73379e1b7a40e