### PR TITLE
Add engineer dashboard

### DIFF
--- a/__tests__/engineer-dashboard-data.test.js
+++ b/__tests__/engineer-dashboard-data.test.js
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('fetchDashboardData aggregates responses', async () => {
+  const jobs = [{ id: 1, scheduled_start: '2025-07-24T08:00:00Z' }];
+  const holidays = [{ id: 2, start_date: '2025-01-01', end_date: '2025-01-05', status: 'approved' }];
+  const attendance = [{ id: 3, employee_id: 5, clock_in: '2025-07-23 08:00', clock_out: '2025-07-23 17:00' }];
+  const shifts = [{ id: 4, employee_id: 5, start_time: '2025-07-25T09:00:00Z', end_time: '2025-07-25T17:00:00Z' }];
+  const user = { id: 5, username: 'bob', email: 'b@b.com' };
+  global.fetch = jest.fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => jobs })
+    .mockResolvedValueOnce({ ok: true, json: async () => holidays })
+    .mockResolvedValueOnce({ ok: true, json: async () => attendance })
+    .mockResolvedValueOnce({ ok: true, json: async () => shifts })
+    .mockResolvedValueOnce({ ok: true, json: async () => user });
+
+  const { fetchDashboardData } = await import('../lib/engineerDashboard.js');
+  const result = await fetchDashboardData();
+
+  expect(fetch).toHaveBeenNthCalledWith(1, '/api/engineer/jobs', { credentials: 'include' });
+  expect(fetch).toHaveBeenNthCalledWith(2, '/api/engineer/holiday-requests', { credentials: 'include' });
+  expect(fetch).toHaveBeenNthCalledWith(3, '/api/hr/attendance');
+  expect(fetch).toHaveBeenNthCalledWith(4, '/api/hr/shifts');
+  expect(fetch).toHaveBeenNthCalledWith(5, '/api/auth/me', { credentials: 'include' });
+  expect(result.jobs).toEqual(jobs);
+  expect(result.holidays).toEqual(holidays);
+  expect(result.attendance).toEqual(attendance);
+  expect(result.shifts).toEqual(shifts);
+  expect(result.user).toEqual(user);
+  expect(result.remainingDays).toBe(15);
+});
+
+test('fetchDashboardData throws on failure', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ ok: false });
+  const { fetchDashboardData } = await import('../lib/engineerDashboard.js');
+  await expect(fetchDashboardData()).rejects.toThrow('Failed');
+});

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -133,6 +133,9 @@ export function Sidebar() {
             >
               Engineer Portal
             </a>
+            <a href="/engineer/dashboard" {...linkProps}>
+              Dashboard
+            </a>
             <a href="/engineer/wiki" {...linkProps}>
               Wiki
             </a>

--- a/lib/engineerDashboard.js
+++ b/lib/engineerDashboard.js
@@ -1,0 +1,34 @@
+export async function fetchDashboardData() {
+  const [jobsRes, holidaysRes, attendanceRes, shiftsRes, userRes] = await Promise.all([
+    fetch('/api/engineer/jobs', { credentials: 'include' }),
+    fetch('/api/engineer/holiday-requests', { credentials: 'include' }),
+    fetch('/api/hr/attendance'),
+    fetch('/api/hr/shifts'),
+    fetch('/api/auth/me', { credentials: 'include' }),
+  ]);
+
+  if (![jobsRes, holidaysRes, attendanceRes, shiftsRes, userRes].every(r => r.ok)) {
+    throw new Error('Failed to load dashboard data');
+  }
+
+  const [jobs, holidays, attendance, shifts, user] = await Promise.all([
+    jobsRes.json(),
+    holidaysRes.json(),
+    attendanceRes.json(),
+    shiftsRes.json(),
+    userRes.json(),
+  ]);
+
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const used = holidays
+    .filter(h => h.status === 'approved' && new Date(h.start_date).getFullYear() === currentYear)
+    .reduce((sum, h) => {
+      const start = new Date(h.start_date);
+      const end = new Date(h.end_date);
+      return sum + Math.round((end - start) / 86400000) + 1;
+    }, 0);
+  const remainingDays = 20 - used;
+
+  return { jobs, holidays, attendance, shifts, user, remainingDays };
+}

--- a/pages/engineer/dashboard.js
+++ b/pages/engineer/dashboard.js
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import { Layout } from '../../components/Layout';
+import { Card } from '../../components/Card';
+import { fetchDashboardData } from '../../lib/engineerDashboard.js';
+
+export default function EngineerDashboard() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetchDashboardData()
+      .then(setData)
+      .catch(() => setError('Failed to load dashboard'));
+  }, []);
+
+  if (!data && !error) return <Layout><p>Loading…</p></Layout>;
+  if (error) return <Layout><p className="text-red-500">{error}</p></Layout>;
+
+  const todayStr = new Date().toDateString();
+  const todaysJobs = data.jobs.filter(j => j.scheduled_start && new Date(j.scheduled_start).toDateString() === todayStr);
+  const upcomingRequests = data.holidays.filter(h => new Date(h.start_date) >= new Date());
+  const upcomingShifts = data.shifts
+    .filter(s => new Date(s.start_time) >= new Date())
+    .sort((a,b) => new Date(a.start_time) - new Date(b.start_time))
+    .slice(0,5);
+  const myAttendance = data.attendance.filter(a => String(a.employee_id) === String(data.user.id));
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-semibold mb-4">Engineer Dashboard</h1>
+      <Card className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Today's Jobs</h2>
+        {todaysJobs.length === 0 ? (
+          <p>No jobs today.</p>
+        ) : (
+          <ul className="list-disc pl-5">
+            {todaysJobs.map(j => (
+              <li key={j.id}>Job #{j.id}</li>
+            ))}
+          </ul>
+        )}
+      </Card>
+      <Card className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Holiday</h2>
+        <p className="mb-2">Remaining days: {data.remainingDays}</p>
+        {upcomingRequests.length === 0 ? (
+          <p>No upcoming requests.</p>
+        ) : (
+          <ul className="list-disc pl-5">
+            {upcomingRequests.map(r => (
+              <li key={r.id}>{r.start_date} to {r.end_date} - {r.status}</li>
+            ))}
+          </ul>
+        )}
+      </Card>
+      <Card className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">HR File</h2>
+        <p>Name: {data.user.username}</p>
+        <p>Email: {data.user.email}</p>
+        <h3 className="text-lg font-semibold mt-4">Attendance</h3>
+        {myAttendance.length === 0 ? (
+          <p>No records</p>
+        ) : (
+          <ul className="list-disc pl-5">
+            {myAttendance.map(r => (
+              <li key={r.id}>{r.clock_in} - {r.clock_out || 'present'}</li>
+            ))}
+          </ul>
+        )}
+      </Card>
+      <Card>
+        <h2 className="text-xl font-semibold mb-2">Upcoming Shifts</h2>
+        {upcomingShifts.length === 0 ? (
+          <p>No upcoming shifts.</p>
+        ) : (
+          <ul className="list-disc pl-5">
+            {upcomingShifts.map(s => (
+              <li key={s.id}>{s.start_time} - {s.end_time}</li>
+            ))}
+          </ul>
+        )}
+      </Card>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add utility to load engineer dashboard info from APIs
- create engineer dashboard page
- link dashboard from sidebar
- test dashboard data fetch logic

## Testing
- `npx jest __tests__/engineer-dashboard-data.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68818058f8448333a1e0bf3d8e50a9ca