### PR TITLE
Fix scheduling drag modal readability

### DIFF
--- a/components/SchedulingCalendar.jsx
+++ b/components/SchedulingCalendar.jsx
@@ -152,10 +152,10 @@ export default function SchedulingCalendar() {
     <div className="min-h-screen p-6 bg-gradient-to-br from-blue-600 to-blue-800">
       {pending && (
         <div
-          className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
           data-testid="assign-modal"
         >
-          <div className="bg-white p-4 rounded space-y-2">
+          <div className="bg-white p-4 rounded space-y-2 text-black">
             <div>
               <label className="block mb-1">Engineer</label>
               <select


### PR DESCRIPTION
## Summary
- fix scheduling modal so text is readable against white background
- ensure modal appears on top of calendar

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND, SyntaxError, and other errors)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6881661d3c7c833385d821fb7e274812