### PR TITLE
Add fleet info to client export

### DIFF
--- a/pages/api/company/export-clients.js
+++ b/pages/api/company/export-clients.js
@@ -7,7 +7,12 @@ async function handler(req, res) {
     res.setHeader('Allow', ['GET']);
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
-  const data = await getClientsWithVehicles();
+  const rows = await getClientsWithVehicles();
+  const data = rows.map(r => ({
+    ...r,
+    fleet_id: r.fleet_id ?? '',
+    company_name: r.company_name ?? '',
+  }));
   const wb = utils.book_new();
   const ws = utils.json_to_sheet(data);
   utils.book_append_sheet(wb, ws);

--- a/services/clientsService.js
+++ b/services/clientsService.js
@@ -198,9 +198,11 @@ export async function getClientsWithVehicles() {
     `SELECT c.id AS client_id, c.first_name, c.last_name, c.email, c.mobile,
             c.landline, c.nie_number, c.street_address, c.town,
             c.province, c.post_code, c.garage_name, c.vehicle_reg, c.pin,
-            v.licence_plate, v.make, v.model, v.color, v.company_vehicle_id
+            v.licence_plate, v.make, v.model, v.color, v.company_vehicle_id,
+            v.fleet_id, f.company_name
        FROM clients c
   LEFT JOIN vehicles v ON v.customer_id = c.id
+  LEFT JOIN fleets f ON v.fleet_id = f.id
    ORDER BY c.id, v.id`
   );
   return rows;


### PR DESCRIPTION
## Summary
- join fleets when exporting clients with vehicles
- include new fleet fields in export data

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688160b7b97c8333b6948bbc3809c9d1