### PR TITLE
Add invoice actions and minor UI fixes

### DIFF
--- a/components/ClientAutocomplete.js
+++ b/components/ClientAutocomplete.js
@@ -60,6 +60,7 @@ export default function ClientAutocomplete({ value, onChange, onSelect }) {
                   setTerm(name);
                 }
                 setResults([]);
+                setShowAdd(false);
               }}
             >
               {(c.first_name || '') + ' ' + (c.last_name || '')}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -51,7 +51,7 @@ export default function MyApp({ Component, pageProps }) {
       )}
       <button
         onClick={() => setShowBug(true)}
-        className="fixed bottom-4 right-4 button px-4 z-40"
+        className="fixed bottom-16 right-4 button px-4 z-40"
       >
         Report Bug
       </button>

--- a/pages/office/invoices/[id].js
+++ b/pages/office/invoices/[id].js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import OfficeLayout from '../../../components/OfficeLayout';
+
+export default function InvoiceViewPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [invoice, setInvoice] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/invoices/${id}`)
+      .then(r => (r.ok ? r.json() : Promise.reject()))
+      .then(setInvoice)
+      .catch(() => setError('Failed to load invoice'));
+  }, [id]);
+
+  if (error) return <OfficeLayout><p className="text-red-500">{error}</p></OfficeLayout>;
+  if (!invoice) return <OfficeLayout><p>Loading…</p></OfficeLayout>;
+
+  return (
+    <OfficeLayout>
+      <div className="mb-6 flex flex-wrap gap-4">
+        <a href={`/api/invoices/${id}/pdf`} className="button px-4 text-sm">Download PDF</a>
+        <button onClick={() => router.back()} className="button-secondary px-4 text-sm">Back</button>
+      </div>
+      <h1 className="text-2xl font-semibold mb-4">Invoice #{invoice.id}</h1>
+      <p><strong>Amount:</strong> €{invoice.amount}</p>
+      <p><strong>Status:</strong> {invoice.status}</p>
+      {invoice.due_date && <p><strong>Due:</strong> {invoice.due_date}</p>}
+      {invoice.terms && <p className="whitespace-pre-wrap mt-4">{invoice.terms}</p>}
+    </OfficeLayout>
+  );
+}

--- a/pages/office/invoices/index.js
+++ b/pages/office/invoices/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import Link from 'next/link';
 import OfficeLayout from '../../../components/OfficeLayout';
 import { fetchInvoices } from '../../../lib/invoices';
 import { fetchClients } from '../../../lib/clients';
@@ -104,6 +105,10 @@ const InvoicesPage = () => {
               <p className="text-sm">{vehicleMap[inv.vehicle_id]?.make || ''}</p>
               <p className="text-sm">Amount: €{inv.amount}</p>
               <p className="text-sm">Status: {inv.status}</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Link href={`/office/invoices/${inv.id}`} className="button px-4 text-sm">View</Link>
+                <a href={`/api/invoices/${inv.id}/pdf`} className="button-secondary px-4 text-sm">Download PDF</a>
+              </div>
             </div>
           ))}
           </div>


### PR DESCRIPTION
## Summary
- allow viewing/download invoices in listing
- add invoice detail page
- close client autocomplete dropdown on select
- move bug report button higher

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6888f0e1663c8333a2ef9a6ef697acfc