### PR TITLE
Add vehicle date editing to engineer job page

### DIFF
--- a/__tests__/engineer-job-page.test.js
+++ b/__tests__/engineer-job-page.test.js
@@ -99,3 +99,26 @@ test('notes form updates notes', async () => {
   expect(global.fetch.mock.calls[2][0]).toBe('/api/jobs/7');
   expect(JSON.parse(global.fetch.mock.calls[2][1].body)).toEqual({ notes: 'note' });
 });
+
+test('vehicle dates form updates vehicle', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '8' } })
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 8, vehicle_id: 3, vehicle: { service_date: '', itv_date: '' } }) })
+    .mockResolvedValue({ ok: true, json: async () => ({}) });
+
+  const { default: Page } = await import('../pages/engineer/jobs/[id].js');
+  render(<Page />);
+  await screen.findByText('Job #8');
+  fireEvent.change(screen.getByLabelText('Service Date'), { target: { value: '2024-05-01' } });
+  fireEvent.change(screen.getByLabelText('ITV Date'), { target: { value: '2024-06-01' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save Dates' }));
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+  expect(global.fetch.mock.calls[2][0]).toBe('/api/vehicles/3');
+  expect(JSON.parse(global.fetch.mock.calls[2][1].body)).toEqual({ service_date: '2024-05-01', itv_date: '2024-06-01' });
+});

--- a/pages/engineer/jobs/[id].js
+++ b/pages/engineer/jobs/[id].js
@@ -14,6 +14,8 @@ export default function EngineerJobPage() {
   const [status, setStatus] = useState('');
   const [mileage, setMileage] = useState('');
   const [notes, setNotes] = useState('');
+  const [serviceDate, setServiceDate] = useState('');
+  const [itvDate, setItvDate] = useState('');
   const [message, setMessage] = useState('');
 
   useEffect(() => {
@@ -31,6 +33,8 @@ export default function EngineerJobPage() {
         setJob(jData);
         setStatus(jData.status || '');
         setNotes(jData.notes || '');
+        setServiceDate(jData.vehicle?.service_date || '');
+        setItvDate(jData.vehicle?.itv_date || '');
       } catch (err) {
         setMessage(err.message);
       }
@@ -68,6 +72,21 @@ export default function EngineerJobPage() {
       body: JSON.stringify({ notes })
     });
     setMessage('Notes saved');
+  }
+
+  async function updateVehicleDates(e) {
+    e.preventDefault();
+    if (!job?.vehicle_id) return;
+    await fetch(`/api/vehicles/${job.vehicle_id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...(job.vehicle || {}),
+        service_date: serviceDate || null,
+        itv_date: itvDate || null,
+      }),
+    });
+    setMessage('Vehicle dates updated');
   }
 
   async function handleUpload(e) {
@@ -152,6 +171,33 @@ export default function EngineerJobPage() {
           <button type="submit" className="button">Update</button>
         </form>
       </Card>
+
+      {job.vehicle && (
+        <Card className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Vehicle Dates</h2>
+          <form onSubmit={updateVehicleDates} className="space-y-2">
+            <div>
+              <label className="block mb-1">Service Date</label>
+              <input
+                type="date"
+                value={serviceDate || ''}
+                onChange={e => setServiceDate(e.target.value)}
+                className="input"
+              />
+            </div>
+            <div>
+              <label className="block mb-1">ITV Date</label>
+              <input
+                type="date"
+                value={itvDate || ''}
+                onChange={e => setItvDate(e.target.value)}
+                className="input"
+              />
+            </div>
+            <button type="submit" className="button">Save Dates</button>
+          </form>
+        </Card>
+      )}
 
       <Card className="mb-6">
         <h2 className="text-xl font-semibold mb-2">Engineer Notes</h2>


### PR DESCRIPTION
## Summary
- add service date and ITV date fields to engineer job detail page
- send updates to the vehicles API
- test the new update logic

## Testing
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68817b84c48c8333928f257e34828725