### PR TITLE
Fix workshop live screen

### DIFF
--- a/__tests__/office-live-screen.test.js
+++ b/__tests__/office-live-screen.test.js
@@ -11,31 +11,34 @@ afterEach(() => {
 });
 
 
-test('LiveScreen lists todays jobs only', async () => {
+test('LiveScreen lists todays jobs with details', async () => {
   const date = new Date();
   const today = date.toLocaleDateString('en-CA');
   const jobs = [
-    { id: 1, status: 'in progress', scheduled_start: '2024-01-01T10:00:00Z', scheduled_end: '2024-01-01T11:00:00Z' }
+    {
+      id: 1,
+      licence_plate: 'AAA111',
+      make: 'Ford',
+      model: 'Focus',
+      engineers: 'Bob',
+      status: 'in progress',
+      scheduled_start: '2024-01-01T10:00:00Z',
+      defect_description: 'leak'
+    }
   ];
   const fetchJobsForDate = jest.fn().mockResolvedValue(jobs);
 
-  jest.unstable_mockModule('../lib/quotes', () => ({
-    fetchQuotes: jest.fn().mockResolvedValue([])
-  }));
   jest.unstable_mockModule('../lib/jobs', () => ({
     fetchJobsForDate
-  }));
-  jest.unstable_mockModule('../lib/invoices', () => ({
-    fetchInvoices: jest.fn().mockResolvedValue([])
-  }));
-  jest.unstable_mockModule('../lib/jobStatuses.js', () => ({
-    fetchJobStatuses: jest.fn().mockResolvedValue([{ id: 1, name: 'in progress' }])
   }));
 
   const { default: Page } = await import('../pages/office/live-screen/index.js');
   render(<Page />);
 
-  const link = await screen.findByRole('link', { name: 'Job #1 – in progress' });
+  await screen.findByText('AAA111');
+  expect(screen.getByText('Ford Focus')).toBeInTheDocument();
+  expect(screen.getByText('Bob')).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: 'View Job' });
   expect(link).toHaveAttribute('href', '/office/jobs/1');
   expect(fetchJobsForDate).toHaveBeenCalledWith(today);
 });

--- a/pages/office/live-screen/index.js
+++ b/pages/office/live-screen/index.js
@@ -1,62 +1,25 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import OfficeLayout from '../../../components/OfficeLayout';
-import { fetchQuotes } from '../../../lib/quotes';
 import { fetchJobsForDate } from '../../../lib/jobs';
-import { fetchInvoices } from '../../../lib/invoices';
-import { fetchJobStatuses } from '../../../lib/jobStatuses.js';
 
 const LiveScreenPage = () => {
-  const [quotes, setQuotes] = useState([]);
   const [jobs, setJobs] = useState([]);
-  const [invoices, setInvoices] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [statuses, setStatuses] = useState([]);
 
   const load = () => {
     setLoading(true);
     const date = new Date();
     const dateStr = date.toLocaleDateString('en-CA');
-    Promise.all([
-      fetchQuotes(),
-      fetchJobsForDate(dateStr),
-      fetchInvoices(),
-      fetchJobStatuses(),
-    ])
-      .then(([q, j, i, s]) => {
-        setQuotes(q);
-        setJobs(j);
-        setInvoices(i);
-        setStatuses(s);
-      })
+    fetchJobsForDate(dateStr)
+      .then(setJobs)
       .catch(() => setError('Failed to load data'))
       .finally(() => setLoading(false));
   };
 
   useEffect(load, []);
 
-  const openQuotes = useMemo(
-    () => quotes.filter(q => !['job-card', 'completed', 'invoiced'].includes(q.status)),
-    [quotes]
-  );
-
-  const unpaidInvoices = useMemo(
-    () => invoices.filter(inv => (inv.status || '').toLowerCase() === 'unpaid'),
-    [invoices]
-  );
-
-  const jobStatusCounts = useMemo(() => {
-    const counts = {};
-    statuses.forEach(s => {
-      counts[s.name] = 0;
-    });
-    jobs.forEach(j => {
-      const s = j.status;
-      if (counts[s] !== undefined) counts[s] += 1;
-    });
-    return counts;
-  }, [jobs, statuses]);
 
   return (
     <OfficeLayout>
@@ -65,53 +28,20 @@ const LiveScreenPage = () => {
       {loading ? (
         <p>Loading…</p>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-3">
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-4 shadow">
-            <h2 className="text-lg font-semibold mb-2">
-              Open Quotes ({openQuotes.length})
-            </h2>
-            <ul className="space-y-1 max-h-60 overflow-y-auto">
-              {openQuotes.map(q => (
-                <li key={q.id}>Quote #{q.id} – {q.status}</li>
-              ))}
-            </ul>
-          </div>
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-4 shadow">
-            <h2 className="text-lg font-semibold mb-2">Jobs</h2>
-            <ul className="space-y-1">
-              {statuses.map(s => (
-                <li key={s.id} className="capitalize">{s.name}: {jobStatusCounts[s.name] || 0}</li>
-              ))}
-            </ul>
-            <ul className="space-y-1 max-h-60 overflow-y-auto mt-2">
-              {jobs.map(j => (
-                <li key={j.id}>
-                  <Link href={`/office/jobs/${j.id}`} className="underline">
-                    Job #{j.id} – {j.status}
-                  </Link>
-                  <div className="text-xs">
-                    {j.scheduled_start
-                      ? new Date(j.scheduled_start).toLocaleString()
-                      : 'N/A'}{' '}
-                    -{' '}
-                    {j.scheduled_end
-                      ? new Date(j.scheduled_end).toLocaleString()
-                      : 'N/A'}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-4 shadow">
-            <h2 className="text-lg font-semibold mb-2">
-              Unpaid Invoices ({unpaidInvoices.length})
-            </h2>
-            <ul className="space-y-1 max-h-60 overflow-y-auto">
-              {unpaidInvoices.map(inv => (
-                <li key={inv.id}>Invoice #{inv.id}</li>
-              ))}
-            </ul>
-          </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {jobs.map(j => (
+            <div key={j.id} className="bg-white dark:bg-gray-800 rounded-lg p-4 shadow">
+              <h2 className="text-lg font-semibold mb-1">{j.licence_plate}</h2>
+              <p className="text-sm mb-1">{j.make} {j.model}</p>
+              <p className="text-sm mb-1">
+                {j.scheduled_start ? new Date(j.scheduled_start).toLocaleTimeString() : 'N/A'}
+              </p>
+              <p className="text-sm mb-1">Engineer: {j.engineers || 'Unassigned'}</p>
+              <p className="text-sm mb-1 capitalize">Status: {j.status}</p>
+              <p className="text-sm mb-2">Defect: {j.defect_description || 'N/A'}</p>
+              <Link href={`/office/jobs/${j.id}`} className="underline text-sm">View Job</Link>
+            </div>
+          ))}
         </div>
       )}
     </OfficeLayout>


### PR DESCRIPTION
## Summary
- expand `getJobsForDate` query with vehicle and defect details
- simplify live screen to show daily job tiles
- update live screen test

## Testing
- `npm test` *(fails: Cannot find module '/workspace/garage/node_modules/.bin/jest')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878977906a48333a454c3b3cc6315b5