### PR TITLE
Fix engineer job listings duplication

### DIFF
--- a/__tests__/engineer-jobs-api.test.js
+++ b/__tests__/engineer-jobs-api.test.js
@@ -43,7 +43,7 @@ test('engineer jobs returns 401 when unauthenticated', async () => {
   }));
   const { default: handler } = await import('../pages/api/engineer/jobs/index.js');
   const req = { method: 'GET', headers: {} };
-  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn() };
   await handler(req, res);
   expect(res.status).toHaveBeenCalledWith(401);
   expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
@@ -62,7 +62,7 @@ test('engineer jobs returns 403 for non-engineer role', async () => {
   }));
   const { default: handler } = await import('../pages/api/engineer/jobs/index.js');
   const req = { method: 'GET', headers: {} };
-  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn() };
   await handler(req, res);
   expect(res.status).toHaveBeenCalledWith(403);
   expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });

--- a/services/jobsService.js
+++ b/services/jobsService.js
@@ -190,8 +190,9 @@ export async function listActiveJobsForEngineer(user_id, status) {
     `SELECT j.id, j.customer_id, j.vehicle_id, j.scheduled_start, j.scheduled_end,
             j.status, j.bay, j.created_at
        FROM jobs j
-       JOIN job_assignments ja ON j.id = ja.job_id
+      JOIN job_assignments ja ON j.id = ja.job_id
       WHERE ${where}
+   GROUP BY j.id
       ORDER BY j.id`,
     params
   );


### PR DESCRIPTION
## Summary
- ensure `listActiveJobsForEngineer` doesn't return duplicate jobs
- update engineer jobs API tests to include required response headers

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6881752feeb4833399c10d0fd72c2481