### PR TITLE
Fix announcements API import paths

### DIFF
--- a/pages/api/dev/announcements/[id].js
+++ b/pages/api/dev/announcements/[id].js
@@ -1,6 +1,6 @@
-import pool from '../../../../../lib/db';
-import { getTokenFromReq } from '../../../../../lib/auth';
-import apiHandler from '../../../../../lib/apiHandler.js';
+import pool from '../../../../lib/db';
+import { getTokenFromReq } from '../../../../lib/auth';
+import apiHandler from '../../../../lib/apiHandler.js';
 
 async function handler(req, res) {
   const t = getTokenFromReq(req);


### PR DESCRIPTION
## Summary
- correct import paths in `pages/api/dev/announcements/[id].js`
- run `next build` to ensure there are no missing modules

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688188ee42d8833383ce1361eb523618