### PR TITLE
Add Windows .exe installer via Electron and electron-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,23 @@ For technical support or questions:
 ---
 
 **Garage Vision** - Professional Automotive Business Management
+
+
+## Windows desktop installer (.exe)
+
+This project can now produce a Windows installer alongside the web app build.
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Build the desktop installer:
+   ```bash
+   npm run dist:win
+   ```
+
+Output files are written to `dist/` (including an NSIS `.exe` installer).
+
+Notes:
+- The desktop app wraps the same Next.js app in Electron.
+- Production desktop builds start the bundled Next.js standalone server and open it in a native window.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,0 +1,97 @@
+const { app, BrowserWindow } = require('electron');
+const { spawn } = require('child_process');
+const path = require('path');
+
+let mainWindow;
+let nextProcess;
+const NEXT_PORT = process.env.PORT || '3000';
+const isDev = !app.isPackaged;
+
+function waitForServer(url, attempts = 60) {
+  return new Promise((resolve, reject) => {
+    const tryConnect = () => {
+      const req = require('http').get(url, (res) => {
+        res.resume();
+        resolve();
+      });
+
+      req.on('error', () => {
+        if (attempts <= 0) {
+          reject(new Error(`Unable to reach ${url}`));
+          return;
+        }
+
+        attempts -= 1;
+        setTimeout(tryConnect, 500);
+      });
+    };
+
+    tryConnect();
+  });
+}
+
+function startNextServer() {
+  if (isDev) {
+    return;
+  }
+
+  const appPath = process.resourcesPath;
+  const serverScript = path.join(appPath, 'app', '.next', 'standalone', 'server.js');
+
+  nextProcess = spawn(process.execPath, [serverScript], {
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      PORT: NEXT_PORT,
+      HOSTNAME: '127.0.0.1'
+    },
+    stdio: 'inherit'
+  });
+
+  nextProcess.on('exit', (code) => {
+    if (code !== 0) {
+      console.error(`Next.js server exited with code ${code}`);
+    }
+  });
+}
+
+async function createWindow() {
+  const targetUrl = isDev ? 'http://localhost:3000' : `http://127.0.0.1:${NEXT_PORT}`;
+
+  if (!isDev) {
+    startNextServer();
+    await waitForServer(targetUrl);
+  }
+
+  mainWindow = new BrowserWindow({
+    width: 1400,
+    height: 900,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  await mainWindow.loadURL(targetUrl);
+}
+
+app.whenReady().then(createWindow).catch((error) => {
+  console.error('Failed to start desktop app', error);
+  app.quit();
+});
+
+app.on('window-all-closed', () => {
+  if (nextProcess) {
+    nextProcess.kill();
+  }
+
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('before-quit', () => {
+  if (nextProcess) {
+    nextProcess.kill();
+  }
+});

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
     domains: [],  // add any image hostnames here
     unoptimized: true, // for static export compatibility
   },
+  output: 'standalone',
   // Disable static generation for problematic pages
   trailingSlash: false,
   // Enable compression

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "start": "next start",
     "lint": "next lint",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
-    "install-design-system": "node install-design-system.js"
+    "install-design-system": "node install-design-system.js",
+    "build:desktop:web": "next build --no-lint",
+    "desktop": "electron .",
+    "dist:win": "npm run build:desktop:web && electron-builder --win nsis"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.270.0",
@@ -58,7 +61,39 @@
     "jest-environment-jsdom": "^30.0.2",
     "node-mocks-http": "1.17.2",
     "postcss": "^8.4.21",
-    "tailwindcss": "^3.3.2"
+    "tailwindcss": "^3.3.2",
+    "electron": "^33.2.1",
+    "electron-builder": "^25.1.8"
   },
-  "type": "module"
+  "type": "module",
+  "main": "electron/main.cjs",
+  "build": {
+    "appId": "com.garagevision.portal",
+    "productName": "Garage Vision Portal",
+    "files": [
+      "electron/**/*",
+      ".next/standalone/**/*",
+      ".next/static/**/*",
+      "public/**/*",
+      "package.json"
+    ],
+    "extraMetadata": {
+      "main": "electron/main.cjs"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
+    },
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true
+    }
+  }
 }


### PR DESCRIPTION
### Motivation
- Provide a Windows installer alongside the web app so the Next.js site can be packaged as a native desktop app.
- Bundle the production Next.js server into the desktop app so the installer contains everything required to run offline from a single installer.

### Description
- Added an Electron entrypoint at `electron/main.cjs` that starts the bundled Next.js standalone server in production, waits for it to respond, and loads it in a `BrowserWindow`.
- Enabled Next.js standalone output by setting `output: 'standalone'` in `next.config.js` so the server can be included in the packaged app.
- Extended `package.json` with desktop-related npm scripts (`build:desktop:web`, `desktop`, `dist:win`), added `electron` and `electron-builder` dev dependencies, set `main` to `electron/main.cjs`, and added an Electron `build` configuration that targets Windows NSIS installers and includes files to package.
- Documented how to build the Windows installer in `README.md` and where build artifacts are output (`dist/`).

### Testing
- Ran `npm run build:desktop:web` which completed successfully and produced a Next.js production build (the build emitted warnings but did not fail).
- Build reported module-not-found warnings for `scrapers/ad360/worker.js` (from some API routes) and a `browserslist` advisory; these did not prevent the production build from completing.
- The project is now ready to run `npm run dist:win` to produce an NSIS `.exe` installer (not executed in CI here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c26453f0832ab9b0f1ed4b0ca580)