### PR TITLE
Enhance invoice PDFs with vehicle details

### DIFF
--- a/lib/pdf/buildInvoicePdf.js
+++ b/lib/pdf/buildInvoicePdf.js
@@ -2,6 +2,7 @@ import PDFDocument from 'pdfkit';
 import { addHeader } from './header';
 import { addInfoBoxes } from './infoBoxes';
 import { addItemsTable } from './itemsTable';
+import { addVehicleTable } from './vehicleTable';
 import { addFooter } from './footer';
 
 function addInvoiceTerms(doc, text) {
@@ -29,7 +30,9 @@ export async function buildInvoicePdf({
   invoiceNumber,
   garage,
   client = {},
+  vehicle = {},
   items = [],
+  defect_description = '',
   terms = '',
 }) {
   const doc = new PDFDocument({ size: 'A4', margin: 40 });
@@ -39,6 +42,47 @@ export async function buildInvoicePdf({
 
   addHeader(doc, { garage, quoteNumber: invoiceNumber, title: 'INVOICE' });
   addInfoBoxes(doc, { garage, client });
+
+  // VEHICLE INFORMATION
+  doc.y += mmToPt(3);
+  doc
+    .font('Helvetica-Bold')
+    .fontSize(14)
+    .fillColor('#007bff')
+    .text('VEHICLE INFORMATION', 40, doc.y);
+  doc.y += mmToPt(3);
+  addVehicleTable(doc, { vehicle });
+
+  // JOB INFORMATION
+  doc.y += mmToPt(3);
+  doc
+    .font('Helvetica-Bold')
+    .fontSize(14)
+    .fillColor('#007bff')
+    .text('JOB INFORMATION', 40, doc.y);
+  doc.y += mmToPt(3);
+  if (defect_description) {
+    const startY = doc.y;
+    const tableWidth = doc.page.width - 80;
+
+    doc
+      .rect(40, startY, tableWidth, 20)
+      .fill('#007bff')
+      .fillColor('#fff')
+      .font('Helvetica-Bold')
+      .fontSize(10)
+      .text('Reported Defect', 45, startY + 5);
+
+    const bodyHeight =
+      doc.heightOfString(defect_description, { width: tableWidth - 10 }) + 10;
+    doc
+      .fillColor('#000')
+      .rect(40, startY + 20, tableWidth, bodyHeight)
+      .stroke('#ddd')
+      .text(defect_description, 45, startY + 25, { width: tableWidth - 10 });
+
+    doc.y = startY + 20 + bodyHeight;
+  }
 
   doc.y += mmToPt(3);
   doc


### PR DESCRIPTION
## Summary
- include job and vehicle lookups in invoice PDF API
- pass vehicle info and defect description to invoice PDF builder
- add vehicle and job sections to invoice PDFs
- extend unit test to cover new behaviour

## Testing
- `npm install`
- `npm test` *(fails: SyntaxError and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_6889098ec3388333a6b2b9ebb5fe6c5d