### PR TITLE
Add invoice PDF builder module

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ generation.
 The resulting files are written to the `output/` directory as
 `quote_<quote_number>.docx` and `quote_<quote_number>.pdf`.
 
+## Invoice PDF Generation
+
+Invoices can be downloaded via `/api/invoices/[id]/pdf`. The endpoint
+builds the PDF using the invoice data, customer details and your
+company's banking terms.
+
 ## Viewing Quotes
 
 From the office interface you can view any quotes linked to a client or vehicle.

--- a/__tests__/email-service.test.js
+++ b/__tests__/email-service.test.js
@@ -34,11 +34,45 @@ test('sendQuoteEmail sends mail', async () => {
   jest.unstable_mockModule('../lib/pdf/buildQuotePdf.js', () => ({
     buildQuotePdf: buildMock
   }));
-  jest.unstable_mockModule('../lib/pdf.js', () => ({
+  jest.unstable_mockModule('../lib/pdf/buildInvoicePdf.js', () => ({
     buildInvoicePdf: jest.fn()
   }));
   const { sendQuoteEmail } = await import('../services/emailService.js');
   await sendQuoteEmail(1);
+  expect(sendMock).toHaveBeenCalled();
+  expect(buildMock).toHaveBeenCalled();
+});
+
+test('sendInvoiceEmail sends mail', async () => {
+  const sendMock = jest.fn().mockResolvedValue();
+  jest.unstable_mockModule('nodemailer', () => ({
+    default: { createTransport: () => ({ sendMail: sendMock }) },
+    createTransport: () => ({ sendMail: sendMock }),
+  }));
+  jest.unstable_mockModule('../services/smtpSettingsService.js', () => ({
+    getSmtpSettings: () => ({ host: 'h', port: 1, from_email: 'f' }),
+  }));
+  jest.unstable_mockModule('../services/invoicesService.js', () => ({
+    getInvoiceById: () => ({ id: 1, customer_id: 2 })
+  }));
+  jest.unstable_mockModule('../services/companySettingsService.js', () => ({
+    getSettings: () => ({})
+  }));
+  jest.unstable_mockModule('../services/clientsService.js', () => ({
+    getClientById: () => ({ email: 'c' })
+  }));
+  jest.unstable_mockModule('../services/invoiceItemsService.js', () => ({
+    getInvoiceItems: () => []
+  }));
+  const buildMock = jest.fn().mockResolvedValue(Buffer.from('PDF'));
+  jest.unstable_mockModule('../lib/pdf/buildInvoicePdf.js', () => ({
+    buildInvoicePdf: buildMock
+  }));
+  jest.unstable_mockModule('../lib/pdf/buildQuotePdf.js', () => ({
+    buildQuotePdf: jest.fn()
+  }));
+  const { sendInvoiceEmail } = await import('../services/emailService.js');
+  await sendInvoiceEmail(1);
   expect(sendMock).toHaveBeenCalled();
   expect(buildMock).toHaveBeenCalled();
 });

--- a/__tests__/invoicePdfApi.test.js
+++ b/__tests__/invoicePdfApi.test.js
@@ -20,7 +20,7 @@ test('invoice pdf endpoint returns PDF', async () => {
   jest.unstable_mockModule('../services/invoiceItemsService.js', () => ({
     getInvoiceItems: jest.fn().mockResolvedValue([])
   }));
-  jest.unstable_mockModule('../lib/pdf.js', () => ({
+  jest.unstable_mockModule('../lib/pdf/buildInvoicePdf.js', () => ({
     buildInvoicePdf: buildMock
   }));
   const { default: handler } = await import('../pages/api/invoices/[id]/pdf.js');

--- a/lib/pdf/buildInvoicePdf.js
+++ b/lib/pdf/buildInvoicePdf.js
@@ -1,0 +1,58 @@
+import PDFDocument from 'pdfkit';
+import { addHeader } from './header';
+import { addInfoBoxes } from './infoBoxes';
+import { addItemsTable } from './itemsTable';
+import { addFooter } from './footer';
+
+function addInvoiceTerms(doc, text) {
+  const y = doc.page.height - 80;
+  doc
+    .font('Helvetica-Bold')
+    .fontSize(10)
+    .fillColor('#000')
+    .text('Invoice Terms and Payment Details', 0, y, {
+      align: 'center',
+      width: doc.page.width - 80,
+    })
+    .moveDown(0.5)
+    .font('Helvetica')
+    .fontSize(8)
+    .text(text, {
+      align: 'center',
+      width: doc.page.width - 80,
+    });
+}
+
+const mmToPt = mm => mm * 2.83465;
+
+export async function buildInvoicePdf({
+  invoiceNumber,
+  garage,
+  client = {},
+  items = [],
+  terms = '',
+}) {
+  const doc = new PDFDocument({ size: 'A4', margin: 40 });
+  const buffers = [];
+  doc.on('data', buffers.push.bind(buffers));
+  doc.on('pageAdded', () => addFooter(doc));
+
+  addHeader(doc, { garage, quoteNumber: invoiceNumber, title: 'INVOICE' });
+  addInfoBoxes(doc, { garage, client });
+
+  doc.y += mmToPt(3);
+  doc
+    .font('Helvetica-Bold')
+    .fontSize(14)
+    .fillColor('#007bff')
+    .text('ITEMS', 40, doc.y);
+  doc.y += mmToPt(3);
+  addItemsTable(doc, { items });
+
+  addInvoiceTerms(doc, terms);
+  addFooter(doc);
+
+  doc.end();
+  await new Promise(r => doc.on('end', r));
+  return Buffer.concat(buffers);
+}

--- a/pages/api/invoices/[id]/pdf.js
+++ b/pages/api/invoices/[id]/pdf.js
@@ -2,7 +2,7 @@ import { getSettings } from '../../../../services/companySettingsService.js';
 import { getInvoiceById } from '../../../../services/invoicesService.js';
 import { getClientById } from '../../../../services/clientsService.js';
 import { getInvoiceItems } from '../../../../services/invoiceItemsService.js';
-import { buildInvoicePdf } from '../../../../lib/pdf.js';
+import { buildInvoicePdf } from '../../../../lib/pdf/buildInvoicePdf.js';
 import apiHandler from '../../../../lib/apiHandler.js';
 
 async function handler(req, res) {
@@ -17,11 +17,44 @@ async function handler(req, res) {
     const company = await getSettings();
     const client = invoice.customer_id ? await getClientById(invoice.customer_id) : null;
     const items = await getInvoiceItems(id);
+    const garage = {
+      name: company?.company_name,
+      logo: company?.logo_url,
+      address: company?.address,
+      phone: company?.phone,
+      email: company?.email,
+    };
+    const clientInfo = client
+      ? {
+          name: `${client.first_name} ${client.last_name}`.trim(),
+          phone: client.mobile || client.landline,
+          email: client.email,
+          address: client.street_address,
+          city: client.town,
+          postcode: client.post_code,
+        }
+      : {};
+    const itemList = items.map(it => ({
+      partNumber: it.partNumber,
+      description: it.description,
+      qty: it.qty,
+      unit_price: it.unit_price,
+    }));
+    const baseTerms = invoice.terms || company.invoice_terms || company.terms || '';
+    const bankDetails = [
+      company.bank_name,
+      company.bank_sort_code && `Sort code: ${company.bank_sort_code}`,
+      company.bank_account_number && `Account: ${company.bank_account_number}`,
+      company.bank_iban && `IBAN: ${company.bank_iban}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
     const pdf = await buildInvoicePdf({
-      company,
-      invoice,
-      client,
-      items
+      invoiceNumber: invoice.id,
+      garage,
+      client: clientInfo,
+      items: itemList,
+      terms: bankDetails ? `${baseTerms}\n\n${bankDetails}` : baseTerms,
     });
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `attachment; filename=invoice-${id}.pdf`);

--- a/services/emailService.js
+++ b/services/emailService.js
@@ -4,7 +4,7 @@ import { getQuoteById } from './quotesService.js';
 import { getClientById } from './clientsService.js';
 import { getQuoteItems } from './quoteItemsService.js';
 import { getSettings } from './companySettingsService.js';
-import { buildInvoicePdf } from '../lib/pdf.js';
+import { buildInvoicePdf } from '../lib/pdf/buildInvoicePdf.js';
 import { buildQuotePdf } from '../lib/pdf/buildQuotePdf.js';
 import { getInvoiceById } from './invoicesService.js';
 import { getInvoiceItems } from './invoiceItemsService.js';


### PR DESCRIPTION
## Summary
- add new `buildInvoicePdf` function for PDF generation
- use the new builder in invoice API and email service
- adjust tests and add coverage for `sendInvoiceEmail`
- document invoice PDF endpoint

## Testing
- `npm ci`
- `npm test` *(fails: Jest encountered unexpected token and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888f7a9961083338bcd66b83bdcc7b7