### PR TITLE
Implement cascading delete for jobs

### DIFF
--- a/pages/api/jobs/[id].js
+++ b/pages/api/jobs/[id].js
@@ -20,8 +20,13 @@ async function handler(req, res) {
       return res.status(200).json(updated);
     }
     if (req.method === 'DELETE') {
-      await service.deleteJob(id);
-      return res.status(204).end();
+      try {
+        await service.deleteJob(id);
+        return res.status(204).end();
+      } catch (err) {
+        console.error(err);
+        return res.status(400).json({ error: err.message });
+      }
     }
     res.setHeader('Allow', ['GET','PUT','DELETE']);
     res.status(405).end(`Method ${req.method} Not Allowed`);


### PR DESCRIPTION
## Summary
- cascade delete jobs via transaction
- surface cascade errors from DELETE api
- test job deletion with purchase orders

## Testing
- `npm test` *(fails: Jest encountered unexpected tokens and missing headers)*

------
https://chatgpt.com/codex/tasks/task_e_688142e8b78c8333801b87c47ae0e28c