### PR TITLE
Add vehicle condition reports

### DIFF
--- a/__tests__/engineer-job-page.test.js
+++ b/__tests__/engineer-job-page.test.js
@@ -150,3 +150,25 @@ test('photo upload posts document with job entity type', async () => {
   const body = JSON.parse(global.fetch.mock.calls[4][1].body);
   expect(body.entity_type).toBe('job');
 });
+
+test('vehicle condition modal posts report', async () => {
+  jest.unstable_mockModule('next/router', () => ({
+    useRouter: () => ({ query: { id: '12' } })
+  }));
+
+  global.fetch = jest
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => [] })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 12, condition_checked: 0 }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 1 }) });
+
+  const { default: Page } = await import('../pages/engineer/jobs/[id].js');
+  render(<Page />);
+  await screen.findByText('Job #12');
+  fireEvent.change(screen.getByLabelText('Description of Defect'), { target: { value: 'scratch' } });
+  fireEvent.change(screen.getByLabelText('Photo URL'), { target: { value: 'u' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+  expect(global.fetch.mock.calls[2][0]).toBe('/api/jobs/12/condition');
+});

--- a/__tests__/vehicle-condition-api.test.js
+++ b/__tests__/vehicle-condition-api.test.js
@@ -1,0 +1,49 @@
+import { jest } from '@jest/globals';
+
+afterEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+test('get condition reports', async () => {
+  const data = [{ id: 1 }];
+  const listMock = jest.fn().mockResolvedValue(data);
+  jest.unstable_mockModule('../services/vehicleConditionReportsService.js', () => ({
+    listReports: listMock,
+    createReport: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/jobs/[id]/condition.js');
+  const req = { method: 'GET', query: { id: '3' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(listMock).toHaveBeenCalledWith('3');
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith(data);
+});
+
+test('post condition report', async () => {
+  const record = { id: 2 };
+  const createMock = jest.fn().mockResolvedValue(record);
+  jest.unstable_mockModule('../services/vehicleConditionReportsService.js', () => ({
+    listReports: jest.fn(),
+    createReport: createMock,
+  }));
+  const { default: handler } = await import('../pages/api/jobs/[id]/condition.js');
+  const req = { method: 'POST', query: { id: '5' }, body: { description: 'd' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(createMock).toHaveBeenCalledWith({ job_id: '5', user_id: null, description: 'd', photo_url: undefined, none: undefined });
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(record);
+});
+
+test('reject unsupported method', async () => {
+  jest.unstable_mockModule('../services/vehicleConditionReportsService.js', () => ({
+    listReports: jest.fn(),
+    createReport: jest.fn(),
+  }));
+  const { default: handler } = await import('../pages/api/jobs/[id]/condition.js');
+  const req = { method: 'PUT', query: { id: '1' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn(), setHeader: jest.fn(), end: jest.fn() };
+  await handler(req, res);
+  expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET', 'POST']);
+  expect(res.status).toHaveBeenCalledWith(405);
+  expect(res.end).toHaveBeenCalledWith('Method PUT Not Allowed');
+});

--- a/components/VehicleConditionModal.jsx
+++ b/components/VehicleConditionModal.jsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Modal } from './ui/Modal.jsx';
+
+export default function VehicleConditionModal({ jobId, onComplete }) {
+  const [description, setDescription] = useState('');
+  const [photoUrl, setPhotoUrl] = useState('');
+  const [none, setNone] = useState(false);
+  const [error, setError] = useState('');
+
+  const submit = async (e) => {
+    e.preventDefault();
+    if (!none && (!description || !photoUrl)) return;
+    try {
+      const res = await fetch(`/api/jobs/${jobId}/condition`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(
+          none ? { none: true } : { description, photo_url: photoUrl }
+        ),
+      });
+      if (!res.ok) throw new Error('Failed');
+      onComplete?.();
+    } catch (err) {
+      setError('Submission failed');
+    }
+  };
+
+  return (
+    <Modal>
+      <form onSubmit={submit} className="space-y-4 w-80">
+        <h2 className="text-lg font-semibold">Vehicle Condition</h2>
+        {error && <p className="text-red-500">{error}</p>}
+        {!none && (
+          <>
+            <div>
+              <label className="block mb-1">Description of Defect</label>
+              <textarea
+                className="input w-full"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label className="block mb-1">Photo URL</label>
+              <input
+                type="url"
+                className="input w-full"
+                value={photoUrl}
+                onChange={(e) => setPhotoUrl(e.target.value)}
+                required
+              />
+            </div>
+          </>
+        )}
+        <label className="block">
+          <input
+            type="checkbox"
+            checked={none}
+            onChange={(e) => setNone(e.target.checked)}
+          />{' '}
+          No Defects
+        </label>
+        <div className="text-right">
+          <button type="submit" className="button px-4">
+            Submit
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/migrations/20260833_create_vehicle_condition_reports.sql
+++ b/migrations/20260833_create_vehicle_condition_reports.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS vehicle_condition_reports (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  job_id INT NOT NULL,
+  user_id INT,
+  description TEXT,
+  photo_url VARCHAR(255),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_vcr_job FOREIGN KEY (job_id) REFERENCES jobs(id),
+  CONSTRAINT fk_vcr_user FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/migrations/20260834_add_condition_checked_to_jobs.sql
+++ b/migrations/20260834_add_condition_checked_to_jobs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE jobs ADD COLUMN condition_checked TINYINT(1) DEFAULT 0;
+

--- a/pages/api/jobs/[id]/condition.js
+++ b/pages/api/jobs/[id]/condition.js
@@ -1,0 +1,31 @@
+import { listReports, createReport } from '../../../../services/vehicleConditionReportsService.js';
+import { getTokenFromReq } from '../../../../lib/auth.js';
+import apiHandler from '../../../../lib/apiHandler.js';
+
+async function handler(req, res) {
+  const { id } = req.query;
+  try {
+    if (req.method === 'GET') {
+      const reports = await listReports(id);
+      return res.status(200).json(reports);
+    }
+    if (req.method === 'POST') {
+      const t = getTokenFromReq(req);
+      const report = await createReport({
+        job_id: id,
+        user_id: t?.sub || null,
+        description: req.body.description,
+        photo_url: req.body.photo_url,
+        none: req.body.none,
+      });
+      return res.status(201).json(report);
+    }
+    res.setHeader('Allow', ['GET', 'POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+export default apiHandler(handler);

--- a/pages/engineer/index.js
+++ b/pages/engineer/index.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Layout } from '../../components/Layout';
 import { Card } from '../../components/Card';
+import VehicleConditionModal from '../../components/VehicleConditionModal.jsx';
 
 export default function EngineerHome() {
   const [jobs, setJobs] = useState([]);
@@ -9,6 +10,7 @@ export default function EngineerHome() {
   const [entry, setEntry] = useState(null);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const [showConditionModal, setShowConditionModal] = useState(false);
 
   useEffect(() => {
     loadJobs();
@@ -39,6 +41,7 @@ export default function EngineerHome() {
         const e = await r.json();
         setEntry(e);
         setMessage('Clocked in');
+        setShowConditionModal(true);
       }
     } catch {
       setMessage('Clock in failed');
@@ -140,6 +143,12 @@ export default function EngineerHome() {
         )}
       </Card>
       {message && <p className="mb-4 text-green-500">{message}</p>}
+      {showConditionModal && (
+        <VehicleConditionModal
+          jobId={selectedJob}
+          onComplete={() => setShowConditionModal(false)}
+        />
+      )}
     </Layout>
   );
 }

--- a/pages/engineer/jobs/[id].js
+++ b/pages/engineer/jobs/[id].js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { Layout } from '../../../components/Layout';
 import { Card } from '../../../components/Card';
+import VehicleConditionModal from '../../../components/VehicleConditionModal.jsx';
 
 const S3_BASE_URL = `https://${process.env.NEXT_PUBLIC_S3_BUCKET}.s3.${process.env.NEXT_PUBLIC_AWS_REGION}.amazonaws.com`;
 
@@ -17,6 +18,8 @@ export default function EngineerJobPage() {
   const [serviceDate, setServiceDate] = useState('');
   const [itvDate, setItvDate] = useState('');
   const [message, setMessage] = useState('');
+  const [conditionChecked, setConditionChecked] = useState(false);
+  const [showConditionModal, setShowConditionModal] = useState(false);
 
   useEffect(() => {
     if (!id) return;
@@ -35,6 +38,8 @@ export default function EngineerJobPage() {
         setNotes(jData.notes || '');
         setServiceDate(jData.vehicle?.service_date || '');
         setItvDate(jData.vehicle?.itv_date || '');
+        setConditionChecked(Boolean(jData.condition_checked));
+        if (!jData.condition_checked) setShowConditionModal(true);
       } catch (err) {
         setMessage(err.message);
       }
@@ -212,6 +217,15 @@ export default function EngineerJobPage() {
         <input type="file" onChange={handleUpload} />
       </Card>
       <p className="mt-6"><Link href="/engineer">&larr; Back</Link></p>
+      {showConditionModal && (
+        <VehicleConditionModal
+          jobId={id}
+          onComplete={() => {
+            setShowConditionModal(false);
+            setConditionChecked(true);
+          }}
+        />
+      )}
     </Layout>
   );
 }

--- a/services/vehicleConditionReportsService.js
+++ b/services/vehicleConditionReportsService.js
@@ -1,0 +1,26 @@
+import pool from '../lib/db.js';
+
+export async function listReports(job_id) {
+  const [rows] = await pool.query(
+    'SELECT id, job_id, user_id, description, photo_url, created_at FROM vehicle_condition_reports WHERE job_id=? ORDER BY id',
+    [job_id]
+  );
+  return rows;
+}
+
+export async function createReport({ job_id, user_id, description, photo_url, none }) {
+  if (none) {
+    await pool.query('UPDATE jobs SET condition_checked=1 WHERE id=?', [job_id]);
+    return { ok: true };
+  }
+  const [{ insertId }] = await pool.query(
+    'INSERT INTO vehicle_condition_reports (job_id, user_id, description, photo_url) VALUES (?,?,?,?)',
+    [job_id, user_id || null, description || null, photo_url || null]
+  );
+  await pool.query('UPDATE jobs SET condition_checked=1 WHERE id=?', [job_id]);
+  const [[row]] = await pool.query(
+    'SELECT id, job_id, user_id, description, photo_url, created_at FROM vehicle_condition_reports WHERE id=?',
+    [insertId]
+  );
+  return row;
+}


### PR DESCRIPTION
## Summary
- create vehicle condition reports migration
- add `condition_checked` flag on jobs
- provide API endpoints to read/save condition reports
- add modal component used on engineer pages
- trigger modal when clocking in or visiting job page
- test API and modal logic

## Testing
- `npm test --silent` *(fails: Cannot read properties of undefined (reading 'x-request-id'))*

------
https://chatgpt.com/codex/tasks/task_e_6881877b75e88333af34752bffb5783d