### PR TITLE
Add job docs

### DIFF
--- a/migrations/20251201_create_documents.sql
+++ b/migrations/20251201_create_documents.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS documents (
   id INT PRIMARY KEY AUTO_INCREMENT,
-  entity_type ENUM('client','vehicle') NOT NULL,
+  entity_type ENUM('client','vehicle','job') NOT NULL,
   entity_id INT NOT NULL,
   filename VARCHAR(512) NOT NULL,
   url TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- allow storing job photos by extending document enum
- test engineer job photo upload flow

## Testing
- `npm test` *(fails: Jest encountered unexpected tokens)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688183f320e0833399d432decf59e1aa